### PR TITLE
Update the start time of the -next jobs

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -13,7 +13,7 @@ name: next
     - tuxsuite/next.tux.yml
     - .github/workflows/next.yml
   schedule:
-  - cron: 0 8 * * 1,2,3,4,5
+  - cron: 0 12 * * 1,2,3,4,5
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/generator.yml
+++ b/generator.yml
@@ -15,8 +15,8 @@ urls:
 schedules:
   - &six_hours {schedule: "0 0,6,12,18 * * *"}
   - &daily     {schedule: "0 0 * * *"}
-  # -next updates M-F in the evening EAST, which is 8:00 UTC
-  - &weekdays  {schedule: "0 8 * * 1,2,3,4,5"}
+  # -next updates M-F in the evening AEST, which is usually around 12:00PM UTC
+  - &weekdays  {schedule: "0 12 * * 1,2,3,4,5"}
 trees:
   - &mainline         {git_repo: *mainline-url, git_ref: master,              name: mainline,         << : *six_hours}
   - &next             {git_repo: *next-url,     git_ref: master,              name: next,             << : *weekdays}


### PR DESCRIPTION
Towards the end of a release cycle, -next releases get later and later
since there are more merge conflicts and build errors to fight through,
meaning that with our current schedule, we often miss the version of
-next that is going to be released.

Push the time we start the builds by three hours, which should ensure
that -next is released by that time.