### PR TITLE
Test CONFIG_KASAN on s390 with clang-13+

### DIFF
--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -536,6 +536,27 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
+  _58be758bb874077e6b86f22d914b9272:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=14 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
+    env:
+      ARCH: s390
+      LLVM_VERSION: 14
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Register clang error/warning problem matcher
+      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
+    - name: Boot Test
+      run: ./check_logs.py
   _f83a8a60320f3abf313f8a5759c5391c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -1155,6 +1176,27 @@ jobs:
       INSTALL_DEPS: 1
       BOOT: 1
       CONFIG: defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Register clang error/warning problem matcher
+      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
+    - name: Boot Test
+      run: ./check_logs.py
+  _6871ff39283ff45d530dbe38ff445fab:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
+    env:
+      ARCH: s390
+      LLVM_VERSION: 13
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -536,6 +536,27 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
+  _58be758bb874077e6b86f22d914b9272:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=14 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
+    env:
+      ARCH: s390
+      LLVM_VERSION: 14
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Register clang error/warning problem matcher
+      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
+    - name: Boot Test
+      run: ./check_logs.py
   _f83a8a60320f3abf313f8a5759c5391c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
@@ -1176,6 +1197,27 @@ jobs:
       INSTALL_DEPS: 1
       BOOT: 1
       CONFIG: defconfig
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Register clang error/warning problem matcher
+      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
+    - name: Boot Test
+      run: ./check_logs.py
+  _6871ff39283ff45d530dbe38ff445fab:
+    runs-on: ubuntu-20.04
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
+    env:
+      ARCH: s390
+      LLVM_VERSION: 13
+      INSTALL_DEPS: 1
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     steps:
     - uses: actions/checkout@v2
       with:

--- a/generator.yml
+++ b/generator.yml
@@ -130,6 +130,7 @@ configs:
   #                                         https://github.com/ClangBuiltLinux/linux/issues/1143
   - &riscv_no_efi      {config: [defconfig, CONFIG_EFI=n],                                                     kernel_image: Image,        << : *riscv-triple,         << : *kernel_modules}
   - &s390              {config: defconfig,                                                                                                 << : *s390-triple,          << : *kernel_modules}
+  - &s390_kasan        {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],            << : *s390-triple,          << : *kernel_modules}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
   - &s390_fedora       {config: [*s390-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                           << : *s390-triple,          << : *kernel_modules}
   - &s390_suse         {config: *s390-suse-config-url,                                                                                     << : *s390-triple,          << : *kernel_modules}
@@ -216,6 +217,7 @@ builds:
   - {<< : *riscv,             << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_tot}
+  - {<< : *s390_kasan,        << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_tot}
   - {<< : *s390_fedora,       << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_tot}
   - {<< : *s390_suse,         << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
@@ -274,6 +276,7 @@ builds:
   - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *riscv_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_tot}
+  - {<< : *s390_kasan,        << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_tot}
   - {<< : *s390_fedora,       << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_tot}
   - {<< : *s390_suse,         << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
@@ -459,6 +462,7 @@ builds:
   - {<< : *riscv,             << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_latest}
+  - {<< : *s390_kasan,        << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_latest}
   - {<< : *s390_fedora,       << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_latest}
   - {<< : *s390_suse,         << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
@@ -517,6 +521,7 @@ builds:
   - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *riscv_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_latest}
+  - {<< : *s390_kasan,        << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_latest}
   - {<< : *s390_fedora,       << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_latest}
   - {<< : *s390_suse,         << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}

--- a/tuxsuite/mainline.tux.yml
+++ b/tuxsuite/mainline.tux.yml
@@ -342,6 +342,22 @@ sets:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
+    target_arch: s390
+    toolchain: clang-nightly
+    kconfig:
+    - defconfig
+    - CONFIG_KASAN=y
+    - CONFIG_KASAN_KUNIT_TEST=y
+    - CONFIG_KASAN_VMALLOC=y
+    - CONFIG_KUNIT=y
+    targets:
+    - config
+    - kernel
+    - modules
+    make_variables:
+      LLVM_IAS: 0
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+    git_ref: master
     target_arch: x86_64
     toolchain: clang-nightly
     kconfig: defconfig
@@ -755,6 +771,22 @@ sets:
     target_arch: s390
     toolchain: clang-13
     kconfig: defconfig
+    targets:
+    - config
+    - kernel
+    - modules
+    make_variables:
+      LLVM_IAS: 0
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
+    git_ref: master
+    target_arch: s390
+    toolchain: clang-13
+    kconfig:
+    - defconfig
+    - CONFIG_KASAN=y
+    - CONFIG_KASAN_KUNIT_TEST=y
+    - CONFIG_KASAN_VMALLOC=y
+    - CONFIG_KUNIT=y
     targets:
     - config
     - kernel

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -342,6 +342,22 @@ sets:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
+    target_arch: s390
+    toolchain: clang-nightly
+    kconfig:
+    - defconfig
+    - CONFIG_KASAN=y
+    - CONFIG_KASAN_KUNIT_TEST=y
+    - CONFIG_KASAN_VMALLOC=y
+    - CONFIG_KUNIT=y
+    targets:
+    - config
+    - kernel
+    - modules
+    make_variables:
+      LLVM_IAS: 0
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+    git_ref: master
     target_arch: x86_64
     toolchain: clang-nightly
     kconfig: defconfig
@@ -770,6 +786,22 @@ sets:
     target_arch: s390
     toolchain: clang-13
     kconfig: defconfig
+    targets:
+    - config
+    - kernel
+    - modules
+    make_variables:
+      LLVM_IAS: 0
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+    git_ref: master
+    target_arch: s390
+    toolchain: clang-13
+    kconfig:
+    - defconfig
+    - CONFIG_KASAN=y
+    - CONFIG_KASAN_KUNIT_TEST=y
+    - CONFIG_KASAN_VMALLOC=y
+    - CONFIG_KUNIT=y
     targets:
     - config
     - kernel


### PR DESCRIPTION
We enabled support for testing `CONFIG_KASAN` in #178 but I did not realize that s390 supported KASAN so let's add it for more coverage. This passes my local tests.

32-bit ARM also supports `CONFIG_KASAN` but unfortunately, there is [an outstanding bug](https://github.com/ClangBuiltLinux/linux/issues/1211), which is resolved with @nickdesaulniers 's [patch](https://lore.kernel.org/r/20210830213846.2609349-1-ndesaulniers@google.com/). Once that patch has been merged, we can do this same thing for `ARCH=arm`.