### PR TITLE
generator.yml: Disable arm64 big endian build with AOSP LLVM

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -1543,27 +1543,6 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _66d5f7613f33d6225179b4f74b52c782:
-    runs-on: ubuntu-20.04
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: android
-      INSTALL_DEPS: 1
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact_defconfigs
-    - name: Register clang error/warning problem matcher
-      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
-    - name: Boot Test
-      run: ./check_logs.py
   _012f9698c8641a28bfe42b1f88c3eeed:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs

--- a/generator.yml
+++ b/generator.yml
@@ -664,7 +664,8 @@ builds:
   - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_android}
   - {<< : *arm32_allyes,      << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_android}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
+  # https://github.com/ClangBuiltLinux/continuous-integration2/issues/141
+  # - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
   - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
   - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_android}

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -939,20 +939,6 @@ sets:
     toolchain: clang-android
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - config
-    - kernel
-    - modules
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
-    git_ref: master
-    target_arch: arm64
-    toolchain: clang-android
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - config


### PR DESCRIPTION
AOSP LLVM does not have the patches that enable us to build arm64 with
LLVM=1 + CONFIG_CPU_BIG_ENDIAN=y, which were merged in LLVM 13:

https://github.com/llvm/llvm-project/commit/eea34aae2e74e9b6fbdd5b95f479bc7f397bf387
https://github.com/llvm/llvm-project/commit/7605a9a009b5fa3bdac07e3131c8d82f6d08feb7

On the kernel side, we restricted CONFIG_CPU_BIG_ENDIAN=y to LLVM 13:

https://git.kernel.org/linus/e9c6deee00e9197e75cd6aa0d265d3d45bd7cc28

As a result, we try to select CONFIG_CPU_BIG_ENDIAN but Kconfig makes us
silently fall back to CONFIG_CPU_LITTLE_ENDIAN=y, resulting in the
userspace boot failure seen here:

https://github.com/ClangBuiltLinux/continuous-integration2/runs/2655483207?check_suite_focus=true

Disable this build until AOSP LLVM does a new build based on LLVM 13
with the above fixes.