### PR TITLE
Deal with most of the current fires

### DIFF
--- a/.github/workflows/4.14.yml
+++ b/.github/workflows/4.14.yml
@@ -115,16 +115,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _883da3595207ffacf848aca83da54bbc:
+  _a3e1013167dc541e6b7fecc6043a090a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc CC=clang LLVM_VERSION=13 powernv_defconfig
+    name: ARCH=powerpc CC=clang LLVM_VERSION=13 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: powernv_defconfig
+      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/4.19.yml
+++ b/.github/workflows/4.19.yml
@@ -115,16 +115,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _883da3595207ffacf848aca83da54bbc:
+  _a3e1013167dc541e6b7fecc6043a090a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc CC=clang LLVM_VERSION=13 powernv_defconfig
+    name: ARCH=powerpc CC=clang LLVM_VERSION=13 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: powernv_defconfig
+      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/5.10.yml
+++ b/.github/workflows/5.10.yml
@@ -220,16 +220,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _3ff9dd832a367410f07232e142fa8650:
+  _fa42c3c6e90d51941b6d1b39e6511ed5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 ppc44x_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 ppc44x_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: ppc44x_defconfig
+      CONFIG: ppc44x_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -241,16 +241,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _069dcf551c46228c7070e4764927aa88:
+  _46f22d98976f9ab6804a50e3c373b252:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: powernv_defconfig
+      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -493,16 +493,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a3bacbe25d9b5eb02296db0c021ec75c:
+  _6261e0d235b78132440284130e2b7c6c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 ppc44x_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 ppc44x_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: ppc44x_defconfig
+      CONFIG: ppc44x_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -514,16 +514,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _4929805e7a2ad956b20f06354ba6557f:
+  _1b6369d133fcc6b3c0f04f2ab019494a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: powernv_defconfig
+      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -766,16 +766,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8190461c1f8057e418b9abae5f927a20:
+  _4761930fb3185292c157074cdf5031ca:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=11 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=11 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: powernv_defconfig
+      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/5.4.yml
+++ b/.github/workflows/5.4.yml
@@ -157,16 +157,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _3ff9dd832a367410f07232e142fa8650:
+  _fa42c3c6e90d51941b6d1b39e6511ed5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 ppc44x_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 ppc44x_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: ppc44x_defconfig
+      CONFIG: ppc44x_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -178,16 +178,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _069dcf551c46228c7070e4764927aa88:
+  _46f22d98976f9ab6804a50e3c373b252:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: powernv_defconfig
+      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -304,16 +304,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _7ad08b1bcc47573b8a65a6f0b4e0ad5a:
+  _63e725810102bc3681f74e56c15317da:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=13 ppc44x_defconfig
+    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=13 ppc44x_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: ppc44x_defconfig
+      CONFIG: ppc44x_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -325,16 +325,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _069dcf551c46228c7070e4764927aa88:
+  _46f22d98976f9ab6804a50e3c373b252:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: powernv_defconfig
+      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -703,16 +703,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _535ebd7ca1798dda46eccb404aea7620:
+  _48b82759be3dfc699febdff2c100550b:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=12 ppc44x_defconfig
+    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=12 ppc44x_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: ppc44x_defconfig
+      CONFIG: ppc44x_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -724,16 +724,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _4929805e7a2ad956b20f06354ba6557f:
+  _1b6369d133fcc6b3c0f04f2ab019494a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: powernv_defconfig
+      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1081,16 +1081,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8190461c1f8057e418b9abae5f927a20:
+  _4761930fb3185292c157074cdf5031ca:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=11 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=11 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: powernv_defconfig
+      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1375,16 +1375,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _f858b2a83b07d7945ea319b9b2400c63:
+  _e84945731add47fd90ec8c0c8b4754a0:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=10 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=10 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 10
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: powernv_defconfig
+      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -220,27 +220,6 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e23f00f1b9cec9a3a69e648c386400ad:
-    runs-on: ubuntu-20.04
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
-    env:
-      ARCH: hexagon
-      LLVM_VERSION: 13
-      INSTALL_DEPS: 1
-      BOOT: 0
-      CONFIG: defconfig
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact_defconfigs
-    - name: Register clang error/warning problem matcher
-      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
-    - name: Boot Test
-      run: ./check_logs.py
   _7dde147b804e95998e110f5dfe487e8f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -304,16 +283,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _7ad08b1bcc47573b8a65a6f0b4e0ad5a:
+  _63e725810102bc3681f74e56c15317da:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=13 ppc44x_defconfig
+    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=13 ppc44x_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: ppc44x_defconfig
+      CONFIG: ppc44x_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -325,16 +304,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _069dcf551c46228c7070e4764927aa88:
+  _46f22d98976f9ab6804a50e3c373b252:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: powernv_defconfig
+      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -346,15 +325,15 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ea24606870e91e9589c8b50eea55772a:
+  _c12f83b6090125ba3d6b7d4da76160e3:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_EFI=n
+    name: ARCH=riscv BOOT=0 LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_EFI=n
     env:
       ARCH: riscv
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
-      BOOT: 1
+      BOOT: 0
       CONFIG: defconfig+CONFIG_EFI=n
     steps:
     - uses: actions/checkout@v2
@@ -640,27 +619,6 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e7c5cf48eb39a0ec57c7b51ec921b5e1:
-    runs-on: ubuntu-20.04
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
-    env:
-      ARCH: hexagon
-      LLVM_VERSION: 12
-      INSTALL_DEPS: 1
-      BOOT: 0
-      CONFIG: defconfig
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact_defconfigs
-    - name: Register clang error/warning problem matcher
-      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
-    - name: Boot Test
-      run: ./check_logs.py
   _300d5ea669ce6bad5b1433d2643b416d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -724,16 +682,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _535ebd7ca1798dda46eccb404aea7620:
+  _48b82759be3dfc699febdff2c100550b:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=12 ppc44x_defconfig
+    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=12 ppc44x_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: ppc44x_defconfig
+      CONFIG: ppc44x_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -745,16 +703,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _4929805e7a2ad956b20f06354ba6557f:
+  _1b6369d133fcc6b3c0f04f2ab019494a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: powernv_defconfig
+      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -766,15 +724,15 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _49b8454e1fcf8ba7fc36c5f5e6cc5299:
+  _98aa9cca27fc530a6448efe7056a03c9:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_EFI=n
+    name: ARCH=riscv BOOT=0 LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_EFI=n
     env:
       ARCH: riscv
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 1
+      BOOT: 0
       CONFIG: defconfig+CONFIG_EFI=n
     steps:
     - uses: actions/checkout@v2
@@ -1018,27 +976,6 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _f9f79b9f447e3c9e709435e7975747ca:
-    runs-on: ubuntu-20.04
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
-    env:
-      ARCH: hexagon
-      LLVM_VERSION: 11
-      INSTALL_DEPS: 1
-      BOOT: 0
-      CONFIG: defconfig
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact_defconfigs
-    - name: Register clang error/warning problem matcher
-      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
-    - name: Boot Test
-      run: ./check_logs.py
   _6b25347145c5e89e498ca11233af4912:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -1102,16 +1039,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8190461c1f8057e418b9abae5f927a20:
+  _4761930fb3185292c157074cdf5031ca:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=11 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_VERSION=11 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: powernv_defconfig
+      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1123,15 +1060,15 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _94771c21f822e6468d29dfe9257e8207:
+  _2e696b01553124e0893a0b89cfd2b934:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_EFI=n
+    name: ARCH=riscv BOOT=0 LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_EFI=n
     env:
       ARCH: riscv
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
-      BOOT: 1
+      BOOT: 0
       CONFIG: defconfig+CONFIG_EFI=n
     steps:
     - uses: actions/checkout@v2

--- a/generator.yml
+++ b/generator.yml
@@ -180,7 +180,8 @@ builds:
   - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
+  # hexagon: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1381)
+  # - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *mips,              << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *mipsel,            << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
@@ -381,7 +382,8 @@ builds:
   - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
+  # hexagon: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1381)
+  # - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *mips,              << : *next,             << : *mips_llvm,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *mipsel,            << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_latest}
@@ -530,7 +532,8 @@ builds:
   - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
   - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
   - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
+  # hexagon: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1381)
+  # - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
   - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
   - {<< : *mips,              << : *next,             << : *mips_llvm,       boot: true,  llvm_version: *llvm_11}
   - {<< : *mipsel,            << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_11}

--- a/generator.yml
+++ b/generator.yml
@@ -86,9 +86,10 @@ configs:
   - &i386              {config: defconfig,                                                                                                 << : *i386-triple,          << : *kernel_modules}
   - &mips              {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y, CONFIG_CPU_BIG_ENDIAN=y],           kernel_image: vmlinux,      << : *mips-triple,          << : *kernel_modules}
   - &mipsel            {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y],                                    kernel_image: vmlinux,      << : *mipsel-triple,        << : *kernel_modules}
-  - &ppc32             {config: ppc44x_defconfig,                                                              kernel_image: uImage,       << : *powerpc-triple,       << : *kernel_modules}
-  - &ppc64             {config: pseries_defconfig,                                                             kernel_image: vmlinux,      << : *powerpc64-triple,     << : *kernel_modules}
-  - &ppc64le           {config: powernv_defconfig,                                                             kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel_modules}
+  # PowerPC builds disable -Werror for now: https://github.com/ClangBuiltLinux/linux/issues/1386
+  - &ppc32             {config: [ppc44x_defconfig, CONFIG_PPC_DISABLE_WERROR=y],                               kernel_image: uImage,       << : *powerpc-triple,       << : *kernel_modules}
+  - &ppc64             {config: [pseries_defconfig, CONFIG_PPC_DISABLE_WERROR=y],                              kernel_image: vmlinux,      << : *powerpc64-triple,     << : *kernel_modules}
+  - &ppc64le           {config: [powernv_defconfig, CONFIG_PPC_DISABLE_WERROR=y],                              kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel_modules}
   #                                         https://github.com/ClangBuiltLinux/linux/issues/1143
   - &riscv             {config: [defconfig, CONFIG_EFI=n],                                                     kernel_image: Image,        << : *riscv-triple,         << : *kernel_modules}
   - &s390              {config: defconfig,                                                                                                 << : *s390-triple,          << : *kernel_modules}

--- a/generator.yml
+++ b/generator.yml
@@ -189,7 +189,8 @@ builds:
   # ppc64: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1292)
   # - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
   - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *riscv,             << : *next,             << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_tot}
+  # riscv: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1389)
+  - {<< : *riscv,             << : *next,             << : *riscv_llvm_full, boot: false, llvm_version: *llvm_tot}
   - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
@@ -389,7 +390,8 @@ builds:
   # ppc64: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1292)
   # - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_latest}
   - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *riscv,             << : *next,             << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_latest}
+  # riscv: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1389)
+  - {<< : *riscv,             << : *next,             << : *riscv_llvm_full, boot: false, llvm_version: *llvm_latest}
   - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
@@ -536,7 +538,8 @@ builds:
   # - {<< : *ppc32,             << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_11}
   # - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_11}
   - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *riscv,             << : *next,             << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_11}
+  # riscv: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1389)
+  - {<< : *riscv,             << : *next,             << : *riscv_llvm_full, boot: false, llvm_version: *llvm_11}
   - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_11}
   - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
   - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}

--- a/tuxsuite/4.14.tux.yml
+++ b/tuxsuite/4.14.tux.yml
@@ -54,7 +54,9 @@ sets:
     git_ref: linux-4.14.y
     target_arch: powerpc
     toolchain: clang-nightly
-    kconfig: powernv_defconfig
+    kconfig:
+    - powernv_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel

--- a/tuxsuite/4.19.tux.yml
+++ b/tuxsuite/4.19.tux.yml
@@ -58,7 +58,9 @@ sets:
     git_ref: linux-4.19.y
     target_arch: powerpc
     toolchain: clang-nightly
-    kconfig: powernv_defconfig
+    kconfig:
+    - powernv_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel

--- a/tuxsuite/5.10.tux.yml
+++ b/tuxsuite/5.10.tux.yml
@@ -125,7 +125,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: powerpc
     toolchain: clang-nightly
-    kconfig: ppc44x_defconfig
+    kconfig:
+    - ppc44x_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel
@@ -137,7 +139,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: powerpc
     toolchain: clang-nightly
-    kconfig: powernv_defconfig
+    kconfig:
+    - powernv_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel
@@ -288,7 +292,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: powerpc
     toolchain: clang-12
-    kconfig: ppc44x_defconfig
+    kconfig:
+    - ppc44x_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel
@@ -300,7 +306,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: powerpc
     toolchain: clang-12
-    kconfig: powernv_defconfig
+    kconfig:
+    - powernv_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel
@@ -451,7 +459,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: powerpc
     toolchain: clang-11
-    kconfig: powernv_defconfig
+    kconfig:
+    - powernv_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel

--- a/tuxsuite/5.4.tux.yml
+++ b/tuxsuite/5.4.tux.yml
@@ -89,7 +89,9 @@ sets:
     git_ref: linux-5.4.y
     target_arch: powerpc
     toolchain: clang-nightly
-    kconfig: ppc44x_defconfig
+    kconfig:
+    - ppc44x_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel
@@ -101,7 +103,9 @@ sets:
     git_ref: linux-5.4.y
     target_arch: powerpc
     toolchain: clang-nightly
-    kconfig: powernv_defconfig
+    kconfig:
+    - powernv_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel

--- a/tuxsuite/mainline.tux.yml
+++ b/tuxsuite/mainline.tux.yml
@@ -184,7 +184,9 @@ sets:
     git_ref: master
     target_arch: powerpc
     toolchain: clang-nightly
-    kconfig: ppc44x_defconfig
+    kconfig:
+    - ppc44x_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel
@@ -196,7 +198,9 @@ sets:
     git_ref: master
     target_arch: powerpc
     toolchain: clang-nightly
-    kconfig: powernv_defconfig
+    kconfig:
+    - powernv_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel
@@ -430,7 +434,9 @@ sets:
     git_ref: master
     target_arch: powerpc
     toolchain: clang-12
-    kconfig: ppc44x_defconfig
+    kconfig:
+    - ppc44x_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel
@@ -442,7 +448,9 @@ sets:
     git_ref: master
     target_arch: powerpc
     toolchain: clang-12
-    kconfig: powernv_defconfig
+    kconfig:
+    - powernv_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel
@@ -661,7 +669,9 @@ sets:
     git_ref: master
     target_arch: powerpc
     toolchain: clang-11
-    kconfig: powernv_defconfig
+    kconfig:
+    - powernv_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel
@@ -839,7 +849,9 @@ sets:
     git_ref: master
     target_arch: powerpc
     toolchain: clang-10
-    kconfig: powernv_defconfig
+    kconfig:
+    - powernv_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -129,18 +129,6 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
-    target_arch: hexagon
-    toolchain: clang-nightly
-    kconfig: defconfig
-    targets:
-    - config
-    - kernel
-    - modules
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
-    git_ref: master
     target_arch: i386
     toolchain: clang-nightly
     kconfig: defconfig
@@ -184,7 +172,9 @@ sets:
     git_ref: master
     target_arch: powerpc
     toolchain: clang-nightly
-    kconfig: ppc44x_defconfig
+    kconfig:
+    - ppc44x_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel
@@ -196,7 +186,9 @@ sets:
     git_ref: master
     target_arch: powerpc
     toolchain: clang-nightly
-    kconfig: powernv_defconfig
+    kconfig:
+    - powernv_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel
@@ -389,18 +381,6 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
-    target_arch: hexagon
-    toolchain: clang-12
-    kconfig: defconfig
-    targets:
-    - config
-    - kernel
-    - modules
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
-    git_ref: master
     target_arch: i386
     toolchain: clang-12
     kconfig: defconfig
@@ -445,7 +425,9 @@ sets:
     git_ref: master
     target_arch: powerpc
     toolchain: clang-12
-    kconfig: ppc44x_defconfig
+    kconfig:
+    - ppc44x_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel
@@ -457,7 +439,9 @@ sets:
     git_ref: master
     target_arch: powerpc
     toolchain: clang-12
-    kconfig: powernv_defconfig
+    kconfig:
+    - powernv_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel
@@ -620,18 +604,6 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
-    target_arch: hexagon
-    toolchain: clang-11
-    kconfig: defconfig
-    targets:
-    - config
-    - kernel
-    - modules
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
-    git_ref: master
     target_arch: i386
     toolchain: clang-11
     kconfig: defconfig
@@ -676,7 +648,9 @@ sets:
     git_ref: master
     target_arch: powerpc
     toolchain: clang-11
-    kconfig: powernv_defconfig
+    kconfig:
+    - powernv_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
     targets:
     - config
     - kernel


### PR DESCRIPTION
This should resolve the vast majority of consistent failures over the past week or so.

The CI is pretty red for LLVM 13 because of an upstream issue, which [I reverted](https://github.com/llvm/llvm-project/commit/e6b086bef2c0597ed14b2aefbb3f6d74b94fd49e) but Debian's apt.llvm.org binaries built between the original patch and my revert :/ that should go away soon so it is not being dealt with here.

I'll ping the Hexagon patches today, hopefully that will be the first thing to get reverted.