### PR TITLE
Move RISC-V back to ld.bfd on 5.10

### DIFF
--- a/.github/workflows/5.10.yml
+++ b/.github/workflows/5.10.yml
@@ -283,10 +283,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _4908c92c4d725c03f7b7115b6b457e9e:
+  _e3cea7aec5ec17089d9d7eb98c7d0315:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
+    name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=13 defconfig
     env:
       ARCH: riscv
       LLVM_VERSION: 13

--- a/generator.yml
+++ b/generator.yml
@@ -120,7 +120,7 @@ tiers:
   - &mips_llvm          {llvm: true,  llvm_ias: false, make_variables: {LD: mips-linux-gnu-ld, LLVM: 1}}
   # PowerPC 64-bit big endian                                           https://github.com/ClangBuiltLinux/linux/issues/602 and https://github.com/ClangBuiltLinux/linux/issues/1260
   - &ppc64_llvm         {llvm: true,  llvm_ias: false, make_variables: {LD: powerpc64le-linux-gnu-ld, LLVM: 1}}
-  # RISC-V                                                              https://github.com/ClangBuiltLinux/linux/issues/1020
+  # RISC-V                                                              https://github.com/ClangBuiltLinux/linux/issues/1020 and https://github.com/ClangBuiltLinux/linux/issues/1409
   - &riscv_llvm_full    {llvm: true,  llvm_ias: true,  make_variables: {LD: riscv64-linux-gnu-ld, LLVM: 1, LLVM_IAS: 1}}
 builds:
   ######################
@@ -220,7 +220,7 @@ builds:
   - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
   - {<< : *ppc64le,           << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *riscv,             << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *riscv,             << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_tot}
   - {<< : *s390,              << : *stable-5_10,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64,            << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_allmod,     << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}

--- a/tuxsuite/5.10.tux.yml
+++ b/tuxsuite/5.10.tux.yml
@@ -176,6 +176,7 @@ sets:
     - modules
     kernel_image: Image
     make_variables:
+      LD: riscv64-linux-gnu-ld
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git


### PR DESCRIPTION
5.10 has a different issue that was tangentially fixed in mainline,
requiring further investigation.