### PR TITLE
Explicitly specify LLVM_IAS=0

### DIFF
--- a/.github/workflows/4.14.yml
+++ b/.github/workflows/4.14.yml
@@ -31,10 +31,10 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
-  _24063fc5fe64c66101a75dbf48842aba:
+  _a0695b67b847cf06f7c6fac7c9f9981d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm CC=clang LLVM_VERSION=13 multi_v7_defconfig
+    name: ARCH=arm CC=clang LLVM_IAS=0 LLVM_VERSION=13 multi_v7_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -52,10 +52,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e3cdf2669388fbb2f01c99215522a0c1:
+  _691bb89e2be29954a42510a42224e0f9:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm CC=clang LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm CC=clang LLVM_IAS=0 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -73,10 +73,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _dfc7cb9a81693bca2e6a190f779350d7:
+  _314270357e5d93012daf4ce76f8acf85:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 CC=clang LD=ld.lld LLVM_VERSION=13 defconfig
+    name: ARCH=arm64 CC=clang LD=ld.lld LLVM_IAS=0 LLVM_VERSION=13 defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 13
@@ -94,10 +94,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _9e742681f02420d47b4f491b12ccfacb:
+  _17d159a26103728e87685971646fbba4:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 CC=clang LD=ld.lld LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=arm64 CC=clang LD=ld.lld LLVM_IAS=0 LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: arm64
       LLVM_VERSION: 13
@@ -115,10 +115,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _883da3595207ffacf848aca83da54bbc:
+  _f4d3de3db46c87da313d87e1f3f6dc29:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc CC=clang LLVM_VERSION=13 powernv_defconfig
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
@@ -136,10 +136,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ef7d1652d6697840a5167fb372bdd048:
+  _c5dcd83d1e9c92ec8d1a3dd8640ad58f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 CC=clang LD=ld.lld LLVM_VERSION=13 defconfig
+    name: ARCH=x86_64 CC=clang LD=ld.lld LLVM_IAS=0 LLVM_VERSION=13 defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13

--- a/.github/workflows/4.19.yml
+++ b/.github/workflows/4.19.yml
@@ -31,10 +31,10 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
-  _c1e13055e5361c03be9afb991342ca79:
+  _66217275b440ea529e2b7432462ab897:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=13 multi_v7_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 multi_v7_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -52,10 +52,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _61786e26a75b319fadc440c70c0e761a:
+  _dccb2e73fc9decea9e1a7d4a932299a6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -73,10 +73,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _2621acf880170bfa716f50c7f7000ed9:
+  _27eec8ad442e6c80c936801a2dca77cc:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_VERSION=13 defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 13
@@ -94,10 +94,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _86b0b67912039ca35e7e909168b14a21:
+  _9eb09c7190bf44727170b34b8557352d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: arm64
       LLVM_VERSION: 13
@@ -115,10 +115,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _883da3595207ffacf848aca83da54bbc:
+  _f4d3de3db46c87da313d87e1f3f6dc29:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc CC=clang LLVM_VERSION=13 powernv_defconfig
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
@@ -136,10 +136,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8b9460f3f4acc112b75ac414b3b20bb0:
+  _7c47476f557cfe69821df8c29bb9c4ac:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_VERSION=13 defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13

--- a/.github/workflows/4.4.yml
+++ b/.github/workflows/4.4.yml
@@ -31,10 +31,10 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
-  _68dfee76937d7d59b74356207524e3a7:
+  _fdebbd56e6e84acbd9eab17d55242c90:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 CC=clang LLVM_VERSION=13 defconfig
+    name: ARCH=arm64 CC=clang LLVM_IAS=0 LLVM_VERSION=13 defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 13
@@ -52,10 +52,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _124abce2c1b5181ff4a9a3b02428c052:
+  _d21a4521edd84e93015876855a493a50:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 CC=clang LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=arm64 CC=clang LLVM_IAS=0 LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: arm64
       LLVM_VERSION: 13
@@ -73,10 +73,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ef7d1652d6697840a5167fb372bdd048:
+  _c5dcd83d1e9c92ec8d1a3dd8640ad58f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 CC=clang LD=ld.lld LLVM_VERSION=13 defconfig
+    name: ARCH=x86_64 CC=clang LD=ld.lld LLVM_IAS=0 LLVM_VERSION=13 defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13

--- a/.github/workflows/4.9.yml
+++ b/.github/workflows/4.9.yml
@@ -31,10 +31,10 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
-  _24063fc5fe64c66101a75dbf48842aba:
+  _a0695b67b847cf06f7c6fac7c9f9981d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm CC=clang LLVM_VERSION=13 multi_v7_defconfig
+    name: ARCH=arm CC=clang LLVM_IAS=0 LLVM_VERSION=13 multi_v7_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -52,10 +52,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _68dfee76937d7d59b74356207524e3a7:
+  _fdebbd56e6e84acbd9eab17d55242c90:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 CC=clang LLVM_VERSION=13 defconfig
+    name: ARCH=arm64 CC=clang LLVM_IAS=0 LLVM_VERSION=13 defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 13
@@ -73,10 +73,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _124abce2c1b5181ff4a9a3b02428c052:
+  _d21a4521edd84e93015876855a493a50:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 CC=clang LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=arm64 CC=clang LLVM_IAS=0 LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: arm64
       LLVM_VERSION: 13
@@ -94,10 +94,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ef7d1652d6697840a5167fb372bdd048:
+  _c5dcd83d1e9c92ec8d1a3dd8640ad58f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 CC=clang LD=ld.lld LLVM_VERSION=13 defconfig
+    name: ARCH=x86_64 CC=clang LD=ld.lld LLVM_IAS=0 LLVM_VERSION=13 defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13

--- a/.github/workflows/5.10.yml
+++ b/.github/workflows/5.10.yml
@@ -31,10 +31,10 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
-  _877f148925688b45a9565666a5c8c8c4:
+  _0641bddb9061ed97d31358c47725e74d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=13 multi_v5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 multi_v5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -52,10 +52,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _55053058bd54acae6c4c7812c32270f7:
+  _b9931b3c7aeb5ecaa92addf21de8f0a6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=13 aspeed_g5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 aspeed_g5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -73,10 +73,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _c1e13055e5361c03be9afb991342ca79:
+  _66217275b440ea529e2b7432462ab897:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=13 multi_v7_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 multi_v7_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -94,10 +94,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _61786e26a75b319fadc440c70c0e761a:
+  _dccb2e73fc9decea9e1a7d4a932299a6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -178,10 +178,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _dd0abd18f6fb089956a0981751bc6b0c:
+  _0eecb2df639bfc6c34cb18f6437e649b:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 13
@@ -199,10 +199,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _4cbced3108106eb3201bf12eab9e65eb:
+  _69a1e3f1d846068b618f26c404160b14:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
+    name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 13
@@ -220,10 +220,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _3ff9dd832a367410f07232e142fa8650:
+  _48a57be25b36aba020e19ff27fcc54a4:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 ppc44x_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 ppc44x_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
@@ -241,10 +241,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ffc1134a05ecdc0f72e9a91ff18808f4:
+  _c0b585545a490a64b13d51c861610e3c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=13 pseries_defconfig
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=13 pseries_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
@@ -262,10 +262,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _069dcf551c46228c7070e4764927aa88:
+  _848b558acb7e2487ba2d59cd1a85aa7a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
@@ -304,10 +304,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _fee5569ddd8b71b19e7fb517769de851:
+  _5efcbae1959e140c37060595422c0e64:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=s390 CC=clang LLVM_VERSION=13 defconfig
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 defconfig
     env:
       ARCH: s390
       LLVM_VERSION: 13
@@ -346,10 +346,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a11abf02e18322177d92417220207cb8:
+  _39967e62e3e6ddc7694ef9844103270f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 multi_v5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -367,10 +367,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _6f7c758da41b41b25476334cfd2afd0e:
+  _2d617a0693d6cbc319274e7d1a888bc5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 aspeed_g5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 aspeed_g5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -388,10 +388,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _60ecbb939df9a7399fa560fa887f0132:
+  _fa79ae3dbe7872500bce9bf269972939:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 multi_v7_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -409,10 +409,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _267d8195f8748ce0c5d40740008e5dde:
+  _770b21725a2daf535b47afe6f68001bc:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -472,10 +472,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _2e8125b1f3df9bc77d92a930d41f4782:
+  _0cc3ac6a57d27d3cef575f41babb7262:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 12
@@ -493,10 +493,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _106d267c84f6ece7cf9710a2cb351c6d:
+  _9ffc4427d344a9bbd18dbfcfa1e5da53:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
+    name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 12
@@ -514,10 +514,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a3bacbe25d9b5eb02296db0c021ec75c:
+  _f19fa50ec541ef4ddce215421e645da8:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 ppc44x_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 ppc44x_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
@@ -535,10 +535,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _dbfb1afee12b5bc2178bd79c1ca36bc9:
+  _2731e549c1005e11869f2cbf544e46e1:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=12 pseries_defconfig
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=12 pseries_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
@@ -556,10 +556,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _4929805e7a2ad956b20f06354ba6557f:
+  _e7d400a7f60ea696f730ba8de7f3d281:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
@@ -598,10 +598,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _efcb2e4e81eb80fd4fdf114ea0296d0c:
+  _ff91e27f2eb0b39e3180ac5e04cf04a1:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=s390 CC=clang LLVM_VERSION=12 defconfig
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=12 defconfig
     env:
       ARCH: s390
       LLVM_VERSION: 12
@@ -640,10 +640,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _326167b20a9a6ecc06fa9d1b2aba10f3:
+  _3ae3531548c624e92b5e217f7cebdcc2:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=11 multi_v5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -661,10 +661,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _c60cf38875a5399afa4b11ba4d6ef6a7:
+  _75528eaffeb79bcc9118acaee19466a9:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=11 aspeed_g5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 aspeed_g5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -682,10 +682,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e568393d55ec884da44c831f42852904:
+  _f045ace3044bbc7c295921e10b3bc6d1:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=11 multi_v7_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -703,10 +703,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _f32548095474a8341719241e481106cd:
+  _27376e72305e073694aefb13f554665f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=11 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -766,10 +766,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _d5751ecccab4f8123d49f1ff7e7c87f5:
+  _772f9a8c79e52c6ee000b01cab13b4f6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 11
@@ -787,10 +787,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _4199aee554a613fda64b1eacc81b5add:
+  _91bbbe2f66767e2566aad8a1f0e4ada4:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
+    name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 11
@@ -808,10 +808,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8190461c1f8057e418b9abae5f927a20:
+  _479b82ae68113f446f1f8a6cd14f002e:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=11 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
@@ -850,10 +850,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _aab5675f3f257b359acd5cbd9b06b94f:
+  _3b0c273122a784488dcfee7a6a9016b9:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=s390 CC=clang LLVM_VERSION=11 defconfig
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=11 defconfig
     env:
       ARCH: s390
       LLVM_VERSION: 11
@@ -907,10 +907,10 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_allconfigs
-  _b6004055e739b487ac5b79a2ecd21871:
+  _939f400888bbc7344717215a96716b90:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -949,10 +949,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a17601dec744d5d8c2a4a9c67b744b30:
+  _8816a455253de9d0455dfa0b0bf9a2d6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=13 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 allyesconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -1096,10 +1096,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e0faf7981c78617941c48bb39357dfa5:
+  _8a7f0138d12509886a29c0b8b2b90e80:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -1117,10 +1117,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a3c122fc012130191ce34a8fc1ed2809:
+  _83e582866c8e77c704428984335400c0:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 allnoconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allnoconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -1138,10 +1138,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ac352b89ff0b84ba7baaec44be7d4fd9:
+  _f67567decbe181f7dac1cebae6b752c2:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allyesconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -1285,10 +1285,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _79c2e713ed9fc3c4381862731d8a664a:
+  _565b3ebd0db7f13bc44114dbc4ce6faa:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=11 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -1306,10 +1306,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _56d21d0eba24aae15e0e7ba0cdd3e62a:
+  _98be35eea81be1fc7cfea5f125dacb85:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=11 allnoconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allnoconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -1327,10 +1327,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ee24c08b15f5892fb5e38906315c0280:
+  _e4b5a7cb392bd67d52690ece87b3e80f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=11 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allyesconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11

--- a/.github/workflows/5.4.yml
+++ b/.github/workflows/5.4.yml
@@ -31,10 +31,10 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
-  _c1e13055e5361c03be9afb991342ca79:
+  _66217275b440ea529e2b7432462ab897:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=13 multi_v7_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 multi_v7_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -52,10 +52,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _61786e26a75b319fadc440c70c0e761a:
+  _dccb2e73fc9decea9e1a7d4a932299a6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -115,10 +115,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _dd0abd18f6fb089956a0981751bc6b0c:
+  _0eecb2df639bfc6c34cb18f6437e649b:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 13
@@ -136,10 +136,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _4cbced3108106eb3201bf12eab9e65eb:
+  _69a1e3f1d846068b618f26c404160b14:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
+    name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 13
@@ -157,10 +157,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _3ff9dd832a367410f07232e142fa8650:
+  _48a57be25b36aba020e19ff27fcc54a4:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 ppc44x_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 ppc44x_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
@@ -178,10 +178,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ffc1134a05ecdc0f72e9a91ff18808f4:
+  _c0b585545a490a64b13d51c861610e3c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=13 pseries_defconfig
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=13 pseries_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
@@ -199,10 +199,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _069dcf551c46228c7070e4764927aa88:
+  _848b558acb7e2487ba2d59cd1a85aa7a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13

--- a/.github/workflows/android-4.14.yml
+++ b/.github/workflows/android-4.14.yml
@@ -31,10 +31,10 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
-  _578ff8b3f8dccbf56540703bd5ab8af9:
+  _6fc223e1966ab7052b25026d1082ebff:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 CC=clang LD=ld.lld LLVM_VERSION=13 cuttlefish_defconfig
+    name: ARCH=arm64 CC=clang LD=ld.lld LLVM_IAS=0 LLVM_VERSION=13 cuttlefish_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 13
@@ -52,10 +52,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _815a65a53c192c1166e2fbac33f48fd9:
+  _6f3686139820fd568cad0dcb30bdf6c8:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 CC=clang LD=ld.lld LLVM_VERSION=13 x86_64_cuttlefish_defconfig
+    name: ARCH=x86_64 CC=clang LD=ld.lld LLVM_IAS=0 LLVM_VERSION=13 x86_64_cuttlefish_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
@@ -73,10 +73,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _4c5fddb1a4a76a91c08e4940c3854d7f:
+  _1c4c36bd309bb6f780cfdcb0ac801fb1:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 CC=clang LD=ld.lld LLVM_VERSION=12 cuttlefish_defconfig
+    name: ARCH=arm64 CC=clang LD=ld.lld LLVM_IAS=0 LLVM_VERSION=12 cuttlefish_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 12
@@ -94,10 +94,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _6498b71b001db9fb3cc43fd0bf1c696b:
+  _a3d0345916f4a8b408b5e5bdf8f9cbec:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 CC=clang LD=ld.lld LLVM_VERSION=12 x86_64_cuttlefish_defconfig
+    name: ARCH=x86_64 CC=clang LD=ld.lld LLVM_IAS=0 LLVM_VERSION=12 x86_64_cuttlefish_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
@@ -115,10 +115,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ef1b3f898096c0a30af926f992e7d15d:
+  _f41a40b9ca513a23053de3c8ddbc5909:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 CC=clang LD=ld.lld LLVM_VERSION=android cuttlefish_defconfig
+    name: ARCH=arm64 CC=clang LD=ld.lld LLVM_IAS=0 LLVM_VERSION=android cuttlefish_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: android
@@ -136,10 +136,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _c6ac34bb506025217f40515638b3521e:
+  _3c9cc1628795dbafc5b9170f79d448ce:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 CC=clang LD=ld.lld LLVM_VERSION=android x86_64_cuttlefish_defconfig
+    name: ARCH=x86_64 CC=clang LD=ld.lld LLVM_IAS=0 LLVM_VERSION=android x86_64_cuttlefish_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: android

--- a/.github/workflows/android-4.9.yml
+++ b/.github/workflows/android-4.9.yml
@@ -31,10 +31,10 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
-  _dffb5e5b93b6e7ad15d9064b604ba9f6:
+  _0ba3c883f05a88598e4dd3a802d180c8:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 CC=clang LLVM_VERSION=13 cuttlefish_defconfig
+    name: ARCH=arm64 CC=clang LLVM_IAS=0 LLVM_VERSION=13 cuttlefish_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 13
@@ -52,10 +52,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _eaf36f55a48a052b14efb887955a41d3:
+  _2a0e81e055c217706ca0d25e06f2dbba:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 CC=clang LLVM_VERSION=13 x86_64_cuttlefish_defconfig
+    name: ARCH=x86_64 CC=clang LLVM_IAS=0 LLVM_VERSION=13 x86_64_cuttlefish_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
@@ -73,10 +73,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _9f337ad59aa2ce084372c493aee63f6c:
+  _f6a680cf919f6d6bd5cd70dea14baebe:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 CC=clang LLVM_VERSION=12 cuttlefish_defconfig
+    name: ARCH=arm64 CC=clang LLVM_IAS=0 LLVM_VERSION=12 cuttlefish_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 12
@@ -94,10 +94,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _037a1474a759c53ce359d6e2a91b3e5d:
+  _7cebc4d90a9e37ff6d11a361474c3237:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 CC=clang LLVM_VERSION=12 x86_64_cuttlefish_defconfig
+    name: ARCH=x86_64 CC=clang LLVM_IAS=0 LLVM_VERSION=12 x86_64_cuttlefish_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
@@ -115,10 +115,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _dcf1ed10c39646894f402b2b01c621c0:
+  _0c55f0c63c29ac3e1b751465c8018ef8:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 CC=clang LLVM_VERSION=android cuttlefish_defconfig
+    name: ARCH=arm64 CC=clang LLVM_IAS=0 LLVM_VERSION=android cuttlefish_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: android
@@ -136,10 +136,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _2de65e87a0f81f7c3f56eeeb11132f2c:
+  _387bf8b26f6b972a040f83464a032bfe:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 CC=clang LLVM_VERSION=android x86_64_cuttlefish_defconfig
+    name: ARCH=x86_64 CC=clang LLVM_IAS=0 LLVM_VERSION=android x86_64_cuttlefish_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: android

--- a/.github/workflows/android-mainline.yml
+++ b/.github/workflows/android-mainline.yml
@@ -94,10 +94,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _267d8195f8748ce0c5d40740008e5dde:
+  _770b21725a2daf535b47afe6f68001bc:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -256,10 +256,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e0faf7981c78617941c48bb39357dfa5:
+  _8a7f0138d12509886a29c0b8b2b90e80:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12

--- a/.github/workflows/android12-5.10.yml
+++ b/.github/workflows/android12-5.10.yml
@@ -94,10 +94,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _267d8195f8748ce0c5d40740008e5dde:
+  _770b21725a2daf535b47afe6f68001bc:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -256,10 +256,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e0faf7981c78617941c48bb39357dfa5:
+  _8a7f0138d12509886a29c0b8b2b90e80:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12

--- a/.github/workflows/android12-5.4.yml
+++ b/.github/workflows/android12-5.4.yml
@@ -31,10 +31,10 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
-  _61786e26a75b319fadc440c70c0e761a:
+  _dccb2e73fc9decea9e1a7d4a932299a6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 13
@@ -94,10 +94,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _267d8195f8748ce0c5d40740008e5dde:
+  _770b21725a2daf535b47afe6f68001bc:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -157,10 +157,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _57fa49b1ef6855f184e18c099348184b:
+  _4326b65437c5924517a9d63fa379bc24:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=android multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=android multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: android
@@ -256,10 +256,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e0faf7981c78617941c48bb39357dfa5:
+  _8a7f0138d12509886a29c0b8b2b90e80:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12

--- a/.github/workflows/android13-5.10.yml
+++ b/.github/workflows/android13-5.10.yml
@@ -94,10 +94,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _267d8195f8748ce0c5d40740008e5dde:
+  _770b21725a2daf535b47afe6f68001bc:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -256,10 +256,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e0faf7981c78617941c48bb39357dfa5:
+  _8a7f0138d12509886a29c0b8b2b90e80:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12

--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -367,10 +367,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _3ff9dd832a367410f07232e142fa8650:
+  _48a57be25b36aba020e19ff27fcc54a4:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 ppc44x_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 ppc44x_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
@@ -388,10 +388,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ffc1134a05ecdc0f72e9a91ff18808f4:
+  _c0b585545a490a64b13d51c861610e3c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=13 pseries_defconfig
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=13 pseries_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
@@ -409,10 +409,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _069dcf551c46228c7070e4764927aa88:
+  _848b558acb7e2487ba2d59cd1a85aa7a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
@@ -451,10 +451,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _fee5569ddd8b71b19e7fb517769de851:
+  _5efcbae1959e140c37060595422c0e64:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=s390 CC=clang LLVM_VERSION=13 defconfig
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 defconfig
     env:
       ARCH: s390
       LLVM_VERSION: 13
@@ -535,10 +535,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a11abf02e18322177d92417220207cb8:
+  _39967e62e3e6ddc7694ef9844103270f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 multi_v5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -556,10 +556,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _6f7c758da41b41b25476334cfd2afd0e:
+  _2d617a0693d6cbc319274e7d1a888bc5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 aspeed_g5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 aspeed_g5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -577,10 +577,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _60ecbb939df9a7399fa560fa887f0132:
+  _fa79ae3dbe7872500bce9bf269972939:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 multi_v7_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -598,10 +598,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _267d8195f8748ce0c5d40740008e5dde:
+  _770b21725a2daf535b47afe6f68001bc:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -619,10 +619,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _83682cb2a47ad2c91afee3391d07e27d:
+  _a980878231cd6e2db930c1452d3825c2:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 imx_v4_v5_defconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 imx_v4_v5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -640,10 +640,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _7720719bb45ee91fc437e4e2b9b4849d:
+  _aa063a2bed61222ee081b8f9d5cef4bb:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 omap2plus_defconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 omap2plus_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -661,10 +661,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _b2f35e5f085a2fcb0f38aef8b1e7ea7d:
+  _c13599a70b23e23c511f4c327c9aea77:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -850,10 +850,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _535ebd7ca1798dda46eccb404aea7620:
+  _6a30520d164c342e0191a1a2f5c3ae67:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=12 ppc44x_defconfig
+    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 ppc44x_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
@@ -871,10 +871,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _dbfb1afee12b5bc2178bd79c1ca36bc9:
+  _2731e549c1005e11869f2cbf544e46e1:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=12 pseries_defconfig
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=12 pseries_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
@@ -892,10 +892,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _4929805e7a2ad956b20f06354ba6557f:
+  _e7d400a7f60ea696f730ba8de7f3d281:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
@@ -997,10 +997,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _326167b20a9a6ecc06fa9d1b2aba10f3:
+  _3ae3531548c624e92b5e217f7cebdcc2:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=11 multi_v5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -1018,10 +1018,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _c60cf38875a5399afa4b11ba4d6ef6a7:
+  _75528eaffeb79bcc9118acaee19466a9:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=11 aspeed_g5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 aspeed_g5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -1039,10 +1039,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e568393d55ec884da44c831f42852904:
+  _f045ace3044bbc7c295921e10b3bc6d1:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=11 multi_v7_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -1060,10 +1060,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _f32548095474a8341719241e481106cd:
+  _27376e72305e073694aefb13f554665f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=11 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -1081,10 +1081,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8580b9e52c1bf221a87bcea328a1e26b:
+  _050101081cc5af5e12c7347491bfbb57:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=11 imx_v4_v5_defconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 imx_v4_v5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -1102,10 +1102,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _fa2ffecc19a6f5e0e73ac93f10279e98:
+  _1ae1af112dbdceec19311ed66924bb9a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=11 omap2plus_defconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 omap2plus_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -1123,10 +1123,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _c5c2fd6a0796369d8a9a14eef4111c2c:
+  _4afa87435ae9249b1597002b8bed68d2:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=11 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -1249,10 +1249,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _d5751ecccab4f8123d49f1ff7e7c87f5:
+  _772f9a8c79e52c6ee000b01cab13b4f6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 11
@@ -1270,10 +1270,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _4199aee554a613fda64b1eacc81b5add:
+  _91bbbe2f66767e2566aad8a1f0e4ada4:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
+    name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 11
@@ -1291,10 +1291,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _1f78fa93ea4d3467dfbba5688f76a298:
+  _e96b0d0f9698e45a12b0f7d394eaa634:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=11 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
@@ -1396,10 +1396,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _fd8f5d7d3d038c2feafce905c5abfb27:
+  _6692825e3a7b84aa03ce5982176b9200:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=10 multi_v5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 multi_v5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 10
@@ -1417,10 +1417,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a751f22e6ba9bbdb1039ee3895125370:
+  _7ce6505ac8e3234bf7f120923864f556:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LD=arm-linux-gnueabihf-ld LLVM_VERSION=10 aspeed_g5_defconfig
+    name: ARCH=arm LLVM=1 LD=arm-linux-gnueabihf-ld LLVM_IAS=0 LLVM_VERSION=10 aspeed_g5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 10
@@ -1438,10 +1438,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _929ef902a624959eb09c397923751212:
+  _8d4c408eb0725ebb7d15550f73f0d1af:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=10 multi_v7_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 multi_v7_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 10
@@ -1459,10 +1459,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _63a27c3bcba04fab80b30ca454b2a2a9:
+  _907678d6077bc2f81d0595856d171e8c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=10 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 10
@@ -1480,10 +1480,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _9a919af0584ad3314340747afd5e7e03:
+  _137b9762bccbb06542ad04fc36291b3b:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_VERSION=10 defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 10
@@ -1501,10 +1501,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _eabd42e7d56b3a0a9c15e6397695d96d:
+  _29bfb1df7da745aeb69bab0885f5ed33:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=i386 LLVM=1 LLVM_VERSION=10 defconfig
+    name: ARCH=i386 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 defconfig
     env:
       ARCH: i386
       LLVM_VERSION: 10
@@ -1522,10 +1522,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _020e9ff944ea1e8472762c351ebd39dd:
+  _498b595c528a335a6f8a07ad5a1e04a1:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=10 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=10 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 10
@@ -1543,10 +1543,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _bc8fce7c23996324100110dee4d6e7b6:
+  _edab6b2cb7f6bf3b3449fd8b1d3c9e3f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=10 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
+    name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 10
@@ -1564,10 +1564,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _fdfe2bd2dd6501370696b38b3fb41fc3:
+  _f5f31e26bad48603013ba892645efe90:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=10 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=10 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 10
@@ -1585,10 +1585,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _470bd3fa38c92f94b430e3a89466a304:
+  _f88da53785133963cbd4590f904b7a18:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_VERSION=10 defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 10
@@ -1894,10 +1894,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8ac7dc49dd78e3da5da453b0286a3db9:
+  _17f0345420b6ade6aeacc3497eb5fe79:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=powerpc CC=clang LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
@@ -1915,10 +1915,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8e99d599d12ce5188c1eec382f5d381a:
+  _409b28e38bc385e6d3d3068f3489ea8c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=powerpc CC=clang LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
@@ -1957,10 +1957,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _f146445a237ee546fe925cad19fbf487:
+  _306cd6f0d8de501c4ecfdc903ce9f4a1:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=s390 CC=clang LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: s390
       LLVM_VERSION: 13
@@ -1978,10 +1978,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _bbd010a085fe128a785768612e27d1ac:
+  _20c70aed2de0e5913ffc04e55d5b2480:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=s390 CC=clang LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     env:
       ARCH: s390
       LLVM_VERSION: 13
@@ -2146,10 +2146,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e0faf7981c78617941c48bb39357dfa5:
+  _8a7f0138d12509886a29c0b8b2b90e80:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -2167,10 +2167,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a3c122fc012130191ce34a8fc1ed2809:
+  _83e582866c8e77c704428984335400c0:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 allnoconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allnoconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -2188,10 +2188,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ac352b89ff0b84ba7baaec44be7d4fd9:
+  _f67567decbe181f7dac1cebae6b752c2:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allyesconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -2209,10 +2209,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _5158262b2037b7eef0a164fb221f1a07:
+  _5956d62ae6edadd4596591a4267ef913:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -2230,10 +2230,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _5bea09f74c984839f9223c0d5a33c49e:
+  _c65a27b37c5a7caf522020d62a097166:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -2419,10 +2419,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _21204a078408fce7503dbbd442ca56e8:
+  _6f15f90c890fd785747516d4c39c77a6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=powerpc CC=clang LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
@@ -2440,10 +2440,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a162457ff11356e18e60fd1fb96e5767:
+  _a1c5ea612cdbf834b80c6187336f6949:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=powerpc CC=clang LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
@@ -2461,10 +2461,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _69780c23496313bf0a3a6ce2b25e491f:
+  _0445e3ea394f4e6c3ab23a8dfa84d3e4:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: riscv
       LLVM_VERSION: 12
@@ -2629,10 +2629,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _79c2e713ed9fc3c4381862731d8a664a:
+  _565b3ebd0db7f13bc44114dbc4ce6faa:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=11 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -2650,10 +2650,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _56d21d0eba24aae15e0e7ba0cdd3e62a:
+  _98be35eea81be1fc7cfea5f125dacb85:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=11 allnoconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allnoconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -2671,10 +2671,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ee24c08b15f5892fb5e38906315c0280:
+  _e4b5a7cb392bd67d52690ece87b3e80f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=11 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allyesconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -2692,10 +2692,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _99880280cc3f7095b53004becdf63d5f:
+  _9787aef428bca7a8aa1b80968a889942:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -2713,10 +2713,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _94905be3aafbbbb231e98c69ffb260c3:
+  _a56d649bf59d04b145998497ffd3d36c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -2902,10 +2902,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _3e6d01dabfb8d9bc7913f180879d45d2:
+  _33c4e124f55a998679c38207caccf044:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=powerpc CC=clang LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
@@ -2923,10 +2923,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _4b76e11587e4317d4934b8028dab781c:
+  _25f87da1043f926ba53aee8e9493b399:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=powerpc CC=clang LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
@@ -2944,10 +2944,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _6112162abd0dfe3104d1695d1fea246a:
+  _c71a33af9a96021296554421ae3e3cfb:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_VERSION=11 allmodconfig
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig
     env:
       ARCH: riscv
       LLVM_VERSION: 11
@@ -3112,10 +3112,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ddf8469de853cf3933134d74e60236c8:
+  _56f04e51c99a42d025a820038622edb0:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=10 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 10
@@ -3133,10 +3133,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _2583338fda83d6bb9e0812d6893b5e66:
+  _b608d3f0e09f3a645090be6332486080:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=10 allnoconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 allnoconfig
     env:
       ARCH: arm
       LLVM_VERSION: 10
@@ -3154,10 +3154,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _bdbb31074288296e76bd079fa36d9c51:
+  _bc95ad4fabbd7c72e2ce72553f0aa944:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=10 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 allyesconfig
     env:
       ARCH: arm
       LLVM_VERSION: 10
@@ -3175,10 +3175,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a378f3a9640f6d51ad394cfd3e58cdcf:
+  _24ddbfe1b6a9f253ab32bd9549a4dab3:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_VERSION=10 allnoconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 allnoconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 10
@@ -3196,10 +3196,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _7404b0f622477899bc4752b39f7c92fe:
+  _c8dc16fb21bddc7841fe84996396c772:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_VERSION=10 allnoconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 allnoconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 10

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -367,10 +367,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _3ff9dd832a367410f07232e142fa8650:
+  _48a57be25b36aba020e19ff27fcc54a4:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 ppc44x_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 ppc44x_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
@@ -388,10 +388,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ffc1134a05ecdc0f72e9a91ff18808f4:
+  _c0b585545a490a64b13d51c861610e3c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=13 pseries_defconfig
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=13 pseries_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
@@ -409,10 +409,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _069dcf551c46228c7070e4764927aa88:
+  _848b558acb7e2487ba2d59cd1a85aa7a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=13 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
@@ -451,10 +451,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _fee5569ddd8b71b19e7fb517769de851:
+  _5efcbae1959e140c37060595422c0e64:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=s390 CC=clang LLVM_VERSION=13 defconfig
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 defconfig
     env:
       ARCH: s390
       LLVM_VERSION: 13
@@ -556,10 +556,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a11abf02e18322177d92417220207cb8:
+  _39967e62e3e6ddc7694ef9844103270f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 multi_v5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -577,10 +577,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _6f7c758da41b41b25476334cfd2afd0e:
+  _2d617a0693d6cbc319274e7d1a888bc5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 aspeed_g5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 aspeed_g5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -598,10 +598,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _60ecbb939df9a7399fa560fa887f0132:
+  _fa79ae3dbe7872500bce9bf269972939:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 multi_v7_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -619,10 +619,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _267d8195f8748ce0c5d40740008e5dde:
+  _770b21725a2daf535b47afe6f68001bc:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -640,10 +640,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _83682cb2a47ad2c91afee3391d07e27d:
+  _a980878231cd6e2db930c1452d3825c2:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 imx_v4_v5_defconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 imx_v4_v5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -661,10 +661,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _7720719bb45ee91fc437e4e2b9b4849d:
+  _aa063a2bed61222ee081b8f9d5cef4bb:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 omap2plus_defconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 omap2plus_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -682,10 +682,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _b2f35e5f085a2fcb0f38aef8b1e7ea7d:
+  _c13599a70b23e23c511f4c327c9aea77:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -871,10 +871,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _535ebd7ca1798dda46eccb404aea7620:
+  _6a30520d164c342e0191a1a2f5c3ae67:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_VERSION=12 ppc44x_defconfig
+    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 ppc44x_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
@@ -892,10 +892,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _dbfb1afee12b5bc2178bd79c1ca36bc9:
+  _2731e549c1005e11869f2cbf544e46e1:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=12 pseries_defconfig
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=12 pseries_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
@@ -913,10 +913,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _4929805e7a2ad956b20f06354ba6557f:
+  _e7d400a7f60ea696f730ba8de7f3d281:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_VERSION=12 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
@@ -1018,10 +1018,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _326167b20a9a6ecc06fa9d1b2aba10f3:
+  _3ae3531548c624e92b5e217f7cebdcc2:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=11 multi_v5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -1039,10 +1039,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _c60cf38875a5399afa4b11ba4d6ef6a7:
+  _75528eaffeb79bcc9118acaee19466a9:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=11 aspeed_g5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 aspeed_g5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -1060,10 +1060,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e568393d55ec884da44c831f42852904:
+  _f045ace3044bbc7c295921e10b3bc6d1:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=11 multi_v7_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -1081,10 +1081,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _f32548095474a8341719241e481106cd:
+  _27376e72305e073694aefb13f554665f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=11 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -1102,10 +1102,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8580b9e52c1bf221a87bcea328a1e26b:
+  _050101081cc5af5e12c7347491bfbb57:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=11 imx_v4_v5_defconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 imx_v4_v5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -1123,10 +1123,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _fa2ffecc19a6f5e0e73ac93f10279e98:
+  _1ae1af112dbdceec19311ed66924bb9a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=11 omap2plus_defconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 omap2plus_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -1144,10 +1144,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _c5c2fd6a0796369d8a9a14eef4111c2c:
+  _4afa87435ae9249b1597002b8bed68d2:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=11 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -1270,10 +1270,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _d5751ecccab4f8123d49f1ff7e7c87f5:
+  _772f9a8c79e52c6ee000b01cab13b4f6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 11
@@ -1291,10 +1291,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _4199aee554a613fda64b1eacc81b5add:
+  _91bbbe2f66767e2566aad8a1f0e4ada4:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
+    name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 11
@@ -1312,10 +1312,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _1f78fa93ea4d3467dfbba5688f76a298:
+  _e96b0d0f9698e45a12b0f7d394eaa634:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=11 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
@@ -1417,10 +1417,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _fd8f5d7d3d038c2feafce905c5abfb27:
+  _6692825e3a7b84aa03ce5982176b9200:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=10 multi_v5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 multi_v5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 10
@@ -1438,10 +1438,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a751f22e6ba9bbdb1039ee3895125370:
+  _7ce6505ac8e3234bf7f120923864f556:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LD=arm-linux-gnueabihf-ld LLVM_VERSION=10 aspeed_g5_defconfig
+    name: ARCH=arm LLVM=1 LD=arm-linux-gnueabihf-ld LLVM_IAS=0 LLVM_VERSION=10 aspeed_g5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 10
@@ -1459,10 +1459,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _929ef902a624959eb09c397923751212:
+  _8d4c408eb0725ebb7d15550f73f0d1af:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=10 multi_v7_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 multi_v7_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: 10
@@ -1480,10 +1480,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _63a27c3bcba04fab80b30ca454b2a2a9:
+  _907678d6077bc2f81d0595856d171e8c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=10 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     env:
       ARCH: arm
       LLVM_VERSION: 10
@@ -1501,10 +1501,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _9a919af0584ad3314340747afd5e7e03:
+  _137b9762bccbb06542ad04fc36291b3b:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_VERSION=10 defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 10
@@ -1522,10 +1522,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _eabd42e7d56b3a0a9c15e6397695d96d:
+  _29bfb1df7da745aeb69bab0885f5ed33:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=i386 LLVM=1 LLVM_VERSION=10 defconfig
+    name: ARCH=i386 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 defconfig
     env:
       ARCH: i386
       LLVM_VERSION: 10
@@ -1543,10 +1543,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _020e9ff944ea1e8472762c351ebd39dd:
+  _498b595c528a335a6f8a07ad5a1e04a1:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_VERSION=10 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
+    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=10 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     env:
       ARCH: mips
       LLVM_VERSION: 10
@@ -1564,10 +1564,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _bc8fce7c23996324100110dee4d6e7b6:
+  _edab6b2cb7f6bf3b3449fd8b1d3c9e3f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=mips LLVM=1 LLVM_VERSION=10 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
+    name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     env:
       ARCH: mips
       LLVM_VERSION: 10
@@ -1585,10 +1585,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _fdfe2bd2dd6501370696b38b3fb41fc3:
+  _f5f31e26bad48603013ba892645efe90:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_VERSION=10 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=10 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 10
@@ -1606,10 +1606,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _470bd3fa38c92f94b430e3a89466a304:
+  _f88da53785133963cbd4590f904b7a18:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_VERSION=10 defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 10
@@ -1648,10 +1648,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _1e704c0f0de4b2a4bfb08e01f0ce6142:
+  _a82d5da76edb25de07265b1189803b21:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=android aspeed_g5_defconfig
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=android aspeed_g5_defconfig
     env:
       ARCH: arm
       LLVM_VERSION: android
@@ -2167,10 +2167,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8ac7dc49dd78e3da5da453b0286a3db9:
+  _17f0345420b6ade6aeacc3497eb5fe79:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=powerpc CC=clang LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
@@ -2188,10 +2188,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8e99d599d12ce5188c1eec382f5d381a:
+  _409b28e38bc385e6d3d3068f3489ea8c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=powerpc CC=clang LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
@@ -2230,10 +2230,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _f146445a237ee546fe925cad19fbf487:
+  _306cd6f0d8de501c4ecfdc903ce9f4a1:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=s390 CC=clang LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: s390
       LLVM_VERSION: 13
@@ -2251,10 +2251,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _bbd010a085fe128a785768612e27d1ac:
+  _20c70aed2de0e5913ffc04e55d5b2480:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=s390 CC=clang LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     env:
       ARCH: s390
       LLVM_VERSION: 13
@@ -2419,10 +2419,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e0faf7981c78617941c48bb39357dfa5:
+  _8a7f0138d12509886a29c0b8b2b90e80:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -2440,10 +2440,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a3c122fc012130191ce34a8fc1ed2809:
+  _83e582866c8e77c704428984335400c0:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 allnoconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allnoconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -2461,10 +2461,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ac352b89ff0b84ba7baaec44be7d4fd9:
+  _f67567decbe181f7dac1cebae6b752c2:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=12 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allyesconfig
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -2482,10 +2482,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _5158262b2037b7eef0a164fb221f1a07:
+  _5956d62ae6edadd4596591a4267ef913:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -2503,10 +2503,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _5bea09f74c984839f9223c0d5a33c49e:
+  _c65a27b37c5a7caf522020d62a097166:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     env:
       ARCH: arm
       LLVM_VERSION: 12
@@ -2692,10 +2692,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _21204a078408fce7503dbbd442ca56e8:
+  _6f15f90c890fd785747516d4c39c77a6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=powerpc CC=clang LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
@@ -2713,10 +2713,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a162457ff11356e18e60fd1fb96e5767:
+  _a1c5ea612cdbf834b80c6187336f6949:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=powerpc CC=clang LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
@@ -2734,10 +2734,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _69780c23496313bf0a3a6ce2b25e491f:
+  _0445e3ea394f4e6c3ab23a8dfa84d3e4:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: riscv
       LLVM_VERSION: 12
@@ -2902,10 +2902,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _79c2e713ed9fc3c4381862731d8a664a:
+  _565b3ebd0db7f13bc44114dbc4ce6faa:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=11 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -2923,10 +2923,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _56d21d0eba24aae15e0e7ba0cdd3e62a:
+  _98be35eea81be1fc7cfea5f125dacb85:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=11 allnoconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allnoconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -2944,10 +2944,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ee24c08b15f5892fb5e38906315c0280:
+  _e4b5a7cb392bd67d52690ece87b3e80f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=11 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allyesconfig
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -2965,10 +2965,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _99880280cc3f7095b53004becdf63d5f:
+  _9787aef428bca7a8aa1b80968a889942:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -2986,10 +2986,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _94905be3aafbbbb231e98c69ffb260c3:
+  _a56d649bf59d04b145998497ffd3d36c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm LLVM=1 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     env:
       ARCH: arm
       LLVM_VERSION: 11
@@ -3175,10 +3175,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _3e6d01dabfb8d9bc7913f180879d45d2:
+  _33c4e124f55a998679c38207caccf044:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=powerpc CC=clang LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
@@ -3196,10 +3196,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _4b76e11587e4317d4934b8028dab781c:
+  _25f87da1043f926ba53aee8e9493b399:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=powerpc CC=clang LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
@@ -3217,10 +3217,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _6112162abd0dfe3104d1695d1fea246a:
+  _c71a33af9a96021296554421ae3e3cfb:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_VERSION=11 allmodconfig
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig
     env:
       ARCH: riscv
       LLVM_VERSION: 11
@@ -3385,10 +3385,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ddf8469de853cf3933134d74e60236c8:
+  _56f04e51c99a42d025a820038622edb0:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=10 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: 10
@@ -3406,10 +3406,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _2583338fda83d6bb9e0812d6893b5e66:
+  _b608d3f0e09f3a645090be6332486080:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=10 allnoconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 allnoconfig
     env:
       ARCH: arm
       LLVM_VERSION: 10
@@ -3427,10 +3427,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _bdbb31074288296e76bd079fa36d9c51:
+  _bc95ad4fabbd7c72e2ce72553f0aa944:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=10 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 allyesconfig
     env:
       ARCH: arm
       LLVM_VERSION: 10
@@ -3448,10 +3448,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a378f3a9640f6d51ad394cfd3e58cdcf:
+  _24ddbfe1b6a9f253ab32bd9549a4dab3:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_VERSION=10 allnoconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 allnoconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 10
@@ -3469,10 +3469,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _7404b0f622477899bc4752b39f7c92fe:
+  _c8dc16fb21bddc7841fe84996396c772:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_VERSION=10 allnoconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 allnoconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 10
@@ -3490,10 +3490,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _11a0db5926cfedaac47a461c1f768b52:
+  _b79dc2edc3fda12d85ac78ca2b081960:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=android allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=android allmodconfig
     env:
       ARCH: arm
       LLVM_VERSION: android
@@ -3532,10 +3532,10 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _b37c37f00a5fab86706f218702b50a50:
+  _eef2fa4c94ab7adb8bb82dd2c8595893:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_VERSION=android allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=android allyesconfig
     env:
       ARCH: arm
       LLVM_VERSION: android

--- a/generate_workflow.py
+++ b/generate_workflow.py
@@ -81,9 +81,7 @@ def get_job_name(build):
     # If LD was specified, show what it is
     if "make_variables" in build and "LD" in build["make_variables"]:
         job += " LD=" + str(build["make_variables"]["LD"])
-    # LLVM_IAS=0 is the default. Only show when we have opted into LLVM_IAS.
-    if build["llvm_ias"]:
-        job += " LLVM_IAS=1"
+    job += " LLVM_IAS=" + str(build["make_variables"]["LLVM_IAS"])
     # Having "LLVM <VER>" is a little hard to parse, make it look like
     # an environment variable
     job += " LLVM_VERSION=" + str(build["llvm_version"])

--- a/generator.yml
+++ b/generator.yml
@@ -145,19 +145,19 @@ configs:
 tiers:
   # Generic tiers       LLVM=1       LLVM_IAS=1        Make variables to pass to TuxSuite
   - &llvm_full          {llvm: true,  llvm_ias: true,  make_variables: {LLVM: 1, LLVM_IAS: 1}}
-  - &llvm               {llvm: true,  llvm_ias: false, make_variables: {LLVM: 1}}
-  - &lld                {llvm: false, llvm_ias: false, make_variables: {LD: ld.lld}}
-  - &clang              {llvm: false, llvm_ias: false}
+  - &llvm               {llvm: true,  llvm_ias: false, make_variables: {LLVM: 1, LLVM_IAS: 0}}
+  - &lld                {llvm: false, llvm_ias: false, make_variables: {LD: ld.lld, LLVM_IAS: 0}}
+  - &clang              {llvm: false, llvm_ias: false, make_variables: {LLVM_IAS: 0}}
   # Architecture specific tiers
   # ARM32 aspeed_g5_defconfig                                           https://github.com/ClangBuiltLinux/linux/issues/732
-  - &arm32_v6_llvm      {llvm: true,  llvm_ias: false, make_variables: {LD: arm-linux-gnueabihf-ld, LLVM: 1}}
+  - &arm32_v6_llvm      {llvm: true,  llvm_ias: false, make_variables: {LD: arm-linux-gnueabihf-ld, LLVM: 1, LLVM_IAS: 0}}
   # ARM64 for CROSS_COMPILE_COMPAT
   - &arm64_llvm_full    {llvm: true,  llvm_ias: true,  make_variables: {CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-, LLVM: 1, LLVM_IAS: 1}}
   # MIPS big endian                                                     https://github.com/ClangBuiltLinux/linux/issues/1025
-  - &mips_llvm          {llvm: true,  llvm_ias: false, make_variables: {LD: mips-linux-gnu-ld, LLVM: 1}}
+  - &mips_llvm          {llvm: true,  llvm_ias: false, make_variables: {LD: mips-linux-gnu-ld, LLVM: 1, LLVM_IAS: 0}}
   - &mips_llvm_full     {llvm: true,  llvm_ias: true,  make_variables: {LD: mips-linux-gnu-ld, LLVM: 1, LLVM_IAS: 1}}
   # PowerPC 64-bit big endian                                           https://github.com/ClangBuiltLinux/linux/issues/602 and https://github.com/ClangBuiltLinux/linux/issues/1260
-  - &ppc64_llvm         {llvm: true,  llvm_ias: false, make_variables: {LD: powerpc64le-linux-gnu-ld, LLVM: 1}}
+  - &ppc64_llvm         {llvm: true,  llvm_ias: false, make_variables: {LD: powerpc64le-linux-gnu-ld, LLVM: 1, LLVM_IAS: 0}}
   # RISC-V                                                              https://github.com/ClangBuiltLinux/linux/issues/1020 and https://github.com/ClangBuiltLinux/linux/issues/1409
   - &riscv_llvm_full    {llvm: true,  llvm_ias: true,  make_variables: {LD: riscv64-linux-gnu-ld, LLVM: 1, LLVM_IAS: 1}}
 builds:

--- a/tuxsuite/4.14.tux.yml
+++ b/tuxsuite/4.14.tux.yml
@@ -15,6 +15,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-4.14.y
     target_arch: arm
@@ -26,6 +28,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-4.14.y
     target_arch: arm64
@@ -37,6 +41,7 @@ sets:
     - modules
     make_variables:
       LD: ld.lld
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-4.14.y
     target_arch: arm64
@@ -50,6 +55,7 @@ sets:
     - modules
     make_variables:
       LD: ld.lld
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-4.14.y
     target_arch: powerpc
@@ -60,6 +66,8 @@ sets:
     - kernel
     - modules
     kernel_image: zImage.epapr
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-4.14.y
     target_arch: x86_64
@@ -71,4 +79,5 @@ sets:
     - modules
     make_variables:
       LD: ld.lld
+      LLVM_IAS: 0
 

--- a/tuxsuite/4.19.tux.yml
+++ b/tuxsuite/4.19.tux.yml
@@ -17,6 +17,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-4.19.y
     target_arch: arm
@@ -30,6 +31,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-4.19.y
     target_arch: arm64
@@ -41,6 +43,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-4.19.y
     target_arch: arm64
@@ -54,6 +57,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-4.19.y
     target_arch: powerpc
@@ -64,6 +68,8 @@ sets:
     - kernel
     - modules
     kernel_image: zImage.epapr
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-4.19.y
     target_arch: x86_64
@@ -75,4 +81,5 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
 

--- a/tuxsuite/4.4.tux.yml
+++ b/tuxsuite/4.4.tux.yml
@@ -15,6 +15,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-4.4.y
     target_arch: arm64
@@ -26,6 +28,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-4.4.y
     target_arch: x86_64
@@ -37,4 +41,5 @@ sets:
     - modules
     make_variables:
       LD: ld.lld
+      LLVM_IAS: 0
 

--- a/tuxsuite/4.9.tux.yml
+++ b/tuxsuite/4.9.tux.yml
@@ -15,6 +15,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-4.9.y
     target_arch: arm64
@@ -24,6 +26,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-4.9.y
     target_arch: arm64
@@ -35,6 +39,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-4.9.y
     target_arch: x86_64
@@ -46,4 +52,5 @@ sets:
     - modules
     make_variables:
       LD: ld.lld
+      LLVM_IAS: 0
 

--- a/tuxsuite/5.10.tux.yml
+++ b/tuxsuite/5.10.tux.yml
@@ -18,6 +18,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm
@@ -30,6 +31,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm
@@ -41,6 +43,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm
@@ -54,6 +57,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm64
@@ -108,6 +112,7 @@ sets:
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: mips
@@ -122,6 +127,7 @@ sets:
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: powerpc
@@ -134,6 +140,7 @@ sets:
     kernel_image: uImage
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: powerpc
@@ -147,6 +154,7 @@ sets:
     make_variables:
       LD: powerpc64le-linux-gnu-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: powerpc
@@ -159,6 +167,7 @@ sets:
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: riscv
@@ -182,6 +191,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: x86_64
@@ -206,6 +217,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm
@@ -218,6 +230,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm
@@ -229,6 +242,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm
@@ -242,6 +256,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm64
@@ -283,6 +298,7 @@ sets:
     make_variables:
       LD: mips-linux-gnu-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: mips
@@ -297,6 +313,7 @@ sets:
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: powerpc
@@ -309,6 +326,7 @@ sets:
     kernel_image: uImage
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: powerpc
@@ -322,6 +340,7 @@ sets:
     make_variables:
       LD: powerpc64le-linux-gnu-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: powerpc
@@ -334,6 +353,7 @@ sets:
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: riscv
@@ -359,6 +379,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: x86_64
@@ -383,6 +405,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm
@@ -395,6 +418,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm
@@ -406,6 +430,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm
@@ -419,6 +444,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm64
@@ -460,6 +486,7 @@ sets:
     make_variables:
       LD: mips-linux-gnu-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: mips
@@ -474,6 +501,7 @@ sets:
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: powerpc
@@ -486,6 +514,7 @@ sets:
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: riscv
@@ -511,6 +540,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: x86_64
@@ -536,6 +567,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm
@@ -559,6 +591,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm64
@@ -644,6 +677,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm
@@ -655,6 +689,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm
@@ -666,6 +701,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm64
@@ -751,6 +787,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm
@@ -762,6 +799,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm
@@ -773,6 +811,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.10.y
     target_arch: arm64

--- a/tuxsuite/5.4.tux.yml
+++ b/tuxsuite/5.4.tux.yml
@@ -17,6 +17,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.4.y
     target_arch: arm
@@ -30,6 +31,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.4.y
     target_arch: arm64
@@ -71,6 +73,7 @@ sets:
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.4.y
     target_arch: mips
@@ -85,6 +88,7 @@ sets:
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.4.y
     target_arch: powerpc
@@ -97,6 +101,7 @@ sets:
     kernel_image: uImage
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.4.y
     target_arch: powerpc
@@ -110,6 +115,7 @@ sets:
     make_variables:
       LD: powerpc64le-linux-gnu-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.4.y
     target_arch: powerpc
@@ -122,6 +128,7 @@ sets:
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.4.y
     target_arch: x86_64

--- a/tuxsuite/android-4.14.tux.yml
+++ b/tuxsuite/android-4.14.tux.yml
@@ -17,6 +17,7 @@ sets:
     - modules
     make_variables:
       LD: ld.lld
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android-4.14-stable
     target_arch: x86_64
@@ -28,6 +29,7 @@ sets:
     - modules
     make_variables:
       LD: ld.lld
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android-4.14-stable
     target_arch: arm64
@@ -39,6 +41,7 @@ sets:
     - modules
     make_variables:
       LD: ld.lld
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android-4.14-stable
     target_arch: x86_64
@@ -50,6 +53,7 @@ sets:
     - modules
     make_variables:
       LD: ld.lld
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android-4.14-stable
     target_arch: arm64
@@ -61,6 +65,7 @@ sets:
     - modules
     make_variables:
       LD: ld.lld
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android-4.14-stable
     target_arch: x86_64
@@ -72,4 +77,5 @@ sets:
     - modules
     make_variables:
       LD: ld.lld
+      LLVM_IAS: 0
 

--- a/tuxsuite/android-4.9.tux.yml
+++ b/tuxsuite/android-4.9.tux.yml
@@ -15,6 +15,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android-4.9-q
     target_arch: x86_64
@@ -24,6 +26,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android-4.9-q
     target_arch: arm64
@@ -33,6 +37,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android-4.9-q
     target_arch: x86_64
@@ -42,6 +48,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android-4.9-q
     target_arch: arm64
@@ -51,6 +59,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android-4.9-q
     target_arch: x86_64
@@ -60,4 +70,6 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
 

--- a/tuxsuite/android-mainline.tux.yml
+++ b/tuxsuite/android-mainline.tux.yml
@@ -58,6 +58,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android-mainline
     target_arch: arm64
@@ -146,6 +147,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android-mainline
     target_arch: arm

--- a/tuxsuite/android12-5.10.tux.yml
+++ b/tuxsuite/android12-5.10.tux.yml
@@ -58,6 +58,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android12-5.10
     target_arch: arm64
@@ -146,6 +147,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android12-5.10
     target_arch: arm

--- a/tuxsuite/android12-5.4.tux.yml
+++ b/tuxsuite/android12-5.4.tux.yml
@@ -19,6 +19,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android12-5.4
     target_arch: arm64
@@ -57,6 +58,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android12-5.4
     target_arch: arm64
@@ -95,6 +97,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android12-5.4
     target_arch: arm64
@@ -144,6 +147,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android12-5.4
     target_arch: arm

--- a/tuxsuite/android13-5.10.tux.yml
+++ b/tuxsuite/android13-5.10.tux.yml
@@ -58,6 +58,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android13-5.10
     target_arch: arm64
@@ -146,6 +147,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android13-5.10
     target_arch: arm

--- a/tuxsuite/mainline.tux.yml
+++ b/tuxsuite/mainline.tux.yml
@@ -237,6 +237,7 @@ sets:
     kernel_image: uImage
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: powerpc
@@ -250,6 +251,7 @@ sets:
     make_variables:
       LD: powerpc64le-linux-gnu-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: powerpc
@@ -262,6 +264,7 @@ sets:
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: riscv
@@ -284,6 +287,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: x86_64
@@ -336,6 +341,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -348,6 +354,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -359,6 +366,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -372,6 +380,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -383,6 +392,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -394,6 +404,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -408,6 +419,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm64
@@ -535,6 +547,7 @@ sets:
     kernel_image: uImage
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: powerpc
@@ -548,6 +561,7 @@ sets:
     make_variables:
       LD: powerpc64le-linux-gnu-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: powerpc
@@ -560,6 +574,7 @@ sets:
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: riscv
@@ -628,6 +643,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -640,6 +656,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -651,6 +668,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -664,6 +682,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -675,6 +694,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -686,6 +706,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -700,6 +721,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm64
@@ -783,6 +805,7 @@ sets:
     make_variables:
       LD: mips-linux-gnu-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: mips
@@ -797,6 +820,7 @@ sets:
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: powerpc
@@ -810,6 +834,7 @@ sets:
     make_variables:
       LD: powerpc64le-linux-gnu-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: riscv
@@ -878,6 +903,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -891,6 +917,7 @@ sets:
     make_variables:
       LD: arm-linux-gnueabihf-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -902,6 +929,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -915,6 +943,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm64
@@ -926,6 +955,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: i386
@@ -937,6 +967,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: mips
@@ -953,6 +984,7 @@ sets:
     make_variables:
       LD: mips-linux-gnu-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: mips
@@ -967,6 +999,7 @@ sets:
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: powerpc
@@ -980,6 +1013,7 @@ sets:
     make_variables:
       LD: powerpc64le-linux-gnu-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: x86_64
@@ -991,6 +1025,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
 - name: allconfigs
   builds:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1178,6 +1213,8 @@ sets:
     - kernel
     - modules
     kernel_image: zImage.epapr
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: powerpc
@@ -1188,6 +1225,8 @@ sets:
     - kernel
     - modules
     kernel_image: zImage.epapr
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: riscv
@@ -1212,6 +1251,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: s390
@@ -1221,6 +1262,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: x86_64
@@ -1320,6 +1363,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -1331,6 +1375,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -1342,6 +1387,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -1355,6 +1401,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -1366,6 +1413,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm64
@@ -1489,6 +1537,8 @@ sets:
     - kernel
     - modules
     kernel_image: zImage.epapr
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: powerpc
@@ -1499,6 +1549,8 @@ sets:
     - kernel
     - modules
     kernel_image: zImage.epapr
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: riscv
@@ -1511,6 +1563,7 @@ sets:
     kernel_image: Image
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: x86_64
@@ -1610,6 +1663,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -1621,6 +1675,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -1632,6 +1687,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -1645,6 +1701,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -1656,6 +1713,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm64
@@ -1779,6 +1837,8 @@ sets:
     - kernel
     - modules
     kernel_image: zImage.epapr
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: powerpc
@@ -1789,6 +1849,8 @@ sets:
     - kernel
     - modules
     kernel_image: zImage.epapr
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: riscv
@@ -1801,6 +1863,7 @@ sets:
     kernel_image: Image
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: x86_64
@@ -1900,6 +1963,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -1911,6 +1975,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm
@@ -1922,6 +1987,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: arm64
@@ -1933,6 +1999,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: x86_64
@@ -1944,4 +2011,5 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
 

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -237,6 +237,7 @@ sets:
     kernel_image: uImage
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: powerpc
@@ -250,6 +251,7 @@ sets:
     make_variables:
       LD: powerpc64le-linux-gnu-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: powerpc
@@ -262,6 +264,7 @@ sets:
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: riscv
@@ -284,6 +287,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: x86_64
@@ -351,6 +356,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -363,6 +369,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -374,6 +381,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -387,6 +395,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -398,6 +407,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -409,6 +419,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -423,6 +434,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm64
@@ -550,6 +562,7 @@ sets:
     kernel_image: uImage
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: powerpc
@@ -563,6 +576,7 @@ sets:
     make_variables:
       LD: powerpc64le-linux-gnu-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: powerpc
@@ -575,6 +589,7 @@ sets:
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: riscv
@@ -643,6 +658,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -655,6 +671,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -666,6 +683,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -679,6 +697,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -690,6 +709,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -701,6 +721,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -715,6 +736,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm64
@@ -798,6 +820,7 @@ sets:
     make_variables:
       LD: mips-linux-gnu-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: mips
@@ -812,6 +835,7 @@ sets:
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: powerpc
@@ -825,6 +849,7 @@ sets:
     make_variables:
       LD: powerpc64le-linux-gnu-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: riscv
@@ -893,6 +918,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -906,6 +932,7 @@ sets:
     make_variables:
       LD: arm-linux-gnueabihf-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -917,6 +944,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -930,6 +958,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm64
@@ -941,6 +970,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: i386
@@ -952,6 +982,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: mips
@@ -968,6 +999,7 @@ sets:
     make_variables:
       LD: mips-linux-gnu-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: mips
@@ -982,6 +1014,7 @@ sets:
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: powerpc
@@ -995,6 +1028,7 @@ sets:
     make_variables:
       LD: powerpc64le-linux-gnu-ld
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: x86_64
@@ -1006,6 +1040,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -1031,6 +1066,7 @@ sets:
     - dtbs
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -1351,6 +1387,8 @@ sets:
     - kernel
     - modules
     kernel_image: zImage.epapr
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: powerpc
@@ -1361,6 +1399,8 @@ sets:
     - kernel
     - modules
     kernel_image: zImage.epapr
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: riscv
@@ -1385,6 +1425,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: s390
@@ -1394,6 +1436,8 @@ sets:
     - config
     - kernel
     - modules
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: x86_64
@@ -1493,6 +1537,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -1504,6 +1549,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -1515,6 +1561,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -1528,6 +1575,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -1539,6 +1587,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm64
@@ -1662,6 +1711,8 @@ sets:
     - kernel
     - modules
     kernel_image: zImage.epapr
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: powerpc
@@ -1672,6 +1723,8 @@ sets:
     - kernel
     - modules
     kernel_image: zImage.epapr
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: riscv
@@ -1684,6 +1737,7 @@ sets:
     kernel_image: Image
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: x86_64
@@ -1783,6 +1837,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -1794,6 +1849,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -1805,6 +1861,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -1818,6 +1875,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -1829,6 +1887,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm64
@@ -1952,6 +2011,8 @@ sets:
     - kernel
     - modules
     kernel_image: zImage.epapr
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: powerpc
@@ -1962,6 +2023,8 @@ sets:
     - kernel
     - modules
     kernel_image: zImage.epapr
+    make_variables:
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: riscv
@@ -1974,6 +2037,7 @@ sets:
     kernel_image: Image
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: x86_64
@@ -2073,6 +2137,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -2084,6 +2149,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -2095,6 +2161,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm64
@@ -2106,6 +2173,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: x86_64
@@ -2117,6 +2185,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -2128,6 +2197,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm
@@ -2151,6 +2221,7 @@ sets:
     - modules
     make_variables:
       LLVM: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: arm64


### PR DESCRIPTION
LLVM_IAS=1 is now the default in -next, meaning we need to specify
LLVM_IAS=0 to keep our builds green.

While some of these do not strictly need LLVM_IAS=0 because they are
used on older tree, it is better to be explicit than implicit.