### PR TITLE
Enable i386 builds on older trees

### DIFF
--- a/.github/workflows/5.10.yml
+++ b/.github/workflows/5.10.yml
@@ -145,6 +145,25 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
+  _7dde147b804e95998e110f5dfe487e8f:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
+    env:
+      ARCH: i386
+      LLVM_VERSION: 13
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
   _dd0abd18f6fb089956a0981751bc6b0c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -360,6 +379,25 @@ jobs:
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
     env:
       ARCH: arm64
+      LLVM_VERSION: 12
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _300d5ea669ce6bad5b1433d2643b416d:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
+    env:
+      ARCH: i386
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 1
@@ -607,6 +645,25 @@ jobs:
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
     env:
       ARCH: arm64
+      LLVM_VERSION: 11
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _6b25347145c5e89e498ca11233af4912:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
+    env:
+      ARCH: i386
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 1

--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -183,6 +183,25 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
+  _7dde147b804e95998e110f5dfe487e8f:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
+    env:
+      ARCH: i386
+      LLVM_VERSION: 13
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
   _dd0abd18f6fb089956a0981751bc6b0c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -478,6 +497,25 @@ jobs:
       INSTALL_DEPS: 1
       BOOT: 1
       CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _300d5ea669ce6bad5b1433d2643b416d:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
+    env:
+      ARCH: i386
+      LLVM_VERSION: 12
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: defconfig
     steps:
     - uses: actions/checkout@v2
       with:

--- a/generator.yml
+++ b/generator.yml
@@ -135,8 +135,7 @@ builds:
   - {<< : *arm64_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64_allno,       << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  # i386: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1210)
-  # - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *mips,              << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *mipsel,            << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_tot}
@@ -201,8 +200,7 @@ builds:
   - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  # i386: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1210)
-  # - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *mips,              << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
@@ -335,8 +333,7 @@ builds:
   - {<< : *arm64_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm64_allno,       << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  # i386: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1210)
-  # - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *mips,              << : *mainline,         << : *mips_llvm,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *mipsel,            << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_latest}
@@ -397,8 +394,7 @@ builds:
   - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  # i386: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1210)
-  # - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *mips,              << : *stable-5_10,      << : *mips_llvm,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
@@ -546,8 +542,7 @@ builds:
   - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
   - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
   - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  # i386: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1210)
-  # - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
   - {<< : *mips,              << : *stable-5_10,      << : *mips_llvm,       boot: true,  llvm_version: *llvm_11}
   - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
   # ppc32 and ppc64: Build disabled (https://gitlab.com/Linaro/tuxmake/-/issues/108)

--- a/tuxsuite/5.10.tux.yml
+++ b/tuxsuite/5.10.tux.yml
@@ -82,6 +82,18 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
+    target_arch: i386
+    toolchain: clang-nightly
+    kconfig: defconfig
+    targets:
+    - config
+    - kernel
+    - modules
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+    git_ref: linux-5.10.y
     target_arch: mips
     toolchain: clang-nightly
     kconfig:
@@ -221,6 +233,18 @@ sets:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm64
+    toolchain: clang-12
+    kconfig: defconfig
+    targets:
+    - config
+    - kernel
+    - modules
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+    git_ref: linux-5.10.y
+    target_arch: i386
     toolchain: clang-12
     kconfig: defconfig
     targets:
@@ -385,6 +409,18 @@ sets:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm64
+    toolchain: clang-11
+    kconfig: defconfig
+    targets:
+    - config
+    - kernel
+    - modules
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+    git_ref: linux-5.10.y
+    target_arch: i386
     toolchain: clang-11
     kconfig: defconfig
     targets:

--- a/tuxsuite/mainline.tux.yml
+++ b/tuxsuite/mainline.tux.yml
@@ -113,6 +113,18 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
+    target_arch: i386
+    toolchain: clang-nightly
+    kconfig: defconfig
+    targets:
+    - config
+    - kernel
+    - modules
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+    git_ref: master
     target_arch: mips
     toolchain: clang-nightly
     kconfig:
@@ -310,6 +322,18 @@ sets:
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
+    targets:
+    - config
+    - kernel
+    - modules
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+    git_ref: master
+    target_arch: i386
+    toolchain: clang-12
+    kconfig: defconfig
     targets:
     - config
     - kernel


### PR DESCRIPTION
The patch fixing the build has been backported to all supported trees.