### PR TITLE
Arm android cleanup

### DIFF
--- a/.github/workflows/android-5.10.yml
+++ b/.github/workflows/android-5.10.yml
@@ -88,10 +88,10 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _b587e3b0e4be143723f0f01376e77b62:
+  _267d8195f8748ce0c5d40740008e5dde:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 12

--- a/.github/workflows/android-5.4.yml
+++ b/.github/workflows/android-5.4.yml
@@ -31,10 +31,10 @@ jobs:
       with:
         path: builds.json
         name: output_artifact
-  _f312f8cee59fa1e3e85e4b3262690a47:
+  _61786e26a75b319fadc440c70c0e761a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -88,10 +88,10 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _b587e3b0e4be143723f0f01376e77b62:
+  _267d8195f8748ce0c5d40740008e5dde:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 12

--- a/.github/workflows/android-mainline.yml
+++ b/.github/workflows/android-mainline.yml
@@ -88,10 +88,10 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _b587e3b0e4be143723f0f01376e77b62:
+  _267d8195f8748ce0c5d40740008e5dde:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 12

--- a/generator.yml
+++ b/generator.yml
@@ -409,15 +409,15 @@ builds:
   #  Android  #
   #############
   - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm32_allmod,      << : *android-5_10,     << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_v7_t,        << : *android-5_10,     << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm32_v7_t,        << : *android-5_10,     << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64_gki,         << : *android-5_10,     << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_gki,        << : *android-5_10,     << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm32_allmod,      << : *android-5_4,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_v7_t,        << : *android-5_4,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm32_v7_t,        << : *android-5_4,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64_gki,         << : *android-5_4,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_gki,        << : *android-5_4,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64_gki,         << : *android-4_19,     << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}

--- a/generator.yml
+++ b/generator.yml
@@ -272,7 +272,7 @@ builds:
   - {<< : *arm64_gki,         << : *android-5_10,     << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_gki,        << : *android-5_10,     << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_allmod,      << : *android-5_4,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_v7_t,        << : *android-5_4,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm32_v7_t,        << : *android-5_4,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64_gki,         << : *android-5_4,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_gki,        << : *android-5_4,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64_gki,         << : *android-4_19,     << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}

--- a/tuxsuite/android-5.10.tux.yml
+++ b/tuxsuite/android-5.10.tux.yml
@@ -57,7 +57,6 @@ sets:
     - modules
     make_variables:
       LLVM: 1
-      LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android12-5.10
     target_arch: arm64

--- a/tuxsuite/android-5.4.tux.yml
+++ b/tuxsuite/android-5.4.tux.yml
@@ -19,7 +19,6 @@ sets:
     - modules
     make_variables:
       LLVM: 1
-      LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android12-5.4
     target_arch: arm64
@@ -57,7 +56,6 @@ sets:
     - modules
     make_variables:
       LLVM: 1
-      LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android12-5.4
     target_arch: arm64

--- a/tuxsuite/android-mainline.tux.yml
+++ b/tuxsuite/android-mainline.tux.yml
@@ -57,7 +57,6 @@ sets:
     - modules
     make_variables:
       LLVM: 1
-      LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android-mainline
     target_arch: arm64


### PR DESCRIPTION
see also:
https://github.com/ClangBuiltLinux/linux/issues/1337
we could spin this down, but I'd rather have some coverage and work towards enabling LLVM_IAS=1/llvm_full for them.

Also, regardless of
https://github.com/ClangBuiltLinux/continuous-integration2/pull/115#issuecomment-810559773
I think we'll hit:
https://github.com/ClangBuiltLinux/linux/issues/1271

I have personal obligations today that I need to run to, I suggest merging these for tonight's CI run, then I'll clean up the rest tomorrow.