### PR TITLE
Error out if builds.json is not found

### DIFF
--- a/.github/workflows/4.14.yml
+++ b/.github/workflows/4.14.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _06e78da1a8285e2192c77d3abfa6d4e9:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/4.19.yml
+++ b/.github/workflows/4.19.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _64bbdb8f3d4a3e83679a0d4ce327cee5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/4.4.yml
+++ b/.github/workflows/4.4.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _5f092edd9d36e395e829f79c99eeec7b:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/4.9.yml
+++ b/.github/workflows/4.9.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _06e78da1a8285e2192c77d3abfa6d4e9:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/5.10.yml
+++ b/.github/workflows/5.10.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _0e126de07188208c81511a7e5875ba5d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -1222,6 +1223,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_allconfigs
+        if-no-files-found: error
   _90df3441040ce9141269b5c53a5149d1:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs

--- a/.github/workflows/5.4.yml
+++ b/.github/workflows/5.4.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _64bbdb8f3d4a3e83679a0d4ce327cee5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/android-4.14.yml
+++ b/.github/workflows/android-4.14.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _524451a8302126df1422580acd7db20f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/android-4.19.yml
+++ b/.github/workflows/android-4.19.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _b7027adc4194874a4adbc49c0f26629d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/android-4.9.yml
+++ b/.github/workflows/android-4.9.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _b41231c739380b3527925efba9c7a6b5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/android-mainline.yml
+++ b/.github/workflows/android-mainline.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _067b9930a3e9598b615dddd9bd3a7271:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -298,6 +299,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_allconfigs
+        if-no-files-found: error
   _017ca86b3e71799d51de2c8afd81c60b:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs

--- a/.github/workflows/android12-5.10.yml
+++ b/.github/workflows/android12-5.10.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _067b9930a3e9598b615dddd9bd3a7271:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -298,6 +299,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_allconfigs
+        if-no-files-found: error
   _017ca86b3e71799d51de2c8afd81c60b:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs

--- a/.github/workflows/android12-5.4.yml
+++ b/.github/workflows/android12-5.4.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _e8ff4074fdd3e432d55a111ea5500c7c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -298,6 +299,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_allconfigs
+        if-no-files-found: error
   _017ca86b3e71799d51de2c8afd81c60b:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs

--- a/.github/workflows/android13-5.10.yml
+++ b/.github/workflows/android13-5.10.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _067b9930a3e9598b615dddd9bd3a7271:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -298,6 +299,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_allconfigs
+        if-no-files-found: error
   _017ca86b3e71799d51de2c8afd81c60b:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs

--- a/.github/workflows/arm64-fixes.yml
+++ b/.github/workflows/arm64-fixes.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _8b6514fc2e63bf7f97f781e252c04550:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -172,6 +173,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_allconfigs
+        if-no-files-found: error
   _efbb08e8e064234fb6815e8f0019fb48:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _8b6514fc2e63bf7f97f781e252c04550:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -172,6 +173,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_allconfigs
+        if-no-files-found: error
   _efbb08e8e064234fb6815e8f0019fb48:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs

--- a/.github/workflows/lto-cfi-tip.yml
+++ b/.github/workflows/lto-cfi-tip.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _af7e49a475b3b92f8bde021b362a9ff6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/lto-cfi.yml
+++ b/.github/workflows/lto-cfi.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _af7e49a475b3b92f8bde021b362a9ff6:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _51f130b3d4f18f133015f1d5f8557347:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -2125,6 +2126,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_distribution_configs
+        if-no-files-found: error
   _9417efa1a2a916b417a8798be9c16791:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_distribution_configs
@@ -3148,6 +3150,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_allconfigs
+        if-no-files-found: error
   _017ca86b3e71799d51de2c8afd81c60b:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _51f130b3d4f18f133015f1d5f8557347:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -2419,6 +2420,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_distribution_configs
+        if-no-files-found: error
   _9417efa1a2a916b417a8798be9c16791:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_distribution_configs
@@ -3442,6 +3444,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_allconfigs
+        if-no-files-found: error
   _017ca86b3e71799d51de2c8afd81c60b:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs

--- a/.github/workflows/tip.yml
+++ b/.github/workflows/tip.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_defconfigs
+        if-no-files-found: error
   _6b9b48c5ca690a81c94f317d6baf1765:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -214,6 +215,7 @@ jobs:
       with:
         path: builds.json
         name: output_artifact_allconfigs
+        if-no-files-found: error
   _fe2c9057aa7118b7ceddc2c7bbdc8e2d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs

--- a/generate_workflow.py
+++ b/generate_workflow.py
@@ -117,7 +117,8 @@ def tuxsuite_setups(build_set, tuxsuite_yml):
                     "uses": "actions/upload-artifact@v2",
                     "with": {
                         "path": "builds.json",
-                        "name": "output_artifact_{}".format(build_set)
+                        "name": "output_artifact_{}".format(build_set),
+                        "if-no-files-found": "error"
                     },
                 }
             ]


### PR DESCRIPTION
When the tuxsuite CLI errors out because of invalid input (such as an
invalid make variable), the "tuxsuite" step in GitHub Actions passes
but all the check_logs.py steps error because builds.json is not found.
This is a little cryptic because it seems like the kernel builds
happened but they really didn't.

To make it a little easier to triage failures like this, make the upload
artifacts step error out if builds.json is not found, which means the
tuxsuite client errored out before builds were started or there was
something fatal with the builds that did happen. No builds.json file
means that check_logs.py cannot run at all so there is no point in even
letting those jobs run.