### PR TITLE
utils.py: Fix crash with LLVM_VERSION=android

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -61,11 +61,11 @@ def _read_builds():
 
 
 def get_requested_llvm_version():
-    ver = int(os.environ["LLVM_VERSION"])
+    ver = os.environ["LLVM_VERSION"]
     ci_folder = pathlib.Path(__file__).resolve().parent
     with open(ci_folder.joinpath("LLVM_TOT_VERSION")) as f:
-        llvm_tot_version = int(f.read())
-    return "clang-" + ("nightly" if ver == llvm_tot_version else str(ver))
+        llvm_tot_version = str(int(f.read())).strip()
+    return "clang-" + ("nightly" if ver == llvm_tot_version else ver)
 
 
 def get_build():


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "./check_logs.py", line 102, in <module>
    build = get_build()
  File
"/home/runner/work/continuous-integration2/continuous-integration2/utils.py",
line 74, in get_build
    llvm_version = get_requested_llvm_version()
  File
"/home/runner/work/continuous-integration2/continuous-integration2/utils.py",
line 64, in get_requested_llvm_version
    ver = int(os.environ["LLVM_VERSION"])
ValueError: invalid literal for int() with base 10: 'android'
```