### PR TITLE
Disable certain PowerPC builds with LLVM 11

### DIFF
--- a/.github/workflows/5.10.yml
+++ b/.github/workflows/5.10.yml
@@ -639,44 +639,6 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _2f2c384e9ae91ede08b3403161a3d5eb:
-    runs-on: ubuntu-20.04
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=11 ppc44x_defconfig
-    env:
-      ARCH: powerpc
-      LLVM_VERSION: 11
-      INSTALL_DEPS: 1
-      BOOT: 1
-      CONFIG: ppc44x_defconfig
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact
-    - name: Boot Test
-      run: ./check_logs.py
-  _77589831d4669a1981dad16fdae71677:
-    runs-on: ubuntu-20.04
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=11 pseries_defconfig
-    env:
-      ARCH: powerpc
-      LLVM_VERSION: 11
-      INSTALL_DEPS: 1
-      BOOT: 1
-      CONFIG: pseries_defconfig
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact
-    - name: Boot Test
-      run: ./check_logs.py
   _8190461c1f8057e418b9abae5f927a20:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs

--- a/generator.yml
+++ b/generator.yml
@@ -411,8 +411,9 @@ builds:
   # - {<< : *i386,          << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
   - {<< : *mips,          << : *stable-5_10,      << : *mips_llvm,       boot: true,  llvm_version: *llvm_11}
   - {<< : *mipsel,        << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *ppc32,         << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *ppc64,         << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_11}
+  # ppc32 and ppc64: Build disabled (https://gitlab.com/Linaro/tuxmake/-/issues/108)
+  # - {<< : *ppc32,         << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
+  # - {<< : *ppc64,         << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_11}
   - {<< : *ppc64le,       << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
   - {<< : *riscv,         << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_11}
   - {<< : *s390,          << : *stable-5_10,      << : *clang,           boot: true,  llvm_version: *llvm_11}

--- a/tuxsuite/5.10.tux.yml
+++ b/tuxsuite/5.10.tux.yml
@@ -406,31 +406,6 @@ sets:
     git_ref: linux-5.10.y
     target_arch: powerpc
     toolchain: clang-11
-    kconfig: ppc44x_defconfig
-    targets:
-    - config
-    - kernel
-    - modules
-    kernel_image: uImage
-    make_variables:
-      LLVM: 1
-  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.10.y
-    target_arch: powerpc
-    toolchain: clang-11
-    kconfig: pseries_defconfig
-    targets:
-    - config
-    - kernel
-    - modules
-    kernel_image: vmlinux
-    make_variables:
-      LD: powerpc64le-linux-gnu-ld
-      LLVM: 1
-  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.10.y
-    target_arch: powerpc
-    toolchain: clang-11
     kconfig: powernv_defconfig
     targets:
     - config


### PR DESCRIPTION
These should not have been enabled:

https://github.com/ClangBuiltLinux/continuous-integration2/runs/1874137744
https://github.com/ClangBuiltLinux/continuous-integration2/runs/1874137673