### PR TITLE
utils.py: Fix get_cbl_name() for mipsel

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -36,7 +36,7 @@ def get_cbl_name():
         "multi_v5_defconfig": "arm32_v5",
         "aspeed_g5_defconfig": "arm32_v6",
         "multi_v7_defconfig": "arm32_v7",
-        "malta_kvm_guest_defconfig": "mipsel",
+        "malta_defconfig": "mipsel",
         "ppc44x_defconfig": "ppc32",
         "pseries_defconfig": "ppc64",
         "powernv_defconfig": "ppc64le",


### PR DESCRIPTION
malta_defconfig is now the base, not malta_kvm_guest_defconfig.