### PR TITLE
Use deterministic MD5 hash

### DIFF
--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact
-  4537385126242870597:
+  _2f31caea64189172224e4f00071d26f1:
     runs-on: ubuntu-20.04
     needs: kick_tuxbuild
     name: ARCH=arm LLVM=1 LLVM_IAS=1 BOOT=1 LLVM 12 multi_v5_defconfig
@@ -38,7 +38,7 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  7166002817969073485:
+  _b1980b1b58c71e25890efad28684383b:
     runs-on: ubuntu-20.04
     needs: kick_tuxbuild
     name: ARCH=arm LLVM=1 LLVM_IAS=1 BOOT=1 LLVM 12 aspeed_g5_defconfig
@@ -58,7 +58,7 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  2551850696637750843:
+  _db3abfab189898b60d2902e701651da3:
     runs-on: ubuntu-20.04
     needs: kick_tuxbuild
     name: ARCH=arm LLVM=1 LLVM_IAS=1 BOOT=1 LLVM 12 multi_v7_defconfig
@@ -78,7 +78,7 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  -765878788211304428:
+  _047eb1aa64b9595252197636de0f1327:
     runs-on: ubuntu-20.04
     needs: kick_tuxbuild
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 BOOT=1 LLVM 12 defconfig
@@ -98,7 +98,7 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  -1927321282524276875:
+  _af6f80cfd25ab4381dfe6f974cb87ddc:
     runs-on: ubuntu-20.04
     needs: kick_tuxbuild
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 BOOT=1 LLVM 12 defconfig
@@ -118,7 +118,7 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  -6955133369707966678:
+  _db51faed08b817528428f89a529fd79e:
     runs-on: ubuntu-20.04
     needs: kick_tuxbuild
     name: ARCH=arm LLVM=1 LLVM_IAS=1 BOOT=1 LLVM 11 multi_v5_defconfig
@@ -138,7 +138,7 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  116347308515865955:
+  _6b331471c6508782a26a864608af0044:
     runs-on: ubuntu-20.04
     needs: kick_tuxbuild
     name: ARCH=arm LLVM=1 LLVM_IAS=1 BOOT=1 LLVM 11 aspeed_g5_defconfig
@@ -158,7 +158,7 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  3607126909282523730:
+  _1784502e3f8b4b3d189d1dc291026ee6:
     runs-on: ubuntu-20.04
     needs: kick_tuxbuild
     name: ARCH=arm LLVM=1 LLVM_IAS=1 BOOT=1 LLVM 11 multi_v7_defconfig
@@ -178,7 +178,7 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  7831103767623698310:
+  _9148373ae5ea26c971bb54ffe784d924:
     runs-on: ubuntu-20.04
     needs: kick_tuxbuild
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 BOOT=1 LLVM 11 defconfig
@@ -198,7 +198,7 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  -5110477357835244759:
+  _ee7595d5ca720f6818bcb5e079ef8d63:
     runs-on: ubuntu-20.04
     needs: kick_tuxbuild
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 BOOT=1 LLVM 11 defconfig

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact
-  -2445226549631522483:
+  _2f31caea64189172224e4f00071d26f1:
     runs-on: ubuntu-20.04
     needs: kick_tuxbuild
     name: ARCH=arm LLVM=1 LLVM_IAS=1 BOOT=1 LLVM 12 multi_v5_defconfig
@@ -38,7 +38,7 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  -1611733779756360454:
+  _b1980b1b58c71e25890efad28684383b:
     runs-on: ubuntu-20.04
     needs: kick_tuxbuild
     name: ARCH=arm LLVM=1 LLVM_IAS=1 BOOT=1 LLVM 12 aspeed_g5_defconfig
@@ -58,7 +58,7 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  4780324131017435127:
+  _db3abfab189898b60d2902e701651da3:
     runs-on: ubuntu-20.04
     needs: kick_tuxbuild
     name: ARCH=arm LLVM=1 LLVM_IAS=1 BOOT=1 LLVM 12 multi_v7_defconfig
@@ -78,7 +78,7 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  4518105199117456010:
+  _047eb1aa64b9595252197636de0f1327:
     runs-on: ubuntu-20.04
     needs: kick_tuxbuild
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 BOOT=1 LLVM 12 defconfig
@@ -98,7 +98,7 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  5042566988340568611:
+  _af6f80cfd25ab4381dfe6f974cb87ddc:
     runs-on: ubuntu-20.04
     needs: kick_tuxbuild
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 BOOT=1 LLVM 12 defconfig

--- a/generate_workflow.py
+++ b/generate_workflow.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import hashlib
 import yaml
 import sys
 
@@ -33,10 +34,15 @@ def get_job_name(build):
     + " " + build["config"]
 
 
+def sanitize_job_name(name):
+    h = hashlib.new("md5", name.encode("utf-8"), usedForSecurity=False)
+    return "_" + h.hexdigest()
+
+
 def get_steps(build):
     name = get_job_name(build)
     return {
-        hash(name): {
+        sanitize_job_name(name): {
             "runs-on": "ubuntu-20.04",
             "needs": "kick_tuxbuild",
             "name": name,


### PR DESCRIPTION
previously could produce invalid names,
https://github.com/ClangBuiltLinux/continuous-integration2/actions/runs/481731328
errored with:
Names must start with a letter or '_' and contain only alphanumeric
characters, '-', or '_'.
It contained a `.` and `+` in -2.44522654963152E+18.

Also was not deterministic, so regenerating regenerated new hashes.

Prefix with `_`.