### PR TITLE
Fixup the Hexagon jobs and optimize around BOOT=0

### DIFF
--- a/check_logs.py
+++ b/check_logs.py
@@ -91,6 +91,7 @@ def boot_test(build):
         return
     fetch_kernel_image(build)
     fetch_dtb(build)
+    install_deps()
     run_boot()
 
 
@@ -102,5 +103,4 @@ if __name__ == "__main__":
     build = get_build()
     print(json.dumps(build, indent=4))
     check_log(build)
-    install_deps()
     boot_test(build)

--- a/install_deps.py
+++ b/install_deps.py
@@ -15,6 +15,7 @@ def install_deps():
     arch_dependencies = {
         "arm64": ["qemu-system-aarch64"],
         "arm": ["qemu-system-arm"],
+        "hexagon": [],
         "i386": ["qemu-system-x86"],
         "mips": ["qemu-system-mips"],
         "powerpc": ["qemu-system-ppc"],


### PR DESCRIPTION
`check_logs.py` fails currently due to `ARCH=hexagon` not being handled. At the same time, I noticed that we should not have even run into this because `BOOT=0` means we should not even bother installing dependencies, which is the second commit.