### PR TITLE
Make it green as of 4-26-2021

### DIFF
--- a/.github/workflows/android-mainline.yml
+++ b/.github/workflows/android-mainline.yml
@@ -160,10 +160,10 @@ jobs:
       with:
         path: builds.json
         name: output_artifact
-  _697acf7d42a48e3722c6145f69814f68:
+  _b6004055e739b487ac5b79a2ecd21871:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=13 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -179,10 +179,10 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _49eb3976558e569e0dc38562abcc30c6:
+  _e0faf7981c78617941c48bb39357dfa5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12

--- a/.github/workflows/android12-5.10.yml
+++ b/.github/workflows/android12-5.10.yml
@@ -160,10 +160,10 @@ jobs:
       with:
         path: builds.json
         name: output_artifact
-  _697acf7d42a48e3722c6145f69814f68:
+  _b6004055e739b487ac5b79a2ecd21871:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=13 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -179,10 +179,10 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _49eb3976558e569e0dc38562abcc30c6:
+  _e0faf7981c78617941c48bb39357dfa5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12

--- a/.github/workflows/android12-5.4.yml
+++ b/.github/workflows/android12-5.4.yml
@@ -160,10 +160,10 @@ jobs:
       with:
         path: builds.json
         name: output_artifact
-  _697acf7d42a48e3722c6145f69814f68:
+  _b6004055e739b487ac5b79a2ecd21871:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=13 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -179,10 +179,10 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _49eb3976558e569e0dc38562abcc30c6:
+  _e0faf7981c78617941c48bb39357dfa5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12

--- a/.github/workflows/android13-5.10.yml
+++ b/.github/workflows/android13-5.10.yml
@@ -160,10 +160,10 @@ jobs:
       with:
         path: builds.json
         name: output_artifact
-  _697acf7d42a48e3722c6145f69814f68:
+  _b6004055e739b487ac5b79a2ecd21871:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=13 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -179,10 +179,10 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _49eb3976558e569e0dc38562abcc30c6:
+  _e0faf7981c78617941c48bb39357dfa5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -240,15 +240,15 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _3ff9dd832a367410f07232e142fa8650:
+  _7ad08b1bcc47573b8a65a6f0b4e0ad5a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 ppc44x_defconfig
+    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=13 ppc44x_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
-      BOOT: 1
+      BOOT: 0
       CONFIG: ppc44x_defconfig
     steps:
     - uses: actions/checkout@v2
@@ -582,15 +582,15 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _a3bacbe25d9b5eb02296db0c021ec75c:
+  _535ebd7ca1798dda46eccb404aea7620:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 ppc44x_defconfig
+    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=12 ppc44x_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 1
+      BOOT: 0
       CONFIG: ppc44x_defconfig
     steps:
     - uses: actions/checkout@v2
@@ -1162,25 +1162,6 @@ jobs:
       INSTALL_DEPS: 1
       BOOT: 1
       CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact
-    - name: Boot Test
-      run: ./check_logs.py
-  _f858b2a83b07d7945ea319b9b2400c63:
-    runs-on: ubuntu-20.04
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=10 powernv_defconfig
-    env:
-      ARCH: powerpc
-      LLVM_VERSION: 10
-      INSTALL_DEPS: 1
-      BOOT: 1
-      CONFIG: powernv_defconfig
     steps:
     - uses: actions/checkout@v2
       with:

--- a/generator.yml
+++ b/generator.yml
@@ -630,7 +630,8 @@ builds:
   # ppc32 and ppc64: Build disabled (https://gitlab.com/Linaro/tuxmake/-/issues/108)
   # - {<< : *ppc32,             << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_10}
   # - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_10}
-  - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_10}
+  # ppc64le: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1359)
+  # - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_10}
   - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_10}
   - {<< : *x86_64,            << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_10}
   # x86_64: all{mod,yes}config builds disabled (https://github.com/ClangBuiltLinux/linux/issues/1293)

--- a/generator.yml
+++ b/generator.yml
@@ -174,7 +174,8 @@ builds:
   - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *mips,              << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *mipsel,            << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc32,             << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
+  # ppc32: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1345)
+  - {<< : *ppc32,             << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_tot}
   # ppc64: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1292)
   # - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
   - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
@@ -370,7 +371,8 @@ builds:
   - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *mips,              << : *next,             << : *mips_llvm,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *mipsel,            << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc32,             << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_latest}
+  # ppc32: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1345)
+  - {<< : *ppc32,             << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_latest}
   # ppc64: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1292)
   # - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_latest}
   - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_latest}

--- a/generator.yml
+++ b/generator.yml
@@ -264,19 +264,19 @@ builds:
   #############
   #  Android  #
   #############
-  - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm,            boot: false, llvm_version: *llvm_tot}
   - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_allmod,      << : *android13-5_10,   << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm32_allmod,      << : *android13-5_10,   << : *llvm,            boot: false, llvm_version: *llvm_tot}
   - {<< : *arm32_v7_t,        << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64_gki,         << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_gki,        << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_allmod,      << : *android12-5_10,   << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm32_allmod,      << : *android12-5_10,   << : *llvm,            boot: false, llvm_version: *llvm_tot}
   - {<< : *arm32_v7_t,        << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64_gki,         << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_gki,        << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_allmod,      << : *android12-5_4,    << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm32_allmod,      << : *android12-5_4,    << : *llvm,            boot: false, llvm_version: *llvm_tot}
   - {<< : *arm32_v7_t,        << : *android12-5_4,    << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64_gki,         << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_gki,        << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}

--- a/generator.yml
+++ b/generator.yml
@@ -413,19 +413,19 @@ builds:
   #############
   #  Android  #
   #############
-  - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm,            boot: false, llvm_version: *llvm_latest}
   - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_allmod,      << : *android13-5_10,   << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm32_allmod,      << : *android13-5_10,   << : *llvm,            boot: false, llvm_version: *llvm_latest}
   - {<< : *arm32_v7_t,        << : *android13-5_10,   << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64_gki,         << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_gki,        << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_allmod,      << : *android12-5_10,   << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm32_allmod,      << : *android12-5_10,   << : *llvm,            boot: false, llvm_version: *llvm_latest}
   - {<< : *arm32_v7_t,        << : *android12-5_10,   << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64_gki,         << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_gki,        << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_allmod,      << : *android12-5_4,    << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm32_allmod,      << : *android12-5_4,    << : *llvm,            boot: false, llvm_version: *llvm_latest}
   - {<< : *arm32_v7_t,        << : *android12-5_4,    << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64_gki,         << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_gki,        << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}

--- a/tuxsuite/android-mainline.tux.yml
+++ b/tuxsuite/android-mainline.tux.yml
@@ -94,7 +94,6 @@ sets:
     - modules
     make_variables:
       LLVM: 1
-      LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android-mainline
     target_arch: arm
@@ -106,5 +105,4 @@ sets:
     - modules
     make_variables:
       LLVM: 1
-      LLVM_IAS: 1
 

--- a/tuxsuite/android12-5.10.tux.yml
+++ b/tuxsuite/android12-5.10.tux.yml
@@ -94,7 +94,6 @@ sets:
     - modules
     make_variables:
       LLVM: 1
-      LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android12-5.10
     target_arch: arm
@@ -106,5 +105,4 @@ sets:
     - modules
     make_variables:
       LLVM: 1
-      LLVM_IAS: 1
 

--- a/tuxsuite/android12-5.4.tux.yml
+++ b/tuxsuite/android12-5.4.tux.yml
@@ -93,7 +93,6 @@ sets:
     - modules
     make_variables:
       LLVM: 1
-      LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android12-5.4
     target_arch: arm
@@ -105,5 +104,4 @@ sets:
     - modules
     make_variables:
       LLVM: 1
-      LLVM_IAS: 1
 

--- a/tuxsuite/android13-5.10.tux.yml
+++ b/tuxsuite/android13-5.10.tux.yml
@@ -94,7 +94,6 @@ sets:
     - modules
     make_variables:
       LLVM: 1
-      LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android13-5.10
     target_arch: arm
@@ -106,5 +105,4 @@ sets:
     - modules
     make_variables:
       LLVM: 1
-      LLVM_IAS: 1
 

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -785,18 +785,6 @@ sets:
       LLVM: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
-    target_arch: powerpc
-    toolchain: clang-10
-    kconfig: powernv_defconfig
-    targets:
-    - config
-    - kernel
-    - modules
-    kernel_image: zImage.epapr
-    make_variables:
-      LLVM: 1
-  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
-    git_ref: master
     target_arch: s390
     toolchain: clang-10
     kconfig: defconfig


### PR DESCRIPTION
This should make all of the CI green; the x86 failures on -next are not addressed by this because the problem has been fixed in the KVM tree, it should be fixed when linux-next is updated tonight.

The patches should make sense individually, let me know if there are any problems.