### PR TITLE
Check matrices for number of jobs

### DIFF
--- a/.github/workflows/matrix-check.yml
+++ b/.github/workflows/matrix-check.yml
@@ -1,0 +1,12 @@
+# GitHub limits a workflow matrix to 256 jobs
+# https://docs.github.com/en/actions/reference/usage-limits-billing-and-administration#usage-limits
+name: Check workflow matrices
+on: [push, pull_request]
+jobs:
+  check_check_version:
+    name: Check workflow matrices
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: check-matrix.sh
+      run: bash check-matrix.sh

--- a/check-matrix.sh
+++ b/check-matrix.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+if [[ -n ${GITHUB_ACTIONS} ]]; then
+    repo=${GITHUB_WORKSPACE}
+else
+    repo=$(dirname "$(readlink -f "${0}")")
+fi
+
+for workflow in "${repo}"/.github/workflows/*.yml; do
+    # Get number of jobs from workflow (kick_tuxsuite... and md5 names)
+    jobs=$(grep -cP "  _|  kick" "${workflow}")
+    workflow=$(basename "${workflow}")
+
+    # If we did not find any jobs in the following format, it is not a TuxSuite
+    # workflow and we don't care.
+    [[ ${jobs} -eq 0 ]] && continue
+
+    echo "${workflow} has $jobs jobs"
+    if [[ ${jobs} -gt 256 ]]; then
+        echo "${workflow} has more than 256 jobs, please reduce the number of jobs or split the matrix up."
+        ret_code=1
+    fi
+done
+
+exit ${ret_code:-0}


### PR DESCRIPTION
GitHub Actions has a maximum of 256 jobs per matrix. In order to make
sure that we stay under this, add a workflow to check the number of jobs
in a TuxSuite matrix. The other workflows will never hit this number of
jobs so we just ignore them.