### PR TITLE
Enable pseries_defconfig (ppc64) again

### DIFF
--- a/.github/workflows/5.10.yml
+++ b/.github/workflows/5.10.yml
@@ -241,6 +241,27 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
+  _ea05e1cee7edc100c8d2e4d8be3bab04:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=13 pseries_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    env:
+      ARCH: powerpc
+      LLVM_VERSION: 13
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: pseries_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Register clang error/warning problem matcher
+      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
+    - name: Boot Test
+      run: ./check_logs.py
   _46f22d98976f9ab6804a50e3c373b252:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -503,6 +524,27 @@ jobs:
       INSTALL_DEPS: 1
       BOOT: 1
       CONFIG: ppc44x_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Register clang error/warning problem matcher
+      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
+    - name: Boot Test
+      run: ./check_logs.py
+  _0c341c35d03f3e5fc1fea9054152b13e:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=12 pseries_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    env:
+      ARCH: powerpc
+      LLVM_VERSION: 12
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: pseries_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/5.4.yml
+++ b/.github/workflows/5.4.yml
@@ -178,6 +178,27 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
+  _ea05e1cee7edc100c8d2e4d8be3bab04:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=13 pseries_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    env:
+      ARCH: powerpc
+      LLVM_VERSION: 13
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: pseries_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Register clang error/warning problem matcher
+      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
+    - name: Boot Test
+      run: ./check_logs.py
   _46f22d98976f9ab6804a50e3c373b252:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -325,6 +325,27 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
+  _ea05e1cee7edc100c8d2e4d8be3bab04:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=13 pseries_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    env:
+      ARCH: powerpc
+      LLVM_VERSION: 13
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: pseries_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Register clang error/warning problem matcher
+      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
+    - name: Boot Test
+      run: ./check_logs.py
   _46f22d98976f9ab6804a50e3c373b252:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -713,6 +734,27 @@ jobs:
       INSTALL_DEPS: 1
       BOOT: 0
       CONFIG: ppc44x_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Register clang error/warning problem matcher
+      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
+    - name: Boot Test
+      run: ./check_logs.py
+  _0c341c35d03f3e5fc1fea9054152b13e:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=12 pseries_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    env:
+      ARCH: powerpc
+      LLVM_VERSION: 12
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: pseries_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -304,6 +304,27 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
+  _ea05e1cee7edc100c8d2e4d8be3bab04:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=13 pseries_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    env:
+      ARCH: powerpc
+      LLVM_VERSION: 13
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: pseries_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Register clang error/warning problem matcher
+      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
+    - name: Boot Test
+      run: ./check_logs.py
   _46f22d98976f9ab6804a50e3c373b252:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -692,6 +713,27 @@ jobs:
       INSTALL_DEPS: 1
       BOOT: 0
       CONFIG: ppc44x_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Register clang error/warning problem matcher
+      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
+    - name: Boot Test
+      run: ./check_logs.py
+  _0c341c35d03f3e5fc1fea9054152b13e:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=12 pseries_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    env:
+      ARCH: powerpc
+      LLVM_VERSION: 12
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: pseries_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     steps:
     - uses: actions/checkout@v2
       with:

--- a/generator.yml
+++ b/generator.yml
@@ -149,8 +149,7 @@ builds:
   - {<< : *mipsel,            << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   # ppc32: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1345)
   - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  # ppc64: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1292)
-  # - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
+  - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
   - {<< : *ppc64le,           << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *riscv,             << : *mainline,         << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_tot}
   - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_tot}
@@ -187,8 +186,7 @@ builds:
   - {<< : *mipsel,            << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   # ppc32: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1345)
   - {<< : *ppc32,             << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  # ppc64: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1292)
-  # - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
+  - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
   - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   # riscv: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1389)
   - {<< : *riscv,             << : *next,             << : *riscv_llvm_full, boot: false, llvm_version: *llvm_tot}
@@ -220,8 +218,7 @@ builds:
   - {<< : *mips,              << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  # ppc64: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1292)
-  # - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
+  - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
   - {<< : *ppc64le,           << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *riscv,             << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_tot}
   - {<< : *s390,              << : *stable-5_10,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
@@ -239,8 +236,7 @@ builds:
   - {<< : *mips,              << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *mipsel,            << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *ppc32,             << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  # ppc64: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1292)
-  # - {<< : *ppc64,             << : *stable-5_4,       << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
+  - {<< : *ppc64,             << : *stable-5_4,       << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
   - {<< : *ppc64le,           << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64,            << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   ############
@@ -352,8 +348,7 @@ builds:
   - {<< : *mipsel,            << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   # ppc32: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1345)
   - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_latest}
-  # ppc64: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1292)
-  # - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_latest}
+  - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_latest}
   - {<< : *ppc64le,           << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   - {<< : *riscv,             << : *mainline,         << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_latest}
   - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_latest}
@@ -389,8 +384,7 @@ builds:
   - {<< : *mipsel,            << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   # ppc32: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1345)
   - {<< : *ppc32,             << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_latest}
-  # ppc64: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1292)
-  # - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_latest}
+  - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_latest}
   - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   # riscv: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1389)
   - {<< : *riscv,             << : *next,             << : *riscv_llvm_full, boot: false, llvm_version: *llvm_latest}
@@ -420,8 +414,7 @@ builds:
   - {<< : *mips,              << : *stable-5_10,      << : *mips_llvm,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  # ppc64: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1292)
-  # - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_latest}
+  - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_latest}
   - {<< : *ppc64le,           << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   - {<< : *riscv,             << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_latest}
   - {<< : *s390,              << : *stable-5_10,      << : *clang,           boot: true,  llvm_version: *llvm_latest}

--- a/tuxsuite/5.10.tux.yml
+++ b/tuxsuite/5.10.tux.yml
@@ -140,6 +140,21 @@ sets:
     target_arch: powerpc
     toolchain: clang-nightly
     kconfig:
+    - pseries_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LD: powerpc64le-linux-gnu-ld
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+    git_ref: linux-5.10.y
+    target_arch: powerpc
+    toolchain: clang-nightly
+    kconfig:
     - powernv_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
     targets:
@@ -301,6 +316,21 @@ sets:
     - modules
     kernel_image: uImage
     make_variables:
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+    git_ref: linux-5.10.y
+    target_arch: powerpc
+    toolchain: clang-12
+    kconfig:
+    - pseries_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LD: powerpc64le-linux-gnu-ld
       LLVM: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y

--- a/tuxsuite/5.4.tux.yml
+++ b/tuxsuite/5.4.tux.yml
@@ -104,6 +104,21 @@ sets:
     target_arch: powerpc
     toolchain: clang-nightly
     kconfig:
+    - pseries_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LD: powerpc64le-linux-gnu-ld
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+    git_ref: linux-5.4.y
+    target_arch: powerpc
+    toolchain: clang-nightly
+    kconfig:
     - powernv_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
     targets:

--- a/tuxsuite/mainline.tux.yml
+++ b/tuxsuite/mainline.tux.yml
@@ -199,6 +199,21 @@ sets:
     target_arch: powerpc
     toolchain: clang-nightly
     kconfig:
+    - pseries_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LD: powerpc64le-linux-gnu-ld
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+    git_ref: master
+    target_arch: powerpc
+    toolchain: clang-nightly
+    kconfig:
     - powernv_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
     targets:
@@ -443,6 +458,21 @@ sets:
     - modules
     kernel_image: uImage
     make_variables:
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+    git_ref: master
+    target_arch: powerpc
+    toolchain: clang-12
+    kconfig:
+    - pseries_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LD: powerpc64le-linux-gnu-ld
       LLVM: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -187,6 +187,21 @@ sets:
     target_arch: powerpc
     toolchain: clang-nightly
     kconfig:
+    - pseries_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LD: powerpc64le-linux-gnu-ld
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+    git_ref: master
+    target_arch: powerpc
+    toolchain: clang-nightly
+    kconfig:
     - powernv_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
     targets:
@@ -434,6 +449,21 @@ sets:
     - modules
     kernel_image: uImage
     make_variables:
+      LLVM: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+    git_ref: master
+    target_arch: powerpc
+    toolchain: clang-12
+    kconfig:
+    - pseries_defconfig
+    - CONFIG_PPC_DISABLE_WERROR=y
+    targets:
+    - config
+    - kernel
+    - modules
+    kernel_image: vmlinux
+    make_variables:
+      LD: powerpc64le-linux-gnu-ld
       LLVM: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master


### PR DESCRIPTION
This was disabled because of [a `-Werror` issue](https://github.com/ClangBuiltLinux/linux/issues/1292). We disable -Werror for all
PowerPC builds because of a macro collision so we can re-enable this
build as well.

This matches PowerPC's own CI:

https://git.kernel.org/powerpc/c/62e2871dfaf347501cf3fa6a999acd48679088c2