### PR TITLE
Build arm64 with CFI on mainline and next

### DIFF
--- a/.github/workflows/lto-cfi-tip.yml
+++ b/.github/workflows/lto-cfi-tip.yml
@@ -31,35 +31,16 @@ jobs:
       with:
         path: builds.json
         name: output_artifact
-  _ddb8a9ecc48db368b936d4b14e2ceade:
+  _5bb9cc6de7765b18bb5c959714e1ed5a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+cfi.config
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 13
-      INSTALL_DEPS: 1
-      BOOT: 1
-      CONFIG: defconfig+cfi.config
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact
-    - name: Boot Test
-      run: ./check_logs.py
-  _a2bf5bcf0a388c31eac2092d1f607cae:
-    runs-on: ubuntu-20.04
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+cfi.config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: defconfig+cfi.config
+      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -69,35 +50,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _e63e880dece4ca5cad56bc4de7ae795b:
+  _be409d8468fc6bfdb5d967daf5c9da6d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+cfi.config
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 12
-      INSTALL_DEPS: 1
-      BOOT: 1
-      CONFIG: defconfig+cfi.config
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact
-    - name: Boot Test
-      run: ./check_logs.py
-  _22475442062efee40ee11af27760dafc:
-    runs-on: ubuntu-20.04
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+cfi.config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: defconfig+cfi.config
+      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/lto-cfi.yml
+++ b/.github/workflows/lto-cfi.yml
@@ -31,35 +31,16 @@ jobs:
       with:
         path: builds.json
         name: output_artifact
-  _ddb8a9ecc48db368b936d4b14e2ceade:
+  _5bb9cc6de7765b18bb5c959714e1ed5a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+cfi.config
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 13
-      INSTALL_DEPS: 1
-      BOOT: 1
-      CONFIG: defconfig+cfi.config
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact
-    - name: Boot Test
-      run: ./check_logs.py
-  _a2bf5bcf0a388c31eac2092d1f607cae:
-    runs-on: ubuntu-20.04
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+cfi.config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: defconfig+cfi.config
+      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -69,35 +50,16 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
-  _e63e880dece4ca5cad56bc4de7ae795b:
+  _be409d8468fc6bfdb5d967daf5c9da6d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+cfi.config
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 12
-      INSTALL_DEPS: 1
-      BOOT: 1
-      CONFIG: defconfig+cfi.config
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact
-    - name: Boot Test
-      run: ./check_logs.py
-  _22475442062efee40ee11af27760dafc:
-    runs-on: ubuntu-20.04
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+cfi.config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: defconfig+cfi.config
+      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -183,6 +183,25 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
+  _0727f525f2017b393835d55bbffbb6ab:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
+    env:
+      ARCH: arm64
+      LLVM_VERSION: 13
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
   _7dde147b804e95998e110f5dfe487e8f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -497,6 +516,25 @@ jobs:
       INSTALL_DEPS: 1
       BOOT: 1
       CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _8c5abf2855f7fef8f5d67ba30dcc77b2:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
+    env:
+      ARCH: arm64
+      LLVM_VERSION: 12
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -183,6 +183,25 @@ jobs:
         name: output_artifact
     - name: Boot Test
       run: ./check_logs.py
+  _0727f525f2017b393835d55bbffbb6ab:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
+    env:
+      ARCH: arm64
+      LLVM_VERSION: 13
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
   _7dde147b804e95998e110f5dfe487e8f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -516,6 +535,25 @@ jobs:
       INSTALL_DEPS: 1
       BOOT: 1
       CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact
+    - name: Boot Test
+      run: ./check_logs.py
+  _8c5abf2855f7fef8f5d67ba30dcc77b2:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
+    env:
+      ARCH: arm64
+      LLVM_VERSION: 12
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
     steps:
     - uses: actions/checkout@v2
       with:

--- a/generator.yml
+++ b/generator.yml
@@ -72,7 +72,7 @@ configs:
   - &arm64be           {config: [defconfig, CONFIG_CPU_BIG_ENDIAN=y],                                                                      << : *arm64-triple,         << : *kernel_modules}
   - &arm64_lto_full    {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                      << : *arm64-triple,         << : *kernel_modules}
   - &arm64_lto_thin    {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                      << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_cfi         {config: [defconfig, cfi.config],                                                                                   << : *arm64-triple,         << : *kernel_modules}
+  - &arm64_cfi         {config: [defconfig, CONFIG_LTO_CLANG_THIN=y, CONFIG_CFI_CLANG=y],                                                  << : *arm64-triple,         << : *kernel_modules}
   - &arm64_gki         {config: gki_defconfig,                                                                                             << : *arm64-triple,         << : *kernel_modules}
   - &arm64_cut         {config: cuttlefish_defconfig,                                                                                      << : *arm64-triple,         << : *kernel_modules}
   - &arm64_allmod      {config: allmodconfig,                                                                                              << : *arm64-triple,         << : *kernel_modules}
@@ -91,7 +91,7 @@ configs:
   - &x86_64            {config: defconfig,                                                                                                                             << : *kernel_modules}
   - &x86_64_lto_full   {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                                                  << : *kernel_modules}
   - &x86_64_lto_thin   {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                                                  << : *kernel_modules}
-  - &x86_64_cfi        {config: [defconfig, cfi.config],                                                                                                               << : *kernel_modules}
+  - &x86_64_cfi        {config: [defconfig, CONFIG_LTO_CLANG_THIN=y, CONFIG_CFI_CLANG=y],                                                                              << : *kernel_modules}
   - &x86_64_gki        {config: gki_defconfig,                                                                                                                         << : *kernel_modules}
   - &x86_64_cut        {config: x86_64_cuttlefish_defconfig,                                                                                                           << : *kernel_modules}
   - &x86_64_allmod     {config: allmodconfig,                                                                                                                          << : *kernel_modules}

--- a/generator.yml
+++ b/generator.yml
@@ -133,6 +133,7 @@ builds:
   - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64_allno,       << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
@@ -168,6 +169,7 @@ builds:
   - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
@@ -291,9 +293,7 @@ builds:
   #########
   #  CFI  #
   #########
-  - {<< : *arm64_cfi,         << : *lto-cfi,          << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_cfi,        << : *lto-cfi,          << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_cfi,         << : *lto-cfi-tip,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_cfi,        << : *lto-cfi-tip,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   #########
   #  TIP  #
@@ -332,6 +332,7 @@ builds:
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm64_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm64_allno,       << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
@@ -366,6 +367,7 @@ builds:
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
@@ -442,9 +444,7 @@ builds:
   #############
   #  LTO/CFI  #
   #############
-  - {<< : *arm64_cfi,         << : *lto-cfi,          << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_cfi,        << : *lto-cfi,          << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_cfi,         << : *lto-cfi-tip,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_cfi,        << : *lto-cfi-tip,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   #########
   #  TIP  #

--- a/tuxsuite/lto-cfi-tip.tux.yml
+++ b/tuxsuite/lto-cfi-tip.tux.yml
@@ -8,39 +8,12 @@ sets:
   builds:
   - git_repo: https://github.com/samitolvanen/linux.git
     git_ref: tip/clang-cfi
-    target_arch: arm64
-    toolchain: clang-nightly
-    kconfig:
-    - defconfig
-    - cfi.config
-    targets:
-    - config
-    - kernel
-    - modules
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - git_repo: https://github.com/samitolvanen/linux.git
-    git_ref: tip/clang-cfi
     target_arch: x86_64
     toolchain: clang-nightly
     kconfig:
     - defconfig
-    - cfi.config
-    targets:
-    - config
-    - kernel
-    - modules
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - git_repo: https://github.com/samitolvanen/linux.git
-    git_ref: tip/clang-cfi
-    target_arch: arm64
-    toolchain: clang-12
-    kconfig:
-    - defconfig
-    - cfi.config
+    - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_CFI_CLANG=y
     targets:
     - config
     - kernel
@@ -54,7 +27,8 @@ sets:
     toolchain: clang-12
     kconfig:
     - defconfig
-    - cfi.config
+    - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_CFI_CLANG=y
     targets:
     - config
     - kernel

--- a/tuxsuite/lto-cfi.tux.yml
+++ b/tuxsuite/lto-cfi.tux.yml
@@ -8,39 +8,12 @@ sets:
   builds:
   - git_repo: https://github.com/samitolvanen/linux.git
     git_ref: clang-cfi
-    target_arch: arm64
-    toolchain: clang-nightly
-    kconfig:
-    - defconfig
-    - cfi.config
-    targets:
-    - config
-    - kernel
-    - modules
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - git_repo: https://github.com/samitolvanen/linux.git
-    git_ref: clang-cfi
     target_arch: x86_64
     toolchain: clang-nightly
     kconfig:
     - defconfig
-    - cfi.config
-    targets:
-    - config
-    - kernel
-    - modules
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - git_repo: https://github.com/samitolvanen/linux.git
-    git_ref: clang-cfi
-    target_arch: arm64
-    toolchain: clang-12
-    kconfig:
-    - defconfig
-    - cfi.config
+    - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_CFI_CLANG=y
     targets:
     - config
     - kernel
@@ -54,7 +27,8 @@ sets:
     toolchain: clang-12
     kconfig:
     - defconfig
-    - cfi.config
+    - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_CFI_CLANG=y
     targets:
     - config
     - kernel

--- a/tuxsuite/mainline.tux.yml
+++ b/tuxsuite/mainline.tux.yml
@@ -113,6 +113,21 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
+    target_arch: arm64
+    toolchain: clang-nightly
+    kconfig:
+    - defconfig
+    - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_CFI_CLANG=y
+    targets:
+    - config
+    - kernel
+    - modules
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+    git_ref: master
     target_arch: i386
     toolchain: clang-nightly
     kconfig: defconfig
@@ -322,6 +337,21 @@ sets:
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
+    targets:
+    - config
+    - kernel
+    - modules
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+    git_ref: master
+    target_arch: arm64
+    toolchain: clang-12
+    kconfig:
+    - defconfig
+    - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_CFI_CLANG=y
     targets:
     - config
     - kernel

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -113,6 +113,21 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
+    target_arch: arm64
+    toolchain: clang-nightly
+    kconfig:
+    - defconfig
+    - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_CFI_CLANG=y
+    targets:
+    - config
+    - kernel
+    - modules
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+    git_ref: master
     target_arch: i386
     toolchain: clang-nightly
     kconfig: defconfig
@@ -337,6 +352,21 @@ sets:
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
+    targets:
+    - config
+    - kernel
+    - modules
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+    git_ref: master
+    target_arch: arm64
+    toolchain: clang-12
+    kconfig:
+    - defconfig
+    - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_CFI_CLANG=y
     targets:
     - config
     - kernel


### PR DESCRIPTION
Setting to draft for now as -next is broken and I do not want to introduce more breakage: https://lore.kernel.org/r/CA+G9fYsRZswjeDZj1hiGDu5HZ+jYCVsOOL6MAzEb=LVfQ1_NpA@mail.gmail.com/

@samitolvanen: Once this is merged, you can remove the commit that adds the `.config` fragments unless you find them useful.