### PR TITLE
check_logs.py: Do not use number of errors to fail the build

### DIFF
--- a/check_logs.py
+++ b/check_logs.py
@@ -83,8 +83,8 @@ def run_boot():
 
 
 def boot_test(build):
-    if build["errors_count"] > 0:
-        print_red("errors encountered during build, skipping boot")
+    if build["result"] == "fail":
+        print_red("fatal build errors encountered during build, skipping boot")
         sys.exit(1)
     if "BOOT" in os.environ and os.environ["BOOT"] == "0":
         print_yellow("boot test disabled via config, skipping boot")


### PR DESCRIPTION
It is possible for there to be errors in the build that are not fatal:

https://builds.tuxbuild.com/1uccc7bvODo3jO9zwLBJBhrudAw/build.log

https://lore.kernel.org/r/20210625122902.4058783-1-stefanb@linux.vnet.ibm.com/

The result field in status.json will tell us if the build fatally
errored based on make's error status so use that instead so that we do
not have false positive failures.