### PR TITLE
ci2: Enable some PowerPC builds

### DIFF
--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -98,6 +98,66 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
+  _d23056385a8224ef80ba8d1f7b3c98a0:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite
+    name: ARCH=powerpc LLVM=0 LLVM_IAS=0 BOOT=0 LLVM 12 ppc44x_defconfig
+    env:
+      ARCH: powerpc
+      LLVM: false
+      LLVM_IAS: false
+      INSTALL_DEPS: 1
+      BOOT: false
+      CONFIG: ppc44x_defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _b77960c015f581a56e62796a4f6be980:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite
+    name: ARCH=powerpc LLVM=0 LLVM_IAS=0 BOOT=0 LLVM 12 pseries_defconfig
+    env:
+      ARCH: powerpc
+      LLVM: false
+      LLVM_IAS: false
+      INSTALL_DEPS: 1
+      BOOT: false
+      CONFIG: pseries_defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _34b73f02e4d61a8ed5309f0225c3f605:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite
+    name: ARCH=powerpc LLVM=0 LLVM_IAS=0 BOOT=0 LLVM 12 powernv_defconfig
+    env:
+      ARCH: powerpc
+      LLVM: false
+      LLVM_IAS: false
+      INSTALL_DEPS: 1
+      BOOT: false
+      CONFIG: powernv_defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
   _af6f80cfd25ab4381dfe6f974cb87ddc:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite
@@ -189,6 +249,26 @@ jobs:
       INSTALL_DEPS: 1
       BOOT: true
       CONFIG: defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _6b10ae36ff27f67a001d87cfeeab1936:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite
+    name: ARCH=powerpc LLVM=0 LLVM_IAS=0 BOOT=0 LLVM 11 powernv_defconfig
+    env:
+      ARCH: powerpc
+      LLVM: false
+      LLVM_IAS: false
+      INSTALL_DEPS: 1
+      BOOT: false
+      CONFIG: powernv_defconfig
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -98,6 +98,66 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
+  _d23056385a8224ef80ba8d1f7b3c98a0:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite
+    name: ARCH=powerpc LLVM=0 LLVM_IAS=0 BOOT=0 LLVM 12 ppc44x_defconfig
+    env:
+      ARCH: powerpc
+      LLVM: false
+      LLVM_IAS: false
+      INSTALL_DEPS: 1
+      BOOT: false
+      CONFIG: ppc44x_defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _b77960c015f581a56e62796a4f6be980:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite
+    name: ARCH=powerpc LLVM=0 LLVM_IAS=0 BOOT=0 LLVM 12 pseries_defconfig
+    env:
+      ARCH: powerpc
+      LLVM: false
+      LLVM_IAS: false
+      INSTALL_DEPS: 1
+      BOOT: false
+      CONFIG: pseries_defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _34b73f02e4d61a8ed5309f0225c3f605:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite
+    name: ARCH=powerpc LLVM=0 LLVM_IAS=0 BOOT=0 LLVM 12 powernv_defconfig
+    env:
+      ARCH: powerpc
+      LLVM: false
+      LLVM_IAS: false
+      INSTALL_DEPS: 1
+      BOOT: false
+      CONFIG: powernv_defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
   _af6f80cfd25ab4381dfe6f974cb87ddc:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite

--- a/generator.yml
+++ b/generator.yml
@@ -62,9 +62,9 @@ builds:
   - {<< : *arm64,    << : *mainline,         llvm: true,  llvm_ias: true,  boot: true,  llvm_version: *llvm_tot}
   #- {<< : *mips,     << : *mainline,         llvm: false, llvm_ias: false, boot: true,  llvm_version: *llvm_tot}
   #- {<< : *mipsel,   << : *mainline,         llvm: false, llvm_ias: false, boot: true,  llvm_version: *llvm_tot}
-  #- {<< : *ppc32,    << : *mainline,         llvm: false, llvm_ias: false, boot: true,  llvm_version: *llvm_tot}
-  #- {<< : *ppc64,    << : *mainline,         llvm: false, llvm_ias: false, boot: true,  llvm_version: *llvm_tot}
-  #- {<< : *ppc64le,  << : *mainline,         llvm: false, llvm_ias: false, boot: true,  llvm_version: *llvm_tot}
+  - {<< : *ppc32,    << : *mainline,         llvm: false, llvm_ias: false, boot: false, llvm_version: *llvm_tot}
+  - {<< : *ppc64,    << : *mainline,         llvm: false, llvm_ias: false, boot: false, llvm_version: *llvm_tot}
+  - {<< : *ppc64le,  << : *mainline,         llvm: false, llvm_ias: false, boot: false, llvm_version: *llvm_tot}
   #- {<< : *riscv,    << : *mainline,         llvm: true,  llvm_ias: true,  boot: false, llvm_version: *llvm_tot}
   #- {<< : *s390,     << : *mainline,         llvm: false, llvm_ias: false, boot: false, llvm_version: *llvm_tot}
   #- {<< : *x86,      << : *mainline,         llvm: true,  llvm_ias: true,  boot: true,  llvm_version: *llvm_tot}
@@ -76,9 +76,9 @@ builds:
   - {<< : *arm64,    << : *next,             llvm: true,  llvm_ias: true,  boot: true,  llvm_version: *llvm_tot}
   #- {<< : *mips,     << : *next,             llvm: false, llvm_ias: false, boot: true,  llvm_version: *llvm_tot}
   #- {<< : *mipsel,   << : *next,             llvm: false, llvm_ias: false, boot: true,  llvm_version: *llvm_tot}
-  #- {<< : *ppc32,    << : *next,             llvm: false, llvm_ias: false, boot: true,  llvm_version: *llvm_tot}
-  #- {<< : *ppc64,    << : *next,             llvm: false, llvm_ias: false, boot: true,  llvm_version: *llvm_tot}
-  #- {<< : *ppc64le,  << : *next,             llvm: false, llvm_ias: false, boot: true,  llvm_version: *llvm_tot}
+  - {<< : *ppc32,    << : *next,             llvm: false, llvm_ias: false, boot: false, llvm_version: *llvm_tot}
+  - {<< : *ppc64,    << : *next,             llvm: false, llvm_ias: false, boot: false, llvm_version: *llvm_tot}
+  - {<< : *ppc64le,  << : *next,             llvm: false, llvm_ias: false, boot: false, llvm_version: *llvm_tot}
   #- {<< : *riscv,    << : *next,             llvm: true,  llvm_ias: true,  boot: false, llvm_version: *llvm_tot}
   #- {<< : *s390,     << : *next,             llvm: false, llvm_ias: false, boot: false, llvm_version: *llvm_tot}
   #- {<< : *x86,      << : *next,             llvm: true,  llvm_ias: true,  boot: true,  llvm_version: *llvm_tot}
@@ -133,5 +133,5 @@ builds:
   #- {<< : *mipsel,   << : *mainline,         llvm: false, llvm_ias: false, boot: true,  llvm_version: *llvm_latest}
   #- {<< : *ppc32,    << : *mainline,         llvm: false, llvm_ias: false, boot: true,  llvm_version: *llvm_latest}
   #- {<< : *ppc64,    << : *mainline,         llvm: false, llvm_ias: false, boot: true,  llvm_version: *llvm_latest}
-  #- {<< : *ppc64le,  << : *mainline,         llvm: false, llvm_ias: false, boot: true,  llvm_version: *llvm_latest}
+  - {<< : *ppc64le,  << : *mainline,         llvm: false, llvm_ias: false, boot: false, llvm_version: *llvm_latest}
   - {<< : *x86_64,   << : *mainline,         llvm: true,  llvm_ias: true,  boot: true,  llvm_version: *llvm_latest}

--- a/tuxsuite/mainline.tux.yml
+++ b/tuxsuite/mainline.tux.yml
@@ -10,9 +10,13 @@ sets:
       - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", git_ref: "master", target_arch: arm, toolchain: clang-nightly, kconfig: aspeed_g5_defconfig, make_variables: {LLVM: "1"}}
       - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", git_ref: "master", target_arch: arm, toolchain: clang-nightly, kconfig: multi_v7_defconfig, make_variables: {LLVM: "1"}}
       - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", git_ref: "master", target_arch: arm64, toolchain: clang-nightly, kconfig: defconfig, make_variables: {LLVM: "1"}}
+      - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", git_ref: "master", target_arch: powerpc, toolchain: clang-nightly, kconfig: ppc44x_defconfig, make_variables: {LLVM: "0"}}
+      - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", git_ref: "master", target_arch: powerpc, toolchain: clang-nightly, kconfig: pseries_defconfig, make_variables: {LLVM: "0"}}
+      - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", git_ref: "master", target_arch: powerpc, toolchain: clang-nightly, kconfig: powernv_defconfig, make_variables: {LLVM: "0"}}
       - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", git_ref: "master", target_arch: x86_64, toolchain: clang-nightly, kconfig: defconfig, make_variables: {LLVM: "1"}}
       - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", git_ref: "master", target_arch: arm, toolchain: clang-11, kconfig: multi_v5_defconfig, make_variables: {LLVM: "1"}}
       - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", git_ref: "master", target_arch: arm, toolchain: clang-11, kconfig: aspeed_g5_defconfig, make_variables: {LLVM: "1"}}
       - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", git_ref: "master", target_arch: arm, toolchain: clang-11, kconfig: multi_v7_defconfig, make_variables: {LLVM: "1"}}
       - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", git_ref: "master", target_arch: arm64, toolchain: clang-11, kconfig: defconfig, make_variables: {LLVM: "1"}}
+      - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", git_ref: "master", target_arch: powerpc, toolchain: clang-11, kconfig: powernv_defconfig, make_variables: {LLVM: "0"}}
       - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", git_ref: "master", target_arch: x86_64, toolchain: clang-11, kconfig: defconfig, make_variables: {LLVM: "1"}}

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -10,4 +10,7 @@ sets:
       - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git", git_ref: "master", target_arch: arm, toolchain: clang-nightly, kconfig: aspeed_g5_defconfig, make_variables: {LLVM: "1"}}
       - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git", git_ref: "master", target_arch: arm, toolchain: clang-nightly, kconfig: multi_v7_defconfig, make_variables: {LLVM: "1"}}
       - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git", git_ref: "master", target_arch: arm64, toolchain: clang-nightly, kconfig: defconfig, make_variables: {LLVM: "1"}}
+      - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git", git_ref: "master", target_arch: powerpc, toolchain: clang-nightly, kconfig: ppc44x_defconfig, make_variables: {LLVM: "0"}}
+      - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git", git_ref: "master", target_arch: powerpc, toolchain: clang-nightly, kconfig: pseries_defconfig, make_variables: {LLVM: "0"}}
+      - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git", git_ref: "master", target_arch: powerpc, toolchain: clang-nightly, kconfig: powernv_defconfig, make_variables: {LLVM: "0"}}
       - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git", git_ref: "master", target_arch: x86_64, toolchain: clang-nightly, kconfig: defconfig, make_variables: {LLVM: "1"}}


### PR DESCRIPTION
We can enable all of the PowerPC builds for clang-12 because the issue
exposed by tuxmake has been fixed:

https://github.com/llvm/llvm-project/commit/0a23fbd28c7509f2f980946091e6055bf27164d2

We can enable ppc64le for clang-11 because it has the right target.

We cannot boot any of them because we do not have the right images.