### PR TITLE
Disable CONFIG_ATOMIC64_SELFTEST for Fedora's i686 config

### DIFF
--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -2209,16 +2209,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _831adaa701b4d758e7e6adca97c72b07:
+  _56e6880015e5f4109c6aaf83e07bfcc5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_ATOMIC64_SELFTEST=n+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: i386
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_BPF_PRELOAD=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_ATOMIC64_SELFTEST=n+CONFIG_BPF_PRELOAD=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -2482,16 +2482,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e0cfa5482bb9dc5112b2335a8cadd84c:
+  _a16d4940633b739bdef0667943f0b9a8:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_ATOMIC64_SELFTEST=n+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: i386
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_BPF_PRELOAD=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_ATOMIC64_SELFTEST=n+CONFIG_BPF_PRELOAD=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -2755,16 +2755,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _2fe036afc32d903b62d526a522143edc:
+  _d1e2b995470e409e284ae6dadbf703a6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_ATOMIC64_SELFTEST=n+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: i386
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_BPF_PRELOAD=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_ATOMIC64_SELFTEST=n+CONFIG_BPF_PRELOAD=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -2986,16 +2986,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _21d491b74db1095a72c015b4469234e2:
+  _09238b29fc27aba9cd6fbf0fc8ae74fa:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_ATOMIC64_SELFTEST=n+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: i386
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_BPF_PRELOAD=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_ATOMIC64_SELFTEST=n+CONFIG_BPF_PRELOAD=n
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -2503,16 +2503,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _831adaa701b4d758e7e6adca97c72b07:
+  _56e6880015e5f4109c6aaf83e07bfcc5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_ATOMIC64_SELFTEST=n+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: i386
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_BPF_PRELOAD=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_ATOMIC64_SELFTEST=n+CONFIG_BPF_PRELOAD=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -2776,16 +2776,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e0cfa5482bb9dc5112b2335a8cadd84c:
+  _a16d4940633b739bdef0667943f0b9a8:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_ATOMIC64_SELFTEST=n+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: i386
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_BPF_PRELOAD=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_ATOMIC64_SELFTEST=n+CONFIG_BPF_PRELOAD=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -3049,16 +3049,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _2fe036afc32d903b62d526a522143edc:
+  _d1e2b995470e409e284ae6dadbf703a6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_ATOMIC64_SELFTEST=n+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: i386
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_BPF_PRELOAD=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_ATOMIC64_SELFTEST=n+CONFIG_BPF_PRELOAD=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -3280,16 +3280,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _21d491b74db1095a72c015b4469234e2:
+  _09238b29fc27aba9cd6fbf0fc8ae74fa:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_ATOMIC64_SELFTEST=n+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: i386
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_BPF_PRELOAD=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config+CONFIG_ATOMIC64_SELFTEST=n+CONFIG_BPF_PRELOAD=n
     steps:
     - uses: actions/checkout@v2
       with:

--- a/generator.yml
+++ b/generator.yml
@@ -110,8 +110,9 @@ configs:
   - &arm64_suse        {config: [*arm64-suse-config-url, CONFIG_DEBUG_INFO_BTF=n],                                                         << : *arm64-triple,         << : *kernel_modules}
   - &hexagon           {config: defconfig,                                                                                                 << : *hexagon-triple,       << : *kernel_modules}
   - &i386              {config: defconfig,                                                                                                 << : *i386-triple,          << : *kernel_modules}
-  - &i686_fedora       {config: [*i686-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                           << : *i386-triple,          << : *kernel_modules}
+  # CONFIG_ATOMIC64_SELFTEST disabled: https://github.com/ClangBuiltLinux/linux/issues/1437
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
+  - &i686_fedora       {config: [*i686-fedora-config-url, CONFIG_ATOMIC64_SELFTEST=n, CONFIG_BPF_PRELOAD=n],                               << : *i386-triple,          << : *kernel_modules}
   - &i386_suse         {config: *i386-suse-config-url,                                                                                     << : *i386-triple,          << : *kernel_modules}
   - &mips              {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y, CONFIG_CPU_BIG_ENDIAN=y],           kernel_image: vmlinux,      << : *mips-triple,          << : *kernel_modules}
   - &mipsel            {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y],                                    kernel_image: vmlinux,      << : *mipsel-triple,        << : *kernel_modules}

--- a/tuxsuite/mainline.tux.yml
+++ b/tuxsuite/mainline.tux.yml
@@ -1413,6 +1413,7 @@ sets:
     toolchain: clang-nightly
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config
+    - CONFIG_ATOMIC64_SELFTEST=n
     - CONFIG_BPF_PRELOAD=n
     targets:
     - config
@@ -1581,6 +1582,7 @@ sets:
     toolchain: clang-13
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config
+    - CONFIG_ATOMIC64_SELFTEST=n
     - CONFIG_BPF_PRELOAD=n
     targets:
     - config
@@ -1749,6 +1751,7 @@ sets:
     toolchain: clang-12
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config
+    - CONFIG_ATOMIC64_SELFTEST=n
     - CONFIG_BPF_PRELOAD=n
     targets:
     - config
@@ -1893,6 +1896,7 @@ sets:
     toolchain: clang-11
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config
+    - CONFIG_ATOMIC64_SELFTEST=n
     - CONFIG_BPF_PRELOAD=n
     targets:
     - config

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -1602,6 +1602,7 @@ sets:
     toolchain: clang-nightly
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config
+    - CONFIG_ATOMIC64_SELFTEST=n
     - CONFIG_BPF_PRELOAD=n
     targets:
     - config
@@ -1770,6 +1771,7 @@ sets:
     toolchain: clang-13
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config
+    - CONFIG_ATOMIC64_SELFTEST=n
     - CONFIG_BPF_PRELOAD=n
     targets:
     - config
@@ -1938,6 +1940,7 @@ sets:
     toolchain: clang-12
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config
+    - CONFIG_ATOMIC64_SELFTEST=n
     - CONFIG_BPF_PRELOAD=n
     targets:
     - config
@@ -2082,6 +2085,7 @@ sets:
     toolchain: clang-11
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-i686-fedora.config
+    - CONFIG_ATOMIC64_SELFTEST=n
     - CONFIG_BPF_PRELOAD=n
     targets:
     - config


### PR DESCRIPTION
It causes erratic panics that may be related to QEMU. In order to keep
the build green, disable this config.