### PR TITLE
Enable LLVM_IAS=1 for arm32 allmodconfig on android-mainline

### DIFF
--- a/.github/workflows/android-mainline.yml
+++ b/.github/workflows/android-mainline.yml
@@ -160,10 +160,10 @@ jobs:
       with:
         path: builds.json
         name: output_artifact
-  _b6004055e739b487ac5b79a2ecd21871:
+  _697acf7d42a48e3722c6145f69814f68:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13

--- a/generator.yml
+++ b/generator.yml
@@ -265,7 +265,7 @@ builds:
   #############
   #  Android  #
   #############
-  - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm,            boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}

--- a/tuxsuite/android-mainline.tux.yml
+++ b/tuxsuite/android-mainline.tux.yml
@@ -94,6 +94,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android-mainline
     target_arch: arm


### PR DESCRIPTION
Android has started merging the 5.13 merges into android-mainline, meaning that we have the crypto fix that we need.