### PR TITLE
Remove CROSS_COMPILE_COMPAT for upstream 5.4

### DIFF
--- a/generator.yml
+++ b/generator.yml
@@ -231,7 +231,7 @@ builds:
   ###########
   - {<< : *arm32_v7,          << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_v7_t,        << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64,             << : *stable-5_4,       << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64,             << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64be,           << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *mips,              << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *mipsel,            << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}

--- a/tuxsuite/5.4.tux.yml
+++ b/tuxsuite/5.4.tux.yml
@@ -40,7 +40,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git


### PR DESCRIPTION
The compat vDSO for arm64 did not build upstream until 5.7 because of
the series associated with commit a5d442f50a41 ("arm64: vdso32: Enable
Clang Compilation"). That series was backported to Android 5.4 so we do
not need any changes there.

Link: https://github.com/ClangBuiltLinux/continuous-integration2/runs/2947999652?check_suite_focus=true