### PR TITLE
Re-support RISCV defconfig with LLVM=1 LLVM_IAS=1

### DIFF
--- a/.github/workflows/5.10.yml
+++ b/.github/workflows/5.10.yml
@@ -283,16 +283,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ea24606870e91e9589c8b50eea55772a:
+  _4908c92c4d725c03f7b7115b6b457e9e:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_EFI=n
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     env:
       ARCH: riscv
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: defconfig+CONFIG_EFI=n
+      CONFIG: defconfig
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -367,16 +367,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ea24606870e91e9589c8b50eea55772a:
+  _4908c92c4d725c03f7b7115b6b457e9e:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_EFI=n
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     env:
       ARCH: riscv
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: defconfig+CONFIG_EFI=n
+      CONFIG: defconfig
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -367,16 +367,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _c12f83b6090125ba3d6b7d4da76160e3:
+  _33ad25088921cc373b349749664a8adc:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv BOOT=0 LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_EFI=n
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     env:
       ARCH: riscv
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: defconfig+CONFIG_EFI=n
+      CONFIG: defconfig
     steps:
     - uses: actions/checkout@v2
       with:

--- a/generator.yml
+++ b/generator.yml
@@ -90,8 +90,9 @@ configs:
   - &ppc32             {config: [ppc44x_defconfig, CONFIG_PPC_DISABLE_WERROR=y],                               kernel_image: uImage,       << : *powerpc-triple,       << : *kernel_modules}
   - &ppc64             {config: [pseries_defconfig, CONFIG_PPC_DISABLE_WERROR=y],                              kernel_image: vmlinux,      << : *powerpc64-triple,     << : *kernel_modules}
   - &ppc64le           {config: [powernv_defconfig, CONFIG_PPC_DISABLE_WERROR=y],                              kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel_modules}
+  - &riscv             {config: defconfig,                                                                     kernel_image: Image,        << : *riscv-triple,         << : *kernel_modules}
   #                                         https://github.com/ClangBuiltLinux/linux/issues/1143
-  - &riscv             {config: [defconfig, CONFIG_EFI=n],                                                     kernel_image: Image,        << : *riscv-triple,         << : *kernel_modules}
+  - &riscv_no_efi      {config: [defconfig, CONFIG_EFI=n],                                                     kernel_image: Image,        << : *riscv-triple,         << : *kernel_modules}
   - &s390              {config: defconfig,                                                                                                 << : *s390-triple,          << : *kernel_modules}
   - &x86_64            {config: defconfig,                                                                                                                             << : *kernel_modules}
   - &x86_64_lto_full   {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                                                  << : *kernel_modules}
@@ -150,7 +151,7 @@ builds:
   - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
   - {<< : *ppc64le,           << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *riscv,             << : *mainline,         << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_tot}
+  - {<< : *riscv,             << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
@@ -186,7 +187,7 @@ builds:
   - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
   - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   # riscv: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1389)
-  - {<< : *riscv,             << : *next,             << : *riscv_llvm_full, boot: false, llvm_version: *llvm_tot}
+  - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
@@ -217,7 +218,7 @@ builds:
   - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
   - {<< : *ppc64le,           << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *riscv,             << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_tot}
+  - {<< : *riscv,             << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *s390,              << : *stable-5_10,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64,            << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_allmod,     << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
@@ -347,7 +348,9 @@ builds:
   - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_latest}
   - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_latest}
   - {<< : *ppc64le,           << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *riscv,             << : *mainline,         << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_latest}
+  # https://github.com/ClangBuiltLinux/linux/issues/1023
+  # https://github.com/ClangBuiltLinux/linux/issues/1143
+  - {<< : *riscv_no_efi,      << : *mainline,         << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_latest}
   - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
@@ -383,7 +386,9 @@ builds:
   - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_latest}
   - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   # riscv: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1389)
-  - {<< : *riscv,             << : *next,             << : *riscv_llvm_full, boot: false, llvm_version: *llvm_latest}
+  # https://github.com/ClangBuiltLinux/linux/issues/1023
+  # https://github.com/ClangBuiltLinux/linux/issues/1143
+  - {<< : *riscv_no_efi,      << : *next,             << : *riscv_llvm_full, boot: false, llvm_version: *llvm_latest}
   - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
@@ -412,7 +417,9 @@ builds:
   - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_latest}
   - {<< : *ppc64le,           << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *riscv,             << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_latest}
+  # https://github.com/ClangBuiltLinux/linux/issues/1023
+  # https://github.com/ClangBuiltLinux/linux/issues/1143
+  - {<< : *riscv_no_efi,      << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_latest}
   - {<< : *s390,              << : *stable-5_10,      << : *clang,           boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64,            << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_allmod,     << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
@@ -495,7 +502,9 @@ builds:
   # - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_11}
   # - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_11}
   - {<< : *ppc64le,           << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *riscv,             << : *mainline,         << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_11}
+  # https://github.com/ClangBuiltLinux/linux/issues/1023
+  # https://github.com/ClangBuiltLinux/linux/issues/1143
+  - {<< : *riscv_no_efi,      << : *mainline,         << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_11}
   - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_11}
   - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
   - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
@@ -530,7 +539,9 @@ builds:
   # - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_11}
   - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_11}
   # riscv: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1389)
-  - {<< : *riscv,             << : *next,             << : *riscv_llvm_full, boot: false, llvm_version: *llvm_11}
+  # https://github.com/ClangBuiltLinux/linux/issues/1023
+  # https://github.com/ClangBuiltLinux/linux/issues/1143
+  - {<< : *riscv_no_efi,      << : *next,             << : *riscv_llvm_full, boot: false, llvm_version: *llvm_11}
   - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_11}
   - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
   - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
@@ -560,7 +571,9 @@ builds:
   # - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
   # - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_11}
   - {<< : *ppc64le,           << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *riscv,             << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_11}
+  # https://github.com/ClangBuiltLinux/linux/issues/1023
+  # https://github.com/ClangBuiltLinux/linux/issues/1143
+  - {<< : *riscv_no_efi,      << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_11}
   - {<< : *s390,              << : *stable-5_10,      << : *clang,           boot: true,  llvm_version: *llvm_11}
   - {<< : *x86_64,            << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
   - {<< : *x86_64_allmod,     << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}

--- a/tuxsuite/5.10.tux.yml
+++ b/tuxsuite/5.10.tux.yml
@@ -168,16 +168,13 @@ sets:
     git_ref: linux-5.10.y
     target_arch: riscv
     toolchain: clang-nightly
-    kconfig:
-    - defconfig
-    - CONFIG_EFI=n
+    kconfig: defconfig
     targets:
     - config
     - kernel
     - modules
     kernel_image: Image
     make_variables:
-      LD: riscv64-linux-gnu-ld
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git

--- a/tuxsuite/mainline.tux.yml
+++ b/tuxsuite/mainline.tux.yml
@@ -227,16 +227,13 @@ sets:
     git_ref: master
     target_arch: riscv
     toolchain: clang-nightly
-    kconfig:
-    - defconfig
-    - CONFIG_EFI=n
+    kconfig: defconfig
     targets:
     - config
     - kernel
     - modules
     kernel_image: Image
     make_variables:
-      LD: riscv64-linux-gnu-ld
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -227,16 +227,13 @@ sets:
     git_ref: master
     target_arch: riscv
     toolchain: clang-nightly
-    kconfig:
-    - defconfig
-    - CONFIG_EFI=n
+    kconfig: defconfig
     targets:
     - config
     - kernel
     - modules
     kernel_image: Image
     make_variables:
-      LD: riscv64-linux-gnu-ld
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git


### PR DESCRIPTION
Thanks to @compnerd's fix:
https://reviews.llvm.org/rGbbea64250f65480d787e1c5ff45c4de3ec2dcda8
ClangBuiltLinux/linux#1023
ClangBuiltLinux/linux#1043

LLVM 13 (ToT) can now fully build RISCV defconfig again.

Split off the configs into riscv (defconfig) and riscv_no_efi. Older
versions of llvm should use riscv_no_efi.

Then keep the old riscv_llvm_full "tier," continue to use it for older
versions of llvm, but move llvm_tot back to use llvm_full.