### PR TITLE
enable LLVM_IAS=1 for more 32b arm targets

### DIFF
--- a/.github/workflows/5.10.yml
+++ b/.github/workflows/5.10.yml
@@ -768,10 +768,10 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _67124def5a4f894c4fee22cb7d093342:
+  _e3671bdb6f10d3349593b86cc9b324f6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=13 allnoconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13

--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -31,10 +31,10 @@ jobs:
       with:
         path: builds.json
         name: output_artifact
-  _877f148925688b45a9565666a5c8c8c4:
+  _1158c1dfe5f9fcc225240c547be18fda:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=13 multi_v5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -69,10 +69,10 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _c1e13055e5361c03be9afb991342ca79:
+  _9532604fe2c353a710edd757453b4457:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=13 multi_v7_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -996,10 +996,10 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _67124def5a4f894c4fee22cb7d093342:
+  _e3671bdb6f10d3349593b86cc9b324f6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=13 allnoconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -31,10 +31,10 @@ jobs:
       with:
         path: builds.json
         name: output_artifact
-  _877f148925688b45a9565666a5c8c8c4:
+  _1158c1dfe5f9fcc225240c547be18fda:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=13 multi_v5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -69,10 +69,10 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _c1e13055e5361c03be9afb991342ca79:
+  _9532604fe2c353a710edd757453b4457:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=13 multi_v7_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -1034,10 +1034,10 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _67124def5a4f894c4fee22cb7d093342:
+  _e3671bdb6f10d3349593b86cc9b324f6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=13 allnoconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13

--- a/generator.yml
+++ b/generator.yml
@@ -113,12 +113,12 @@ builds:
   #  Mainline  #
   ##############
   #  configs:             trees:                  make_variables:        BOOT=1       llvm_versions:
-  - {<< : *arm32_v5,      << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm32_v5,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_v6,      << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_v7,      << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm32_v7,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_v7_t,    << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_allmod,  << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_allno,   << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm32_allno,   << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm32_allyes,  << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64,         << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64be,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
@@ -142,12 +142,12 @@ builds:
   ##########
   #  Next  #
   ##########
-  - {<< : *arm32_v5,      << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm32_v5,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_v6,      << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_v7,      << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm32_v7,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_v7_t,    << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_allmod,  << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_allno,   << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm32_allno,   << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm32_allyes,  << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64,         << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64be,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
@@ -175,7 +175,7 @@ builds:
   - {<< : *arm32_v7,      << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_v7_t,    << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_allmod,  << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_allno,   << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm32_allno,   << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm32_allyes,  << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64,         << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64be,       << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}

--- a/tuxsuite/5.10.tux.yml
+++ b/tuxsuite/5.10.tux.yml
@@ -488,6 +488,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm

--- a/tuxsuite/mainline.tux.yml
+++ b/tuxsuite/mainline.tux.yml
@@ -18,6 +18,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -41,6 +42,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -630,6 +632,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -18,6 +18,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -41,6 +42,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -654,6 +656,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm


### PR DESCRIPTION
arm32_v6 isn't booting with IAS:
https://github.com/ClangBuiltLinux/linux/issues/1313

arm32_v7 is blocked on one last build issue:
https://github.com/ClangBuiltLinux/linux/issues/1286

arm32_all{mod|yes}config is blocked on some patches that will probably
land in the 5.12 merge window:
https://www.armlinux.org.uk/developer/patches/viewpatch.php?id=9061/1
https://www.armlinux.org.uk/developer/patches/viewpatch.php?id=9062/1

I need to go chase backports back to 4.19.