### PR TITLE
Change MIPS base config

### DIFF
--- a/.github/workflows/5.10.yml
+++ b/.github/workflows/5.10.yml
@@ -145,16 +145,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _bdc608b94eb1c0747e66613a5d86400e:
+  _dd0abd18f6fb089956a0981751bc6b0c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -164,16 +164,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _e22b407fd54e5a9525eb06be76c357d0:
+  _4cbced3108106eb3201bf12eab9e65eb:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_kvm_guest_defconfig
+    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -373,16 +373,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _34f6759fcc54c90da20900a041d8014d:
+  _2e8125b1f3df9bc77d92a930d41f4782:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=12 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -392,16 +392,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _7b8e833ae066ea79f1a6e4ff3389a632:
+  _106d267c84f6ece7cf9710a2cb351c6d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=12 malta_kvm_guest_defconfig
+    name: ARCH=mips LLVM=1 LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -620,16 +620,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _a82a7c15d9664631e5324fb16007e6c8:
+  _d5751ecccab4f8123d49f1ff7e7c87f5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=11 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -639,16 +639,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _df6659605e188f908ee2328126b07a38:
+  _4199aee554a613fda64b1eacc81b5add:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=11 malta_kvm_guest_defconfig
+    name: ARCH=mips LLVM=1 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/5.4.yml
+++ b/.github/workflows/5.4.yml
@@ -107,16 +107,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _bdc608b94eb1c0747e66613a5d86400e:
+  _dd0abd18f6fb089956a0981751bc6b0c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -126,16 +126,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _e22b407fd54e5a9525eb06be76c357d0:
+  _4cbced3108106eb3201bf12eab9e65eb:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_kvm_guest_defconfig
+    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -164,16 +164,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _bdc608b94eb1c0747e66613a5d86400e:
+  _dd0abd18f6fb089956a0981751bc6b0c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -183,16 +183,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _e22b407fd54e5a9525eb06be76c357d0:
+  _4cbced3108106eb3201bf12eab9e65eb:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_kvm_guest_defconfig
+    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -430,16 +430,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _34f6759fcc54c90da20900a041d8014d:
+  _2e8125b1f3df9bc77d92a930d41f4782:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=12 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -449,16 +449,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _7b8e833ae066ea79f1a6e4ff3389a632:
+  _106d267c84f6ece7cf9710a2cb351c6d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=12 malta_kvm_guest_defconfig
+    name: ARCH=mips LLVM=1 LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -734,16 +734,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _a82a7c15d9664631e5324fb16007e6c8:
+  _d5751ecccab4f8123d49f1ff7e7c87f5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=11 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -753,16 +753,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _df6659605e188f908ee2328126b07a38:
+  _4199aee554a613fda64b1eacc81b5add:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=11 malta_kvm_guest_defconfig
+    name: ARCH=mips LLVM=1 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -981,16 +981,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _1fe8cbbe1f257d4a2bb36caa6d968d86:
+  _020e9ff944ea1e8472762c351ebd39dd:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=10 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=10 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 10
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1000,16 +1000,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _887af52b1d6887124d7ec22c8dcb6b95:
+  _bc8fce7c23996324100110dee4d6e7b6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=10 malta_kvm_guest_defconfig
+    name: ARCH=mips LLVM=1 LLVM_VERSION=10 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 10
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -183,16 +183,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _bdc608b94eb1c0747e66613a5d86400e:
+  _dd0abd18f6fb089956a0981751bc6b0c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -202,16 +202,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _e22b407fd54e5a9525eb06be76c357d0:
+  _4cbced3108106eb3201bf12eab9e65eb:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_kvm_guest_defconfig
+    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -468,16 +468,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _34f6759fcc54c90da20900a041d8014d:
+  _2e8125b1f3df9bc77d92a930d41f4782:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=12 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -487,16 +487,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _7b8e833ae066ea79f1a6e4ff3389a632:
+  _106d267c84f6ece7cf9710a2cb351c6d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=12 malta_kvm_guest_defconfig
+    name: ARCH=mips LLVM=1 LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -772,16 +772,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _a82a7c15d9664631e5324fb16007e6c8:
+  _d5751ecccab4f8123d49f1ff7e7c87f5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=11 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -791,16 +791,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _df6659605e188f908ee2328126b07a38:
+  _4199aee554a613fda64b1eacc81b5add:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=11 malta_kvm_guest_defconfig
+    name: ARCH=mips LLVM=1 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1019,16 +1019,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _1fe8cbbe1f257d4a2bb36caa6d968d86:
+  _020e9ff944ea1e8472762c351ebd39dd:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=10 malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=10 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 10
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig+CONFIG_CPU_BIG_ENDIAN=y
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1038,16 +1038,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _887af52b1d6887124d7ec22c8dcb6b95:
+  _bc8fce7c23996324100110dee4d6e7b6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=10 malta_kvm_guest_defconfig
+    name: ARCH=mips LLVM=1 LLVM_VERSION=10 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 10
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: malta_kvm_guest_defconfig
+      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     steps:
     - uses: actions/checkout@v2
       with:

--- a/generator.yml
+++ b/generator.yml
@@ -56,40 +56,40 @@ targets:
   - &kernel_modules      {targets: [config,kernel,modules]}
   - &kernel_modules_dtbs {targets: [config,kernel,modules,dtbs]}
 configs:
-  #                 config:                                                       image target (optional)     [triples:] (Optional: x86)  targets to build
-  - &arm32_v5      {config: multi_v5_defconfig,                                                               << : *arm-triple,           << : *kernel_modules_dtbs}
-  - &arm32_v6      {config: aspeed_g5_defconfig,                                                              << : *arm-triple,           << : *kernel_modules_dtbs}
-  - &arm32_v7      {config: multi_v7_defconfig,                                                               << : *arm-triple,           << : *kernel_modules}
-  - &arm32_v7_t    {config: [multi_v7_defconfig, CONFIG_THUMB2_KERNEL=y],                                     << : *arm-triple,           << : *kernel_modules}
-  - &arm32_allmod  {config: allmodconfig,                                                                     << : *arm-triple,           << : *kernel_modules}
-  - &arm32_allno   {config: allnoconfig,                                                                      << : *arm-triple,           << : *kernel_modules}
-  - &arm32_allyes  {config: allyesconfig,                                                                     << : *arm-triple,           << : *kernel_modules}
-  - &arm64         {config: defconfig,                                                                        << : *arm64-triple,         << : *kernel_modules}
-  - &arm64be       {config: [defconfig, CONFIG_CPU_BIG_ENDIAN=y],                                             << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_lto     {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                             << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_cfi     {config: [defconfig, cfi.config],                                                          << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_gki     {config: gki_defconfig,                                                                    << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_cut     {config: cuttlefish_defconfig,                                                             << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_allmod  {config: allmodconfig,                                                                     << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_allno   {config: allnoconfig,                                                                      << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_allyes  {config: allyesconfig,                                                                     << : *arm64-triple,         << : *kernel_modules}
-  - &i386          {config: defconfig,                                                                        << : *i386-triple,          << : *kernel_modules}
+  #                 config:                                                                      image target (optional)     [triples:] (Optional: x86)  targets to build
+  - &arm32_v5      {config: multi_v5_defconfig,                                                                              << : *arm-triple,           << : *kernel_modules_dtbs}
+  - &arm32_v6      {config: aspeed_g5_defconfig,                                                                             << : *arm-triple,           << : *kernel_modules_dtbs}
+  - &arm32_v7      {config: multi_v7_defconfig,                                                                              << : *arm-triple,           << : *kernel_modules}
+  - &arm32_v7_t    {config: [multi_v7_defconfig, CONFIG_THUMB2_KERNEL=y],                                                    << : *arm-triple,           << : *kernel_modules}
+  - &arm32_allmod  {config: allmodconfig,                                                                                    << : *arm-triple,           << : *kernel_modules}
+  - &arm32_allno   {config: allnoconfig,                                                                                     << : *arm-triple,           << : *kernel_modules}
+  - &arm32_allyes  {config: allyesconfig,                                                                                    << : *arm-triple,           << : *kernel_modules}
+  - &arm64         {config: defconfig,                                                                                       << : *arm64-triple,         << : *kernel_modules}
+  - &arm64be       {config: [defconfig, CONFIG_CPU_BIG_ENDIAN=y],                                                            << : *arm64-triple,         << : *kernel_modules}
+  - &arm64_lto     {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                            << : *arm64-triple,         << : *kernel_modules}
+  - &arm64_cfi     {config: [defconfig, cfi.config],                                                                         << : *arm64-triple,         << : *kernel_modules}
+  - &arm64_gki     {config: gki_defconfig,                                                                                   << : *arm64-triple,         << : *kernel_modules}
+  - &arm64_cut     {config: cuttlefish_defconfig,                                                                            << : *arm64-triple,         << : *kernel_modules}
+  - &arm64_allmod  {config: allmodconfig,                                                                                    << : *arm64-triple,         << : *kernel_modules}
+  - &arm64_allno   {config: allnoconfig,                                                                                     << : *arm64-triple,         << : *kernel_modules}
+  - &arm64_allyes  {config: allyesconfig,                                                                                    << : *arm64-triple,         << : *kernel_modules}
+  - &i386          {config: defconfig,                                                                                       << : *i386-triple,          << : *kernel_modules}
   - &mips          {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y, CONFIG_CPU_BIG_ENDIAN=y], kernel_image: vmlinux,      << : *mips-triple,          << : *kernel_modules}
-  - &mipsel        {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y],                            kernel_image: vmlinux,      << : *mipsel-triple,        << : *kernel_modules}
-  - &ppc32         {config: ppc44x_defconfig,                                     kernel_image: uImage,       << : *powerpc-triple,       << : *kernel_modules}
-  - &ppc64         {config: pseries_defconfig,                                    kernel_image: vmlinux,      << : *powerpc64-triple,     << : *kernel_modules}
-  - &ppc64le       {config: powernv_defconfig,                                    kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel_modules}
+  - &mipsel        {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y],                          kernel_image: vmlinux,      << : *mipsel-triple,        << : *kernel_modules}
+  - &ppc32         {config: ppc44x_defconfig,                                                    kernel_image: uImage,       << : *powerpc-triple,       << : *kernel_modules}
+  - &ppc64         {config: pseries_defconfig,                                                   kernel_image: vmlinux,      << : *powerpc64-triple,     << : *kernel_modules}
+  - &ppc64le       {config: powernv_defconfig,                                                   kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel_modules}
   #                                     https://github.com/ClangBuiltLinux/linux/issues/1143
-  - &riscv         {config: [defconfig, CONFIG_EFI=n],                            kernel_image: Image,        << : *riscv-triple,         << : *kernel_modules}
-  - &s390          {config: defconfig,                                                                        << : *s390-triple,          << : *kernel_modules}
-  - &x86_64        {config: defconfig,                                                                                                    << : *kernel_modules}
-  - &x86_64_lto    {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                         << : *kernel_modules}
-  - &x86_64_cfi    {config: [defconfig, cfi.config],                                                                                      << : *kernel_modules}
-  - &x86_64_gki    {config: gki_defconfig,                                                                                                << : *kernel_modules}
-  - &x86_64_cut    {config: x86_64_cuttlefish_defconfig,                                                                                  << : *kernel_modules}
-  - &x86_64_allmod {config: allmodconfig,                                                                                                 << : *kernel_modules}
-  - &x86_64_allno  {config: allnoconfig,                                                                                                  << : *kernel_modules}
-  - &x86_64_allyes {config: allyesconfig,                                                                                                 << : *kernel_modules}
+  - &riscv         {config: [defconfig, CONFIG_EFI=n],                                           kernel_image: Image,        << : *riscv-triple,         << : *kernel_modules}
+  - &s390          {config: defconfig,                                                                                       << : *s390-triple,          << : *kernel_modules}
+  - &x86_64        {config: defconfig,                                                                                                                   << : *kernel_modules}
+  - &x86_64_lto    {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                                        << : *kernel_modules}
+  - &x86_64_cfi    {config: [defconfig, cfi.config],                                                                                                     << : *kernel_modules}
+  - &x86_64_gki    {config: gki_defconfig,                                                                                                               << : *kernel_modules}
+  - &x86_64_cut    {config: x86_64_cuttlefish_defconfig,                                                                                                 << : *kernel_modules}
+  - &x86_64_allmod {config: allmodconfig,                                                                                                                << : *kernel_modules}
+  - &x86_64_allno  {config: allnoconfig,                                                                                                                 << : *kernel_modules}
+  - &x86_64_allyes {config: allyesconfig,                                                                                                                << : *kernel_modules}
 tiers:
   # Generic tiers       LLVM=1       LLVM_IAS=1        Make variables to pass to TuxSuite
   - &llvm_full          {llvm: true,  llvm_ias: true,  make_variables: {LLVM: 1, LLVM_IAS: 1}}

--- a/generator.yml
+++ b/generator.yml
@@ -74,8 +74,8 @@ configs:
   - &arm64_allno   {config: allnoconfig,                                                                      << : *arm64-triple,         << : *kernel_modules}
   - &arm64_allyes  {config: allyesconfig,                                                                     << : *arm64-triple,         << : *kernel_modules}
   - &i386          {config: defconfig,                                                                        << : *i386-triple,          << : *kernel_modules}
-  - &mips          {config: [malta_kvm_guest_defconfig, CONFIG_CPU_BIG_ENDIAN=y], kernel_image: vmlinux,      << : *mips-triple,          << : *kernel_modules}
-  - &mipsel        {config: malta_kvm_guest_defconfig,                            kernel_image: vmlinux,      << : *mipsel-triple,        << : *kernel_modules}
+  - &mips          {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y, CONFIG_CPU_BIG_ENDIAN=y], kernel_image: vmlinux,      << : *mips-triple,          << : *kernel_modules}
+  - &mipsel        {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y],                            kernel_image: vmlinux,      << : *mipsel-triple,        << : *kernel_modules}
   - &ppc32         {config: ppc44x_defconfig,                                     kernel_image: uImage,       << : *powerpc-triple,       << : *kernel_modules}
   - &ppc64         {config: pseries_defconfig,                                    kernel_image: vmlinux,      << : *powerpc64-triple,     << : *kernel_modules}
   - &ppc64le       {config: powernv_defconfig,                                    kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel_modules}

--- a/tuxsuite/5.10.tux.yml
+++ b/tuxsuite/5.10.tux.yml
@@ -85,7 +85,8 @@ sets:
     target_arch: mips
     toolchain: clang-nightly
     kconfig:
-    - malta_kvm_guest_defconfig
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
     - config
@@ -98,7 +99,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: mips
     toolchain: clang-nightly
-    kconfig: malta_kvm_guest_defconfig
+    kconfig:
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - config
     - kernel
@@ -232,7 +235,8 @@ sets:
     target_arch: mips
     toolchain: clang-12
     kconfig:
-    - malta_kvm_guest_defconfig
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
     - config
@@ -246,7 +250,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: mips
     toolchain: clang-12
-    kconfig: malta_kvm_guest_defconfig
+    kconfig:
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - config
     - kernel
@@ -393,7 +399,8 @@ sets:
     target_arch: mips
     toolchain: clang-11
     kconfig:
-    - malta_kvm_guest_defconfig
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
     - config
@@ -407,7 +414,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: mips
     toolchain: clang-11
-    kconfig: malta_kvm_guest_defconfig
+    kconfig:
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - config
     - kernel

--- a/tuxsuite/5.4.tux.yml
+++ b/tuxsuite/5.4.tux.yml
@@ -61,7 +61,8 @@ sets:
     target_arch: mips
     toolchain: clang-nightly
     kconfig:
-    - malta_kvm_guest_defconfig
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
     - config
@@ -74,7 +75,9 @@ sets:
     git_ref: linux-5.4.y
     target_arch: mips
     toolchain: clang-nightly
-    kconfig: malta_kvm_guest_defconfig
+    kconfig:
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - config
     - kernel

--- a/tuxsuite/mainline.tux.yml
+++ b/tuxsuite/mainline.tux.yml
@@ -102,7 +102,8 @@ sets:
     target_arch: mips
     toolchain: clang-nightly
     kconfig:
-    - malta_kvm_guest_defconfig
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
     - config
@@ -115,7 +116,9 @@ sets:
     git_ref: master
     target_arch: mips
     toolchain: clang-nightly
-    kconfig: malta_kvm_guest_defconfig
+    kconfig:
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - config
     - kernel
@@ -277,7 +280,8 @@ sets:
     target_arch: mips
     toolchain: clang-12
     kconfig:
-    - malta_kvm_guest_defconfig
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
     - config
@@ -291,7 +295,9 @@ sets:
     git_ref: master
     target_arch: mips
     toolchain: clang-12
-    kconfig: malta_kvm_guest_defconfig
+    kconfig:
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - config
     - kernel
@@ -478,7 +484,8 @@ sets:
     target_arch: mips
     toolchain: clang-11
     kconfig:
-    - malta_kvm_guest_defconfig
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
     - config
@@ -492,7 +499,9 @@ sets:
     git_ref: master
     target_arch: mips
     toolchain: clang-11
-    kconfig: malta_kvm_guest_defconfig
+    kconfig:
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - config
     - kernel
@@ -639,7 +648,8 @@ sets:
     target_arch: mips
     toolchain: clang-10
     kconfig:
-    - malta_kvm_guest_defconfig
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
     - config
@@ -653,7 +663,9 @@ sets:
     git_ref: master
     target_arch: mips
     toolchain: clang-10
-    kconfig: malta_kvm_guest_defconfig
+    kconfig:
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - config
     - kernel

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -114,7 +114,8 @@ sets:
     target_arch: mips
     toolchain: clang-nightly
     kconfig:
-    - malta_kvm_guest_defconfig
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
     - config
@@ -127,7 +128,9 @@ sets:
     git_ref: master
     target_arch: mips
     toolchain: clang-nightly
-    kconfig: malta_kvm_guest_defconfig
+    kconfig:
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - config
     - kernel
@@ -301,7 +304,8 @@ sets:
     target_arch: mips
     toolchain: clang-12
     kconfig:
-    - malta_kvm_guest_defconfig
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
     - config
@@ -315,7 +319,9 @@ sets:
     git_ref: master
     target_arch: mips
     toolchain: clang-12
-    kconfig: malta_kvm_guest_defconfig
+    kconfig:
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - config
     - kernel
@@ -502,7 +508,8 @@ sets:
     target_arch: mips
     toolchain: clang-11
     kconfig:
-    - malta_kvm_guest_defconfig
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
     - config
@@ -516,7 +523,9 @@ sets:
     git_ref: master
     target_arch: mips
     toolchain: clang-11
-    kconfig: malta_kvm_guest_defconfig
+    kconfig:
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - config
     - kernel
@@ -663,7 +672,8 @@ sets:
     target_arch: mips
     toolchain: clang-10
     kconfig:
-    - malta_kvm_guest_defconfig
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
     - config
@@ -677,7 +687,9 @@ sets:
     git_ref: master
     target_arch: mips
     toolchain: clang-10
-    kconfig: malta_kvm_guest_defconfig
+    kconfig:
+    - malta_defconfig
+    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - config
     - kernel


### PR DESCRIPTION
malta_kvm_guest_defconfig is being proposed for deletion:

https://lore.kernel.org/r/20210301152958.3480-1-tsbogend@alpha.franken.de/

Switch to malta_defconfig plus `CONFIG_BLK_DEV_INITRD=y` so that we can
continue to boot userspace via `-initrd`.

Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/96