### PR TITLE
Move back to Ubuntu's qemu-system-riscv64

### DIFF
--- a/check_logs.py
+++ b/check_logs.py
@@ -72,7 +72,7 @@ def run_boot():
     boot_qemu = [
         "./boot-utils/boot-qemu.sh", "-a", cbl_arch, "-k", kernel_image
     ]
-    if cbl_arch == "riscv" or cbl_arch == "s390":
+    if cbl_arch == "s390":
         boot_qemu += ["--use-cbl-qemu"]
     try:
         subprocess.run(boot_qemu, check=True)

--- a/install_deps.py
+++ b/install_deps.py
@@ -20,7 +20,7 @@ def install_deps():
         "powerpc": ["qemu-system-ppc"],
         "x86_64": ["qemu-system-x86"],
         "s390": [],
-        "riscv": [],
+        "riscv": ["opensbi", "qemu-system-riscv64"],
     }
     if not arch in arch_dependencies:
         print("Unknown arch \"%s\", can't install dependencies" % arch,


### PR DESCRIPTION
The issue that necessitated building our own version of QEMU has been resolved.

I will send patches for qemu-binaries and boot-utils shortly.