### PR TITLE
Enable booting MIPS and PowerPC kernels

### DIFF
--- a/.github/workflows/4.14.yml
+++ b/.github/workflows/4.14.yml
@@ -88,15 +88,15 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _40f6d0c14113f1f8498cd098a85518cb:
+  _ac9bf8d2e76250e3ebf48c66c09c1fe6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 CC=clang LLVM_VERSION=12 powernv_defconfig
+    name: ARCH=powerpc CC=clang LLVM_VERSION=12 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: powernv_defconfig
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/4.19.yml
+++ b/.github/workflows/4.19.yml
@@ -88,15 +88,15 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _40f6d0c14113f1f8498cd098a85518cb:
+  _ac9bf8d2e76250e3ebf48c66c09c1fe6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 CC=clang LLVM_VERSION=12 powernv_defconfig
+    name: ARCH=powerpc CC=clang LLVM_VERSION=12 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: powernv_defconfig
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/5.10.yml
+++ b/.github/workflows/5.10.yml
@@ -126,15 +126,53 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _535ebd7ca1798dda46eccb404aea7620:
+  _34f6759fcc54c90da20900a041d8014d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=12 ppc44x_defconfig
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=12 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    env:
+      ARCH: mips
+      LLVM_VERSION: 12
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _7b8e833ae066ea79f1a6e4ff3389a632:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=mips LLVM=1 LLVM_VERSION=12 malta_kvm_guest_defconfig
+    env:
+      ARCH: mips
+      LLVM_VERSION: 12
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: malta_kvm_guest_defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _a3bacbe25d9b5eb02296db0c021ec75c:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 ppc44x_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: ppc44x_defconfig
     steps:
     - uses: actions/checkout@v2
@@ -145,15 +183,15 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _a76a270fda7cd963fb2d6b24de9595cb:
+  _dbfb1afee12b5bc2178bd79c1ca36bc9:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=12 pseries_defconfig
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=12 pseries_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: pseries_defconfig
     steps:
     - uses: actions/checkout@v2
@@ -164,15 +202,15 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _e296e30c07f6fef62558537fbe6bf035:
+  _4929805e7a2ad956b20f06354ba6557f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=12 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: powernv_defconfig
     steps:
     - uses: actions/checkout@v2
@@ -183,15 +221,15 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _98aa9cca27fc530a6448efe7056a03c9:
+  _49b8454e1fcf8ba7fc36c5f5e6cc5299:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv BOOT=0 LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_EFI=n
+    name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_EFI=n
     env:
       ARCH: riscv
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: defconfig+CONFIG_EFI=n
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/5.4.yml
+++ b/.github/workflows/5.4.yml
@@ -88,15 +88,53 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _535ebd7ca1798dda46eccb404aea7620:
+  _b22d88ed6ca44e08b3ddced1f36b2681:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=12 ppc44x_defconfig
+    name: ARCH=mips LLVM=1 LLVM_VERSION=12 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    env:
+      ARCH: mips
+      LLVM_VERSION: 12
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _7b8e833ae066ea79f1a6e4ff3389a632:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=mips LLVM=1 LLVM_VERSION=12 malta_kvm_guest_defconfig
+    env:
+      ARCH: mips
+      LLVM_VERSION: 12
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: malta_kvm_guest_defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _a3bacbe25d9b5eb02296db0c021ec75c:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 ppc44x_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: ppc44x_defconfig
     steps:
     - uses: actions/checkout@v2
@@ -107,15 +145,15 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _a76a270fda7cd963fb2d6b24de9595cb:
+  _dbfb1afee12b5bc2178bd79c1ca36bc9:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=12 pseries_defconfig
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=12 pseries_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: pseries_defconfig
     steps:
     - uses: actions/checkout@v2
@@ -126,15 +164,15 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _e296e30c07f6fef62558537fbe6bf035:
+  _4929805e7a2ad956b20f06354ba6557f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=12 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: powernv_defconfig
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -126,15 +126,53 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _535ebd7ca1798dda46eccb404aea7620:
+  _34f6759fcc54c90da20900a041d8014d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=12 ppc44x_defconfig
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=12 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    env:
+      ARCH: mips
+      LLVM_VERSION: 12
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _7b8e833ae066ea79f1a6e4ff3389a632:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=mips LLVM=1 LLVM_VERSION=12 malta_kvm_guest_defconfig
+    env:
+      ARCH: mips
+      LLVM_VERSION: 12
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: malta_kvm_guest_defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _a3bacbe25d9b5eb02296db0c021ec75c:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 ppc44x_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: ppc44x_defconfig
     steps:
     - uses: actions/checkout@v2
@@ -145,15 +183,15 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _a76a270fda7cd963fb2d6b24de9595cb:
+  _dbfb1afee12b5bc2178bd79c1ca36bc9:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=12 pseries_defconfig
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=12 pseries_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: pseries_defconfig
     steps:
     - uses: actions/checkout@v2
@@ -164,15 +202,15 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _e296e30c07f6fef62558537fbe6bf035:
+  _4929805e7a2ad956b20f06354ba6557f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=12 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: powernv_defconfig
     steps:
     - uses: actions/checkout@v2
@@ -183,15 +221,15 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _98aa9cca27fc530a6448efe7056a03c9:
+  _49b8454e1fcf8ba7fc36c5f5e6cc5299:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv BOOT=0 LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_EFI=n
+    name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_EFI=n
     env:
       ARCH: riscv
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: defconfig+CONFIG_EFI=n
     steps:
     - uses: actions/checkout@v2
@@ -354,15 +392,53 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _78bca94ec9fce86c2275fb6a432820c4:
+  _a82a7c15d9664631e5324fb16007e6c8:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=11 powernv_defconfig
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=11 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    env:
+      ARCH: mips
+      LLVM_VERSION: 11
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _df6659605e188f908ee2328126b07a38:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=mips LLVM=1 LLVM_VERSION=11 malta_kvm_guest_defconfig
+    env:
+      ARCH: mips
+      LLVM_VERSION: 11
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: malta_kvm_guest_defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _8190461c1f8057e418b9abae5f927a20:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=11 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: powernv_defconfig
     steps:
     - uses: actions/checkout@v2
@@ -373,15 +449,15 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _2e696b01553124e0893a0b89cfd2b934:
+  _94771c21f822e6468d29dfe9257e8207:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv BOOT=0 LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_EFI=n
+    name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_EFI=n
     env:
       ARCH: riscv
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: defconfig+CONFIG_EFI=n
     steps:
     - uses: actions/checkout@v2
@@ -544,15 +620,53 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _f66c7b98f62205a5ef552b0bfce4a7f2:
+  _1fe8cbbe1f257d4a2bb36caa6d968d86:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=10 powernv_defconfig
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=10 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    env:
+      ARCH: mips
+      LLVM_VERSION: 10
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _887af52b1d6887124d7ec22c8dcb6b95:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=mips LLVM=1 LLVM_VERSION=10 malta_kvm_guest_defconfig
+    env:
+      ARCH: mips
+      LLVM_VERSION: 10
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: malta_kvm_guest_defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _f858b2a83b07d7945ea319b9b2400c63:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=10 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 10
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: powernv_defconfig
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -145,15 +145,53 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _535ebd7ca1798dda46eccb404aea7620:
+  _34f6759fcc54c90da20900a041d8014d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=12 ppc44x_defconfig
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=12 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    env:
+      ARCH: mips
+      LLVM_VERSION: 12
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _7b8e833ae066ea79f1a6e4ff3389a632:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=mips LLVM=1 LLVM_VERSION=12 malta_kvm_guest_defconfig
+    env:
+      ARCH: mips
+      LLVM_VERSION: 12
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: malta_kvm_guest_defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _a3bacbe25d9b5eb02296db0c021ec75c:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 ppc44x_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: ppc44x_defconfig
     steps:
     - uses: actions/checkout@v2
@@ -164,15 +202,15 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _a76a270fda7cd963fb2d6b24de9595cb:
+  _dbfb1afee12b5bc2178bd79c1ca36bc9:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=12 pseries_defconfig
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=12 pseries_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: pseries_defconfig
     steps:
     - uses: actions/checkout@v2
@@ -183,15 +221,15 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _e296e30c07f6fef62558537fbe6bf035:
+  _4929805e7a2ad956b20f06354ba6557f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=12 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: powernv_defconfig
     steps:
     - uses: actions/checkout@v2
@@ -202,15 +240,15 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _98aa9cca27fc530a6448efe7056a03c9:
+  _49b8454e1fcf8ba7fc36c5f5e6cc5299:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv BOOT=0 LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_EFI=n
+    name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_EFI=n
     env:
       ARCH: riscv
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: defconfig+CONFIG_EFI=n
     steps:
     - uses: actions/checkout@v2
@@ -373,15 +411,53 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _78bca94ec9fce86c2275fb6a432820c4:
+  _a82a7c15d9664631e5324fb16007e6c8:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=11 powernv_defconfig
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=11 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    env:
+      ARCH: mips
+      LLVM_VERSION: 11
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _df6659605e188f908ee2328126b07a38:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=mips LLVM=1 LLVM_VERSION=11 malta_kvm_guest_defconfig
+    env:
+      ARCH: mips
+      LLVM_VERSION: 11
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: malta_kvm_guest_defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _8190461c1f8057e418b9abae5f927a20:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=11 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: powernv_defconfig
     steps:
     - uses: actions/checkout@v2
@@ -392,15 +468,15 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _2e696b01553124e0893a0b89cfd2b934:
+  _94771c21f822e6468d29dfe9257e8207:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv BOOT=0 LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_EFI=n
+    name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_EFI=n
     env:
       ARCH: riscv
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: defconfig+CONFIG_EFI=n
     steps:
     - uses: actions/checkout@v2
@@ -563,15 +639,53 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _f66c7b98f62205a5ef552b0bfce4a7f2:
+  _1fe8cbbe1f257d4a2bb36caa6d968d86:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=10 powernv_defconfig
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=10 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    env:
+      ARCH: mips
+      LLVM_VERSION: 10
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _887af52b1d6887124d7ec22c8dcb6b95:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=mips LLVM=1 LLVM_VERSION=10 malta_kvm_guest_defconfig
+    env:
+      ARCH: mips
+      LLVM_VERSION: 10
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: malta_kvm_guest_defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _f858b2a83b07d7945ea319b9b2400c63:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=10 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 10
       INSTALL_DEPS: 1
-      BOOT: 0
+      BOOT: 1
       CONFIG: powernv_defconfig
     steps:
     - uses: actions/checkout@v2

--- a/check_logs.py
+++ b/check_logs.py
@@ -72,7 +72,7 @@ def run_boot():
     boot_qemu = [
         "./boot-utils/boot-qemu.sh", "-a", cbl_arch, "-k", kernel_image
     ]
-    if cbl_arch == "s390":
+    if cbl_arch == "riscv" or cbl_arch == "s390":
         boot_qemu += ["--use-cbl-qemu"]
     try:
         subprocess.run(boot_qemu, check=True)

--- a/generate_tuxsuite.py
+++ b/generate_tuxsuite.py
@@ -65,6 +65,8 @@ def emit_tuxsuite_yml(config, tree):
                 "kconfig": build["config"],
                 "targets": build["targets"]
             }
+            if "kernel_image" in build:
+                current_build.update({"kernel_image": build["kernel_image"]})
             if "make_variables" in build:
                 current_build.update(
                     {"make_variables": build["make_variables"]})

--- a/generator.yml
+++ b/generator.yml
@@ -59,7 +59,7 @@ defconfigs:
   - &arm64_gki  {config: gki_defconfig,                                << : *arm64-triple,         << : *kernel_modules}
   - &arm64_cut  {config: cuttlefish_defconfig,                         << : *arm64-triple,         << : *kernel_modules}
   - &i386       {config: defconfig,                                    << : *i386-triple,          << : *kernel_modules}
-  - &mips       {config: malta_kvm_guest_defconfig,                    << : *mips-triple,          << : *kernel_modules}
+  - &mips       {config: [malta_kvm_guest_defconfig, CONFIG_CPU_BIG_ENDIAN=y],                    << : *mips-triple,          << : *kernel_modules}
   - &mipsel     {config: malta_kvm_guest_defconfig,                    << : *mipsel-triple,        << : *kernel_modules}
   - &ppc32      {config: ppc44x_defconfig,                             << : *powerpc-triple,       << : *kernel_modules}
   - &ppc64      {config: pseries_defconfig,                            << : *powerpc64-triple,     << : *kernel_modules}

--- a/generator.yml
+++ b/generator.yml
@@ -117,16 +117,12 @@ builds:
   - {<< : *arm32_v7_t, << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *i386,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  # mips and mipsel: Build disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/1)
-  # mips and mipsel: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  # - {<< : *mips,       << : *next,             << : *mips_llvm,       boot: false, llvm_version: *llvm_tot}
-  # - {<< : *mipsel,     << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  # ppc32, ppc64, and ppc64le: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  - {<< : *ppc32,      << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  - {<< : *ppc64,      << : *next,             << : *ppc64_llvm,      boot: false, llvm_version: *llvm_tot}
-  - {<< : *ppc64le,    << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  # riscv: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  - {<< : *riscv,      << : *next,             << : *riscv_llvm_full, boot: false, llvm_version: *llvm_tot}
+  - {<< : *mips,       << : *next,             << : *mips_llvm,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *mipsel,     << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
+  - {<< : *ppc32,      << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
+  - {<< : *ppc64,      << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
+  - {<< : *ppc64le,    << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
+  - {<< : *riscv,      << : *next,             << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_tot}
   - {<< : *s390,       << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64,     << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   ############
@@ -240,17 +236,13 @@ builds:
   - {<< : *arm32_v7_t, << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *i386,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  # mips and mipsel: Build disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/1)
-  # mips and mipsel: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  # - {<< : *mips,       << : *next,             << : *mips_llvm,       boot: false, llvm_version: *llvm_latest}
-  # - {<< : *mipsel,     << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_latest}
+  - {<< : *mips,       << : *next,             << : *mips_llvm,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *mipsel,     << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   # ppc32 and ppc64: Build disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/2)
-  # ppc32, ppc64, and ppc64le: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  # - {<< : *ppc32,      << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_latest}
-  # - {<< : *ppc64,      << : *next,             << : *ppc64_llvm,      boot: false, llvm_version: *llvm_latest}
-  - {<< : *ppc64le,    << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_latest}
-  # riscv: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  - {<< : *riscv,      << : *next,             << : *riscv_llvm_full, boot: false, llvm_version: *llvm_latest}
+  # - {<< : *ppc32,      << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_latest}
+  # - {<< : *ppc64,      << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_latest}
+  - {<< : *ppc64le,    << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_latest}
+  - {<< : *riscv,      << : *next,             << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_latest}
   - {<< : *s390,       << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64,     << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   #############
@@ -282,14 +274,11 @@ builds:
   - {<< : *arm32_v7_t, << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_10}
   - {<< : *arm64,      << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_10}
   - {<< : *i386,       << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_10}
-  # mips and mipsel: Build disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/1)
-  # mips and mipsel: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  # - {<< : *mips,       << : *next,             << : *mips_llvm,       boot: false, llvm_version: *llvm_10}
-  # - {<< : *mipsel,     << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_10}
+  - {<< : *mips,       << : *next,             << : *mips_llvm,       boot: true,  llvm_version: *llvm_10}
+  - {<< : *mipsel,     << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_10}
   # ppc32 and ppc64: Build disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/2)
-  # ppc32, ppc64, and ppc64le: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  # - {<< : *ppc32,      << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_10}
-  # - {<< : *ppc64,      << : *next,             << : *ppc64_llvm,      boot: false, llvm_version: *llvm_10}
-  - {<< : *ppc64le,    << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_10}
+  # - {<< : *ppc32,      << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_10}
+  # - {<< : *ppc64,      << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_10}
+  - {<< : *ppc64le,    << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_10}
   - {<< : *s390,       << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_10}
   - {<< : *x86_64,     << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_10}

--- a/generator.yml
+++ b/generator.yml
@@ -59,13 +59,13 @@ defconfigs:
   - &arm64_gki  {config: gki_defconfig,                                << : *arm64-triple,         << : *kernel_modules}
   - &arm64_cut  {config: cuttlefish_defconfig,                         << : *arm64-triple,         << : *kernel_modules}
   - &i386       {config: defconfig,                                    << : *i386-triple,          << : *kernel_modules}
-  - &mips       {config: [malta_kvm_guest_defconfig, CONFIG_CPU_BIG_ENDIAN=y],                    << : *mips-triple,          << : *kernel_modules}
-  - &mipsel     {config: malta_kvm_guest_defconfig,                    << : *mipsel-triple,        << : *kernel_modules}
-  - &ppc32      {config: ppc44x_defconfig,                             << : *powerpc-triple,       << : *kernel_modules}
-  - &ppc64      {config: pseries_defconfig,                            << : *powerpc64-triple,     << : *kernel_modules}
-  - &ppc64le    {config: powernv_defconfig,                            << : *powerpc64le-triple,   << : *kernel_modules}
+  - &mips       {config: [malta_kvm_guest_defconfig, CONFIG_CPU_BIG_ENDIAN=y], kernel_image: vmlinux, << : *mips-triple,          << : *kernel_modules}
+  - &mipsel     {config: malta_kvm_guest_defconfig,                    kernel_image: vmlinux, << : *mipsel-triple,        << : *kernel_modules}
+  - &ppc32      {config: ppc44x_defconfig,                             kernel_image: uImage, << : *powerpc-triple,       << : *kernel_modules}
+  - &ppc64      {config: pseries_defconfig,                            kernel_image: vmlinux, << : *powerpc64-triple,     << : *kernel_modules}
+  - &ppc64le    {config: powernv_defconfig,                            kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel_modules}
   #                                  https://github.com/ClangBuiltLinux/linux/issues/1143
-  - &riscv      {config: [defconfig, CONFIG_EFI=n],                    << : *riscv-triple,         << : *kernel_modules}
+  - &riscv      {config: [defconfig, CONFIG_EFI=n],                    kernel_image: Image, << : *riscv-triple,         << : *kernel_modules}
   - &s390       {config: defconfig,                                    << : *s390-triple,          << : *kernel_modules}
   - &x86_64     {config: defconfig,                                                                << : *kernel_modules}
   - &x86_64_gki {config: gki_defconfig,                                                            << : *kernel_modules}

--- a/generator.yml
+++ b/generator.yml
@@ -50,26 +50,26 @@ targets:
   - &kernel_modules      {targets: [config,kernel,modules]}
   - &kernel_modules_dtbs {targets: [config,kernel,modules,dtbs]}
 defconfigs:
-  #              config:                                               [triples:] (Optional: x86)  targets to build
-  - &arm32_v5   {config: multi_v5_defconfig,                           << : *arm-triple,           << : *kernel_modules_dtbs}
-  - &arm32_v6   {config: aspeed_g5_defconfig,                          << : *arm-triple,           << : *kernel_modules_dtbs}
-  - &arm32_v7   {config: multi_v7_defconfig,                           << : *arm-triple,           << : *kernel_modules}
-  - &arm32_v7_t {config: [multi_v7_defconfig, CONFIG_THUMB2_KERNEL=y], << : *arm-triple,           << : *kernel_modules}
-  - &arm64      {config: defconfig,                                    << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_gki  {config: gki_defconfig,                                << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_cut  {config: cuttlefish_defconfig,                         << : *arm64-triple,         << : *kernel_modules}
-  - &i386       {config: defconfig,                                    << : *i386-triple,          << : *kernel_modules}
-  - &mips       {config: [malta_kvm_guest_defconfig, CONFIG_CPU_BIG_ENDIAN=y], kernel_image: vmlinux, << : *mips-triple,          << : *kernel_modules}
-  - &mipsel     {config: malta_kvm_guest_defconfig,                    kernel_image: vmlinux, << : *mipsel-triple,        << : *kernel_modules}
-  - &ppc32      {config: ppc44x_defconfig,                             kernel_image: uImage, << : *powerpc-triple,       << : *kernel_modules}
-  - &ppc64      {config: pseries_defconfig,                            kernel_image: vmlinux, << : *powerpc64-triple,     << : *kernel_modules}
-  - &ppc64le    {config: powernv_defconfig,                            kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel_modules}
+  #              config:                                                       image target (optional)     [triples:] (Optional: x86)  targets to build
+  - &arm32_v5   {config: multi_v5_defconfig,                                                               << : *arm-triple,           << : *kernel_modules_dtbs}
+  - &arm32_v6   {config: aspeed_g5_defconfig,                                                              << : *arm-triple,           << : *kernel_modules_dtbs}
+  - &arm32_v7   {config: multi_v7_defconfig,                                                               << : *arm-triple,           << : *kernel_modules}
+  - &arm32_v7_t {config: [multi_v7_defconfig, CONFIG_THUMB2_KERNEL=y],                                     << : *arm-triple,           << : *kernel_modules}
+  - &arm64      {config: defconfig,                                                                        << : *arm64-triple,         << : *kernel_modules}
+  - &arm64_gki  {config: gki_defconfig,                                                                    << : *arm64-triple,         << : *kernel_modules}
+  - &arm64_cut  {config: cuttlefish_defconfig,                                                             << : *arm64-triple,         << : *kernel_modules}
+  - &i386       {config: defconfig,                                                                        << : *i386-triple,          << : *kernel_modules}
+  - &mips       {config: [malta_kvm_guest_defconfig, CONFIG_CPU_BIG_ENDIAN=y], kernel_image: vmlinux,      << : *mips-triple,          << : *kernel_modules}
+  - &mipsel     {config: malta_kvm_guest_defconfig,                            kernel_image: vmlinux,      << : *mipsel-triple,        << : *kernel_modules}
+  - &ppc32      {config: ppc44x_defconfig,                                     kernel_image: uImage,       << : *powerpc-triple,       << : *kernel_modules}
+  - &ppc64      {config: pseries_defconfig,                                    kernel_image: vmlinux,      << : *powerpc64-triple,     << : *kernel_modules}
+  - &ppc64le    {config: powernv_defconfig,                                    kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel_modules}
   #                                  https://github.com/ClangBuiltLinux/linux/issues/1143
-  - &riscv      {config: [defconfig, CONFIG_EFI=n],                    kernel_image: Image, << : *riscv-triple,         << : *kernel_modules}
-  - &s390       {config: defconfig,                                    << : *s390-triple,          << : *kernel_modules}
-  - &x86_64     {config: defconfig,                                                                << : *kernel_modules}
-  - &x86_64_gki {config: gki_defconfig,                                                            << : *kernel_modules}
-  - &x86_64_cut {config: x86_64_cuttlefish_defconfig,                                              << : *kernel_modules}
+  - &riscv      {config: [defconfig, CONFIG_EFI=n],                            kernel_image: Image,        << : *riscv-triple,         << : *kernel_modules}
+  - &s390       {config: defconfig,                                                                        << : *s390-triple,          << : *kernel_modules}
+  - &x86_64     {config: defconfig,                                                                                                    << : *kernel_modules}
+  - &x86_64_gki {config: gki_defconfig,                                                                                                << : *kernel_modules}
+  - &x86_64_cut {config: x86_64_cuttlefish_defconfig,                                                                                  << : *kernel_modules}
 tiers:
   # Generic tiers       LLVM=1       LLVM_IAS=1        Make variables to pass to TuxSuite
   - &llvm_full          {llvm: true,  llvm_ias: true,  make_variables: {LLVM: 1, LLVM_IAS: 1}}

--- a/generator.yml
+++ b/generator.yml
@@ -100,16 +100,12 @@ builds:
   - {<< : *arm64,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   # i386: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1210)
   # - {<< : *i386,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  # mips and mipsel: Build disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/1)
-  # mips and mipsel: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  # - {<< : *mips,       << : *mainline,         << : *mips_llvm,       boot: false, llvm_version: *llvm_tot}
-  # - {<< : *mipsel,     << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  # ppc32, ppc64, and ppc64le: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  - {<< : *ppc32,      << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  - {<< : *ppc64,      << : *mainline,         << : *ppc64_llvm,      boot: false, llvm_version: *llvm_tot}
-  - {<< : *ppc64le,    << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  # riscv: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  - {<< : *riscv,      << : *mainline,         << : *riscv_llvm_full, boot: false, llvm_version: *llvm_tot}
+  - {<< : *mips,       << : *mainline,         << : *mips_llvm,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *mipsel,     << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_tot}
+  - {<< : *ppc32,      << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_tot}
+  - {<< : *ppc64,      << : *mainline,         << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
+  - {<< : *ppc64le,    << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_tot}
+  - {<< : *riscv,      << : *mainline,         << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_tot}
   - {<< : *s390,       << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64,     << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   ##########
@@ -226,17 +222,13 @@ builds:
   - {<< : *arm32_v7_t, << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *i386,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  # mips and mipsel: Build disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/1)
-  # mips and mipsel: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  # - {<< : *mips,       << : *mainline,         << : *mips_llvm,       boot: false, llvm_version: *llvm_latest}
-  # - {<< : *mipsel,     << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_latest}
+  - {<< : *mips,       << : *mainline,         << : *mips_llvm,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *mipsel,     << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   # ppc32 and ppc64: Build disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/2)
-  # ppc32, ppc64, and ppc64le: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  # - {<< : *ppc32,      << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_latest}
-  # - {<< : *ppc64,      << : *mainline,         << : *ppc64_llvm,      boot: false, llvm_version: *llvm_latest}
-  - {<< : *ppc64le,    << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_latest}
-  # riscv: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  - {<< : *riscv,      << : *mainline,         << : *riscv_llvm_full, boot: false, llvm_version: *llvm_latest}
+  # - {<< : *ppc32,      << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_latest}
+  # - {<< : *ppc64,      << : *mainline,         << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_latest}
+  - {<< : *ppc64le,    << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_latest}
+  - {<< : *riscv,      << : *mainline,         << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_latest}
   - {<< : *s390,       << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64,     << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   ##########
@@ -273,15 +265,12 @@ builds:
   - {<< : *arm32_v7_t, << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_10}
   - {<< : *arm64,      << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_10}
   - {<< : *i386,       << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_10}
-  # mips and mipsel: Build disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/1)
-  # mips and mipsel: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  # - {<< : *mips,       << : *mainline,         << : *mips_llvm,       boot: false, llvm_version: *llvm_10}
-  # - {<< : *mipsel,     << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_10}
+  - {<< : *mips,       << : *mainline,         << : *mips_llvm,       boot: true,  llvm_version: *llvm_10}
+  - {<< : *mipsel,     << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_10}
   # ppc32 and ppc64: Build disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/2)
-  # ppc32, ppc64, and ppc64le: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  # - {<< : *ppc32,      << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_10}
-  # - {<< : *ppc64,      << : *mainline,         << : *ppc64_llvm,      boot: false, llvm_version: *llvm_10}
-  - {<< : *ppc64le,    << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_10}
+  # - {<< : *ppc32,      << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_10}
+  # - {<< : *ppc64,      << : *mainline,         << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_10}
+  - {<< : *ppc64le,    << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_10}
   - {<< : *s390,       << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_10}
   - {<< : *x86_64,     << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_10}
   ##########

--- a/generator.yml
+++ b/generator.yml
@@ -149,14 +149,11 @@ builds:
   - {<< : *arm32_v7,   << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_v7_t, << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64,      << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  # mips and mipsel: Build disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/1)
-  # mips and mipsel: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  # - {<< : *mips,       << : *stable-5_4,       << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  # - {<< : *mipsel,     << : *stable-5_4,       << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  # ppc32, ppc64, and ppc64le: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  - {<< : *ppc32,      << : *stable-5_4,       << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  - {<< : *ppc64,      << : *stable-5_4,       << : *ppc64_llvm,      boot: false, llvm_version: *llvm_tot}
-  - {<< : *ppc64le,    << : *stable-5_4,       << : *llvm,            boot: false, llvm_version: *llvm_tot}
+  - {<< : *mips,       << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
+  - {<< : *mipsel,     << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
+  - {<< : *ppc32,      << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
+  - {<< : *ppc64,      << : *stable-5_4,       << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
+  - {<< : *ppc64le,    << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64,     << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   ############
   #  4.19.y  #

--- a/generator.yml
+++ b/generator.yml
@@ -161,8 +161,7 @@ builds:
   - {<< : *arm32_v7,   << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_v7_t, << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64,      << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  # ppc64le: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  - {<< : *ppc64le,    << : *stable-4_19,      << : *clang,           boot: false, llvm_version: *llvm_tot}
+  - {<< : *ppc64le,    << : *stable-4_19,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64,     << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   ############
   #  4.14.y  #

--- a/generator.yml
+++ b/generator.yml
@@ -169,8 +169,7 @@ builds:
   - {<< : *arm32_v7,   << : *stable-4_14,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_v7_t, << : *stable-4_14,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64,      << : *stable-4_14,      << : *lld,             boot: true,  llvm_version: *llvm_tot}
-  # ppc64le: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  - {<< : *ppc64le,    << : *stable-4_14,      << : *clang,           boot: false, llvm_version: *llvm_tot}
+  - {<< : *ppc64le,    << : *stable-4_14,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64,     << : *stable-4_14,      << : *lld,             boot: true,  llvm_version: *llvm_tot}
   ###########
   #  4.9.y  #

--- a/generator.yml
+++ b/generator.yml
@@ -135,16 +135,12 @@ builds:
   - {<< : *arm64,      << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   # i386: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1210)
   # - {<< : *i386,       << : *stable-5_10,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  # mips and mipsel: Build disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/1)
-  # mips and mipsel: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  # - {<< : *mips,       << : *stable-5_10,         << : *mips_llvm,       boot: true,  llvm_version: *llvm_tot}
-  # - {<< : *mipsel,     << : *stable-5_10,         << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  # ppc32, ppc64, and ppc64le: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  - {<< : *ppc32,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  - {<< : *ppc64,      << : *stable-5_10,      << : *ppc64_llvm,      boot: false, llvm_version: *llvm_tot}
-  - {<< : *ppc64le,    << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  # riscv: Boot disabled (https://github.com/ClangBuiltLinux/continuous-integration2/issues/27)
-  - {<< : *riscv,      << : *stable-5_10,      << : *riscv_llvm_full, boot: false, llvm_version: *llvm_tot}
+  - {<< : *mips,       << : *stable-5_10,      << : *mips_llvm,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *mipsel,     << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
+  - {<< : *ppc32,      << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
+  - {<< : *ppc64,      << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
+  - {<< : *ppc64le,    << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
+  - {<< : *riscv,      << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_tot}
   - {<< : *s390,       << : *stable-5_10,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64,     << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   ###########

--- a/install_deps.py
+++ b/install_deps.py
@@ -20,7 +20,7 @@ def install_deps():
         "powerpc": ["qemu-system-ppc"],
         "x86_64": ["qemu-system-x86"],
         "s390": [],
-        "riscv": ["qemu-system-riscv64"],
+        "riscv": [],
     }
     if not arch in arch_dependencies:
         print("Unknown arch \"%s\", can't install dependencies" % arch,

--- a/tuxsuite/4.14.tux.yml
+++ b/tuxsuite/4.14.tux.yml
@@ -46,6 +46,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: zImage.epapr
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-4.14.y
     target_arch: x86_64

--- a/tuxsuite/4.19.tux.yml
+++ b/tuxsuite/4.19.tux.yml
@@ -50,6 +50,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: zImage.epapr
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-4.19.y
     target_arch: x86_64

--- a/tuxsuite/5.10.tux.yml
+++ b/tuxsuite/5.10.tux.yml
@@ -68,6 +68,33 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
+    target_arch: mips
+    toolchain: clang-nightly
+    kconfig:
+    - malta_kvm_guest_defconfig
+    - CONFIG_CPU_BIG_ENDIAN=y
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LD: mips-linux-gnu-ld
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+    git_ref: linux-5.10.y
+    target_arch: mips
+    toolchain: clang-nightly
+    kconfig: malta_kvm_guest_defconfig
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+    git_ref: linux-5.10.y
     target_arch: powerpc
     toolchain: clang-nightly
     kconfig: ppc44x_defconfig

--- a/tuxsuite/5.10.tux.yml
+++ b/tuxsuite/5.10.tux.yml
@@ -75,6 +75,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: uImage
     make_variables:
       LLVM: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -86,6 +87,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: vmlinux
     make_variables:
       LD: powerpc64le-linux-gnu-ld
       LLVM: 1
@@ -98,6 +100,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -111,6 +114,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: Image
     make_variables:
       LD: riscv64-linux-gnu-ld
       LLVM: 1

--- a/tuxsuite/5.4.tux.yml
+++ b/tuxsuite/5.4.tux.yml
@@ -44,6 +44,32 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.4.y
+    target_arch: mips
+    toolchain: clang-nightly
+    kconfig:
+    - malta_kvm_guest_defconfig
+    - CONFIG_CPU_BIG_ENDIAN=y
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+    git_ref: linux-5.4.y
+    target_arch: mips
+    toolchain: clang-nightly
+    kconfig: malta_kvm_guest_defconfig
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+    git_ref: linux-5.4.y
     target_arch: powerpc
     toolchain: clang-nightly
     kconfig: ppc44x_defconfig

--- a/tuxsuite/5.4.tux.yml
+++ b/tuxsuite/5.4.tux.yml
@@ -51,6 +51,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: uImage
     make_variables:
       LLVM: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -62,6 +63,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: vmlinux
     make_variables:
       LD: powerpc64le-linux-gnu-ld
       LLVM: 1
@@ -74,6 +76,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git

--- a/tuxsuite/mainline.tux.yml
+++ b/tuxsuite/mainline.tux.yml
@@ -68,6 +68,33 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
+    target_arch: mips
+    toolchain: clang-nightly
+    kconfig:
+    - malta_kvm_guest_defconfig
+    - CONFIG_CPU_BIG_ENDIAN=y
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LD: mips-linux-gnu-ld
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+    git_ref: master
+    target_arch: mips
+    toolchain: clang-nightly
+    kconfig: malta_kvm_guest_defconfig
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+    git_ref: master
     target_arch: powerpc
     toolchain: clang-nightly
     kconfig: ppc44x_defconfig
@@ -214,6 +241,33 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
+    target_arch: mips
+    toolchain: clang-11
+    kconfig:
+    - malta_kvm_guest_defconfig
+    - CONFIG_CPU_BIG_ENDIAN=y
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LD: mips-linux-gnu-ld
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+    git_ref: master
+    target_arch: mips
+    toolchain: clang-11
+    kconfig: malta_kvm_guest_defconfig
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+    git_ref: master
     target_arch: powerpc
     toolchain: clang-11
     kconfig: powernv_defconfig
@@ -330,6 +384,33 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+    git_ref: master
+    target_arch: mips
+    toolchain: clang-10
+    kconfig:
+    - malta_kvm_guest_defconfig
+    - CONFIG_CPU_BIG_ENDIAN=y
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LD: mips-linux-gnu-ld
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+    git_ref: master
+    target_arch: mips
+    toolchain: clang-10
+    kconfig: malta_kvm_guest_defconfig
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
     make_variables:
       LLVM: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git

--- a/tuxsuite/mainline.tux.yml
+++ b/tuxsuite/mainline.tux.yml
@@ -75,6 +75,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: uImage
     make_variables:
       LLVM: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -86,6 +87,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: vmlinux
     make_variables:
       LD: powerpc64le-linux-gnu-ld
       LLVM: 1
@@ -98,6 +100,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -111,6 +114,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: Image
     make_variables:
       LD: riscv64-linux-gnu-ld
       LLVM: 1
@@ -217,6 +221,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -230,6 +235,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: Image
     make_variables:
       LD: riscv64-linux-gnu-ld
       LLVM: 1
@@ -335,6 +341,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -87,6 +87,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: uImage
     make_variables:
       LLVM: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -98,6 +99,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: vmlinux
     make_variables:
       LD: powerpc64le-linux-gnu-ld
       LLVM: 1
@@ -110,6 +112,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -123,6 +126,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: Image
     make_variables:
       LD: riscv64-linux-gnu-ld
       LLVM: 1
@@ -229,6 +233,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -242,6 +247,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: Image
     make_variables:
       LD: riscv64-linux-gnu-ld
       LLVM: 1
@@ -347,6 +353,7 @@ sets:
     - config
     - kernel
     - modules
+    kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -80,6 +80,33 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
+    target_arch: mips
+    toolchain: clang-nightly
+    kconfig:
+    - malta_kvm_guest_defconfig
+    - CONFIG_CPU_BIG_ENDIAN=y
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LD: mips-linux-gnu-ld
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+    git_ref: master
+    target_arch: mips
+    toolchain: clang-nightly
+    kconfig: malta_kvm_guest_defconfig
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+    git_ref: master
     target_arch: powerpc
     toolchain: clang-nightly
     kconfig: ppc44x_defconfig
@@ -226,6 +253,33 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
+    target_arch: mips
+    toolchain: clang-11
+    kconfig:
+    - malta_kvm_guest_defconfig
+    - CONFIG_CPU_BIG_ENDIAN=y
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LD: mips-linux-gnu-ld
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+    git_ref: master
+    target_arch: mips
+    toolchain: clang-11
+    kconfig: malta_kvm_guest_defconfig
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+    git_ref: master
     target_arch: powerpc
     toolchain: clang-11
     kconfig: powernv_defconfig
@@ -342,6 +396,33 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+    git_ref: master
+    target_arch: mips
+    toolchain: clang-10
+    kconfig:
+    - malta_kvm_guest_defconfig
+    - CONFIG_CPU_BIG_ENDIAN=y
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LD: mips-linux-gnu-ld
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+    git_ref: master
+    target_arch: mips
+    toolchain: clang-10
+    kconfig: malta_kvm_guest_defconfig
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
     make_variables:
       LLVM: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git

--- a/utils.py
+++ b/utils.py
@@ -9,17 +9,19 @@ TOT_LLVM = 12
 
 def get_image_name():
     arch = os.environ["ARCH"]
-    # "ppc32": "uImage",
-    # "ppc64": "vmlinux",
-    # "ppc64le": "zImage.epapr",
     if arch == "powerpc":
-        return "zImage.epapr"
+        subarch = get_cbl_name()
+        return {
+            "ppc32": "uImage",
+            "ppc64": "vmlinux",
+            "ppc64le": "zImage.epapr"
+        }[subarch]
     return {
         "arm": "zImage",
         "arm64": "Image.gz",
         "i386": "bzImage",
         "mips": "vmlinux",
-        "riscv": "Image.gz",
+        "riscv": "Image",
         "s390": "bzImage",
         "x86_64": "bzImage",
     }[arch]

--- a/utils.py
+++ b/utils.py
@@ -27,20 +27,24 @@ def get_image_name():
 
 def get_cbl_name():
     arch = os.environ["ARCH"]
-    config = os.environ["CONFIG"].split("+")[0]
+    full_config = os.environ["CONFIG"]
+    base_config = full_config.split("+")[0]
 
     unique_defconfigs = {
         "multi_v5_defconfig": "arm32_v5",
         "aspeed_g5_defconfig": "arm32_v6",
         "multi_v7_defconfig": "arm32_v7",
-        "malta_kvm_guest_defconfig": "mips",
         "ppc44x_defconfig": "ppc32",
         "pseries_defconfig": "ppc64",
         "powernv_defconfig": "ppc64le",
     }
-    if config in unique_defconfigs:
-        return unique_defconfigs[config]
-    if "defconfig" in config:
+    if base_config in unique_defconfigs:
+        return unique_defconfigs[base_config]
+    if base_config == "malta_kvm_guest_defconfig":
+        if "CONFIG_CPU_BIG_ENDIAN=y" in full_config:
+            return "mips"
+        return "mipsel"
+    if "defconfig" in base_config:
         return "x86" if arch == "i386" else arch
     raise Exception("unknown CBL name")
 


### PR DESCRIPTION
I will rebase this on #71 after it is merged but I wanted to get ahead of this for review.

TuxSuite has merged support for `kernel_image` so we can add that to `generator.yml` for architectures that need it.

Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/1
Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/27