### PR TITLE
ci2: Add s390

### DIFF
--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -278,6 +278,26 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
+  _f8dea934d87b99f39977257fdd70a9ad:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite
+    name: ARCH=s390 LLVM=0 LLVM_IAS=0 BOOT=0 LLVM 11 defconfig
+    env:
+      ARCH: s390
+      LLVM: false
+      LLVM_IAS: false
+      INSTALL_DEPS: 1
+      BOOT: false
+      CONFIG: defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
   _ee7595d5ca720f6818bcb5e079ef8d63:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite

--- a/generator.yml
+++ b/generator.yml
@@ -134,4 +134,5 @@ builds:
   #- {<< : *ppc32,    << : *mainline,         llvm: false, llvm_ias: false, boot: true,  llvm_version: *llvm_latest}
   #- {<< : *ppc64,    << : *mainline,         llvm: false, llvm_ias: false, boot: true,  llvm_version: *llvm_latest}
   - {<< : *ppc64le,  << : *mainline,         llvm: false, llvm_ias: false, boot: false, llvm_version: *llvm_latest}
+  - {<< : *s390,     << : *mainline,         llvm: false, llvm_ias: false, boot: false, llvm_version: *llvm_latest}
   - {<< : *x86_64,   << : *mainline,         llvm: true,  llvm_ias: true,  boot: true,  llvm_version: *llvm_latest}

--- a/tuxsuite/mainline.tux.yml
+++ b/tuxsuite/mainline.tux.yml
@@ -19,4 +19,5 @@ sets:
       - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", git_ref: "master", target_arch: arm, toolchain: clang-11, kconfig: multi_v7_defconfig, make_variables: {LLVM: "1"}}
       - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", git_ref: "master", target_arch: arm64, toolchain: clang-11, kconfig: defconfig, make_variables: {LLVM: "1"}}
       - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", git_ref: "master", target_arch: powerpc, toolchain: clang-11, kconfig: powernv_defconfig, make_variables: {LLVM: "0"}}
+      - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", git_ref: "master", target_arch: s390, toolchain: clang-11, kconfig: defconfig, make_variables: {LLVM: "0"}}
       - {git_repo: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git", git_ref: "master", target_arch: x86_64, toolchain: clang-11, kconfig: defconfig, make_variables: {LLVM: "1"}}


### PR DESCRIPTION
This will need to be rebased after #26 is merged and `clang-nightly` is broken right now due to  https://github.com/ClangBuiltLinux/linux/issues/1261.