### PR TITLE
Disable s390 builds for clang 12 and earlier on -next

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -829,27 +829,6 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _efcb2e4e81eb80fd4fdf114ea0296d0c:
-    runs-on: ubuntu-20.04
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=s390 CC=clang LLVM_VERSION=12 defconfig
-    env:
-      ARCH: s390
-      LLVM_VERSION: 12
-      INSTALL_DEPS: 1
-      BOOT: 1
-      CONFIG: defconfig
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact_defconfigs
-    - name: Register clang error/warning problem matcher
-      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
-    - name: Boot Test
-      run: ./check_logs.py
   _d49633cca166398690b1f3ecad135a14:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -1186,27 +1165,6 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _aab5675f3f257b359acd5cbd9b06b94f:
-    runs-on: ubuntu-20.04
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=s390 CC=clang LLVM_VERSION=11 defconfig
-    env:
-      ARCH: s390
-      LLVM_VERSION: 11
-      INSTALL_DEPS: 1
-      BOOT: 1
-      CONFIG: defconfig
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact_defconfigs
-    - name: Register clang error/warning problem matcher
-      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
-    - name: Boot Test
-      run: ./check_logs.py
   _73f8d728902a8cc9c807d77d1aaaedaf:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -1427,27 +1385,6 @@ jobs:
       INSTALL_DEPS: 1
       BOOT: 1
       CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact_defconfigs
-    - name: Register clang error/warning problem matcher
-      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
-    - name: Boot Test
-      run: ./check_logs.py
-  _77129a466d7b015c998bbca441d09b93:
-    runs-on: ubuntu-20.04
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=s390 CC=clang LLVM_VERSION=10 defconfig
-    env:
-      ARCH: s390
-      LLVM_VERSION: 10
-      INSTALL_DEPS: 1
-      BOOT: 1
-      CONFIG: defconfig
     steps:
     - uses: actions/checkout@v2
       with:

--- a/generator.yml
+++ b/generator.yml
@@ -389,7 +389,8 @@ builds:
   # https://github.com/ClangBuiltLinux/linux/issues/1023
   # https://github.com/ClangBuiltLinux/linux/issues/1143
   - {<< : *riscv_no_efi,      << : *next,             << : *riscv_llvm_full, boot: false, llvm_version: *llvm_latest}
-  - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_latest}
+  # s390: Build disabled (https://lore.kernel.org/r/YMtib5hKVyNknZt3@osiris/)
+  # - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_lto_thin,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
@@ -542,7 +543,8 @@ builds:
   # https://github.com/ClangBuiltLinux/linux/issues/1023
   # https://github.com/ClangBuiltLinux/linux/issues/1143
   - {<< : *riscv_no_efi,      << : *next,             << : *riscv_llvm_full, boot: false, llvm_version: *llvm_11}
-  - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_11}
+  # s390: Build disabled (https://lore.kernel.org/r/YMtib5hKVyNknZt3@osiris/)
+  # - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_11}
   - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
   - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
   - {<< : *x86_64_lto_thin,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
@@ -652,7 +654,8 @@ builds:
   # - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_10}
   # ppc64le: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1359)
   # - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_10}
-  - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_10}
+  # s390: Build disabled (https://lore.kernel.org/r/YMtib5hKVyNknZt3@osiris/)
+  # - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_10}
   - {<< : *x86_64,            << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_10}
   # x86_64: all{mod,yes}config builds disabled (https://github.com/ClangBuiltLinux/linux/issues/1293)
   # - {<< : *x86_64_allmod,     << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_10}

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -518,15 +518,6 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
-    target_arch: s390
-    toolchain: clang-12
-    kconfig: defconfig
-    targets:
-    - config
-    - kernel
-    - modules
-  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
-    git_ref: master
     target_arch: x86_64
     toolchain: clang-12
     kconfig: defconfig
@@ -739,15 +730,6 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
-    target_arch: s390
-    toolchain: clang-11
-    kconfig: defconfig
-    targets:
-    - config
-    - kernel
-    - modules
-  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
-    git_ref: master
     target_arch: x86_64
     toolchain: clang-11
     kconfig: defconfig
@@ -887,15 +869,6 @@ sets:
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
-  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
-    git_ref: master
-    target_arch: s390
-    toolchain: clang-10
-    kconfig: defconfig
-    targets:
-    - config
-    - kernel
-    - modules
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: x86_64


### PR DESCRIPTION
This is no longer expected to work:

https://lore.kernel.org/r/YMtib5hKVyNknZt3@osiris/