### PR TITLE
check_logs.py: Increase timeout for CONFIG_KASAN_SW_TAGS builds

### DIFF
--- a/check_logs.py
+++ b/check_logs.py
@@ -79,7 +79,11 @@ def run_boot(build):
     if "CONFIG_KASAN=y" in build["kconfig"] or \
        "CONFIG_KCSAN=y" in build["kconfig"] or \
        "CONFIG_UBSAN=y" in build["kconfig"]:
-        boot_qemu += ["-s", "4", "-t", "10m"]
+        boot_qemu += ["-s", "4"]
+        if "CONFIG_KASAN=y" in build["kconfig"]:
+            boot_qemu += ["-t", "15m"]
+        else:
+            boot_qemu += ["-t", "10m"]
     try:
         subprocess.run(boot_qemu, check=True)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
clang-11 and clang-12 builds with CONFIG_KASAN_SW_TAGS=y are incredibly
slow to boot up but clang-13 and newer builds are fine. Increase the
timeout if CONFIG_KASAN_SW_TAGS=y is in the list of configs so that we
are sure that the build timed out rather than being slow.