### PR TITLE
schedule cron jobs to run daily at midnight

### DIFF
--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -219,5 +219,7 @@ jobs:
     - name: Boot Test
       run: ./check_logs.py
 'on':
+  schedule:
+  - cron: 0 0 * * *
   workflow_dispatch: null
 

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -119,5 +119,7 @@ jobs:
     - name: Boot Test
       run: ./check_logs.py
 'on':
+  schedule:
+  - cron: 0 0 * * *
   workflow_dispatch: null
 

--- a/job_fragment.yml
+++ b/job_fragment.yml
@@ -1,8 +1,9 @@
 name: "replace me"
 on:
   # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#scheduled-events
-  #schedule:
-    #- cron:  '* 0 * * *'
+  schedule:
+    # Daily at midnight.
+    - cron:  '0 0 * * *'
 
   # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_dispatch
   workflow_dispatch:


### PR DESCRIPTION
We might be able to get fancier with these, based on how frequently
certain trees or toolchains get updated. For now, run something
continuously.

It seems that a whole workflow can only have one schedule...