### PR TITLE
Disable -Werror for now

### DIFF
--- a/.github/workflows/5.10.yml
+++ b/.github/workflows/5.10.yml
@@ -1224,16 +1224,16 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _90df3441040ce9141269b5c53a5149d1:
+  _b9ae95a23a1f9360fe123a358ba16974:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1266,16 +1266,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _4bfea3d7145e8c3410937e501167d35e:
+  _f49c5df18e6ea748aaf9d1d04f3d3907:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1287,16 +1287,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _efbb08e8e064234fb6815e8f0019fb48:
+  _f6b527ec66316b0d133ad408849fbf42:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1329,16 +1329,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _cd3b353c4d93128d6d06d81e4df38d43:
+  _3298ed7231f32a513243cd02fe45c064:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1350,16 +1350,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _fe2c9057aa7118b7ceddc2c7bbdc8e2d:
+  _992af5860bcc9a1c28b228d2673cfcde:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1392,16 +1392,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _fb32e519cea6f2c116bd013eec8409de:
+  _d1f6821de38423146e72153d995ad97f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1413,16 +1413,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _939f400888bbc7344717215a96716b90:
+  _1dd519d5e67fb6542ee595775814d363:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1455,16 +1455,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8816a455253de9d0455dfa0b0bf9a2d6:
+  _787230103202571eafef247f0ba0902e:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1476,16 +1476,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _bc93ab0a758b33cf3167fdbdeb2b0705:
+  _3b0dbbefa80e939e712f96093114744a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1518,16 +1518,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a575b3a0efaafab3765963157dfe45f2:
+  _f0a7a9f1bf046cec44065ea240f66c98:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1539,16 +1539,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ff86d54e6acbce65590f71efbb2f826b:
+  _3d883b6dd7ce3b5941eac52b8e5d255a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1581,16 +1581,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _02922017f2cb19d45aba8492132c7804:
+  _24a02828373c02a9d349a03fab7edbb8:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1602,16 +1602,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8a7f0138d12509886a29c0b8b2b90e80:
+  _3f7ecca7b1ed43660ac6389359fde646:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1644,16 +1644,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _f67567decbe181f7dac1cebae6b752c2:
+  _0287fe965f5b39fdfef64647c19b664d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1665,16 +1665,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _40d38df5fba1ddfc0ada216733994225:
+  _7ab46834d7cc85742f3051c0305604d3:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1707,16 +1707,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _49b1b3bdbd9a67648407749094c083d4:
+  _174327284581ce9fc9319c12ab693a53:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1728,16 +1728,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ae767e9ca71f590a84808a724ec476e4:
+  _fa482dc7e25eed59da05016a93e8278c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1770,16 +1770,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _2dff3a82fb364654e103e70b4b546e45:
+  _34a42eb37f34ff66ca3fcb80b692fc4d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1791,16 +1791,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _565b3ebd0db7f13bc44114dbc4ce6faa:
+  _a1932acc412460b9d73716e877b74b94:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1833,16 +1833,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e4b5a7cb392bd67d52690ece87b3e80f:
+  _0af3671327d46b593593448c6623f2c4:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1854,16 +1854,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _51e2eff457ec186a91964ee9c06f04f3:
+  _61405b5bc7dd59acad465db347d382a3:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1896,16 +1896,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8c8559e2e509a14a717cee01ec90bd39:
+  _de31c0d55408a0065c789754fe70d907:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1917,16 +1917,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _315a83fa22517db93a5781d3052eb372:
+  _0d027f6d4a4d947cffb7496e1c16a135:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -1959,16 +1959,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _f93dc26c868cb14278bd57d172f7b70e:
+  _7325bb746df1b067e4e5f94ea088cb6d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/android-mainline.yml
+++ b/.github/workflows/android-mainline.yml
@@ -300,16 +300,16 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _017ca86b3e71799d51de2c8afd81c60b:
+  _972694df5ee8d4da71b17b0ab28548fd:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -321,16 +321,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _697acf7d42a48e3722c6145f69814f68:
+  _90e50b201f4f50c1f1feb26d2c87a1a9:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -342,16 +342,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8a7f0138d12509886a29c0b8b2b90e80:
+  _3f7ecca7b1ed43660ac6389359fde646:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -363,16 +363,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _af49aa812051ce9df4b6608fee8f3653:
+  _3e71a2c8bacb12efca0c94754c72d387:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: android
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/android12-5.10.yml
+++ b/.github/workflows/android12-5.10.yml
@@ -300,16 +300,16 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _017ca86b3e71799d51de2c8afd81c60b:
+  _972694df5ee8d4da71b17b0ab28548fd:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -321,16 +321,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _697acf7d42a48e3722c6145f69814f68:
+  _90e50b201f4f50c1f1feb26d2c87a1a9:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -342,16 +342,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8a7f0138d12509886a29c0b8b2b90e80:
+  _3f7ecca7b1ed43660ac6389359fde646:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -363,16 +363,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _af49aa812051ce9df4b6608fee8f3653:
+  _3e71a2c8bacb12efca0c94754c72d387:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: android
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/android12-5.4.yml
+++ b/.github/workflows/android12-5.4.yml
@@ -300,16 +300,16 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _017ca86b3e71799d51de2c8afd81c60b:
+  _972694df5ee8d4da71b17b0ab28548fd:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -321,16 +321,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _697acf7d42a48e3722c6145f69814f68:
+  _90e50b201f4f50c1f1feb26d2c87a1a9:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -342,16 +342,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8a7f0138d12509886a29c0b8b2b90e80:
+  _3f7ecca7b1ed43660ac6389359fde646:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -363,16 +363,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _af49aa812051ce9df4b6608fee8f3653:
+  _3e71a2c8bacb12efca0c94754c72d387:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: android
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/android13-5.10.yml
+++ b/.github/workflows/android13-5.10.yml
@@ -300,16 +300,16 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _017ca86b3e71799d51de2c8afd81c60b:
+  _972694df5ee8d4da71b17b0ab28548fd:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -321,16 +321,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _697acf7d42a48e3722c6145f69814f68:
+  _90e50b201f4f50c1f1feb26d2c87a1a9:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -342,16 +342,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8a7f0138d12509886a29c0b8b2b90e80:
+  _3f7ecca7b1ed43660ac6389359fde646:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -363,16 +363,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _af49aa812051ce9df4b6608fee8f3653:
+  _3e71a2c8bacb12efca0c94754c72d387:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: android
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/arm64-fixes.yml
+++ b/.github/workflows/arm64-fixes.yml
@@ -174,16 +174,16 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _efbb08e8e064234fb6815e8f0019fb48:
+  _f6b527ec66316b0d133ad408849fbf42:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -216,16 +216,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _cd3b353c4d93128d6d06d81e4df38d43:
+  _3298ed7231f32a513243cd02fe45c064:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -237,16 +237,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _bc93ab0a758b33cf3167fdbdeb2b0705:
+  _3b0dbbefa80e939e712f96093114744a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -279,16 +279,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a575b3a0efaafab3765963157dfe45f2:
+  _f0a7a9f1bf046cec44065ea240f66c98:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -300,16 +300,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _40d38df5fba1ddfc0ada216733994225:
+  _7ab46834d7cc85742f3051c0305604d3:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -342,16 +342,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _49b1b3bdbd9a67648407749094c083d4:
+  _174327284581ce9fc9319c12ab693a53:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -363,16 +363,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _51e2eff457ec186a91964ee9c06f04f3:
+  _61405b5bc7dd59acad465db347d382a3:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -405,16 +405,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8c8559e2e509a14a717cee01ec90bd39:
+  _de31c0d55408a0065c789754fe70d907:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -174,16 +174,16 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _efbb08e8e064234fb6815e8f0019fb48:
+  _f6b527ec66316b0d133ad408849fbf42:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -216,16 +216,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _cd3b353c4d93128d6d06d81e4df38d43:
+  _3298ed7231f32a513243cd02fe45c064:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -237,16 +237,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _bc93ab0a758b33cf3167fdbdeb2b0705:
+  _3b0dbbefa80e939e712f96093114744a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -279,16 +279,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a575b3a0efaafab3765963157dfe45f2:
+  _f0a7a9f1bf046cec44065ea240f66c98:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -300,16 +300,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _40d38df5fba1ddfc0ada216733994225:
+  _7ab46834d7cc85742f3051c0305604d3:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -342,16 +342,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _49b1b3bdbd9a67648407749094c083d4:
+  _174327284581ce9fc9319c12ab693a53:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -363,16 +363,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _51e2eff457ec186a91964ee9c06f04f3:
+  _61405b5bc7dd59acad465db347d382a3:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -405,16 +405,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8c8559e2e509a14a717cee01ec90bd39:
+  _de31c0d55408a0065c789754fe70d907:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -3697,16 +3697,16 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _017ca86b3e71799d51de2c8afd81c60b:
+  _972694df5ee8d4da71b17b0ab28548fd:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -3739,16 +3739,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _914ab545990915881ac056c4d869e1f6:
+  _5bf2903b396e202f5ba34d9bb7b23d68:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -3760,16 +3760,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _efbb08e8e064234fb6815e8f0019fb48:
+  _f6b527ec66316b0d133ad408849fbf42:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -3781,16 +3781,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e626e8d9489fb8d26a2ceee9cf596dc5:
+  _4f9f4c4cd6b02004da6f45b00442a104:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -3823,16 +3823,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _cd3b353c4d93128d6d06d81e4df38d43:
+  _3298ed7231f32a513243cd02fe45c064:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -3844,16 +3844,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _29621856361ed320d093c47e1d789771:
+  _d95abc502ea347d9e174e4ada03a7ee5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: riscv
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -3865,16 +3865,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _fe2c9057aa7118b7ceddc2c7bbdc8e2d:
+  _992af5860bcc9a1c28b228d2673cfcde:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -3886,16 +3886,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _fabeff65b904378ceac6cc67064323fe:
+  _e8497445432edceef823741fc78e44b2:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -3928,16 +3928,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _fb32e519cea6f2c116bd013eec8409de:
+  _d1f6821de38423146e72153d995ad97f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -3949,16 +3949,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _697acf7d42a48e3722c6145f69814f68:
+  _90e50b201f4f50c1f1feb26d2c87a1a9:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -3991,16 +3991,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _3c8f7d269bad99a182ef6b8286ce326b:
+  _cf4e033c76b67da6682ed807aa8174de:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4012,16 +4012,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _bc93ab0a758b33cf3167fdbdeb2b0705:
+  _3b0dbbefa80e939e712f96093114744a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4033,16 +4033,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _d6ae4ccd325979d638473228b3dd8c17:
+  _4778e06fd32f2316790995910819e05b:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4075,16 +4075,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a575b3a0efaafab3765963157dfe45f2:
+  _f0a7a9f1bf046cec44065ea240f66c98:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4096,16 +4096,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _3466aa72f105769b96bdc3e356c9d91a:
+  _c3c4f67a014e1c3e5f3e9dca28d684ea:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: riscv
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4117,16 +4117,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ff86d54e6acbce65590f71efbb2f826b:
+  _3d883b6dd7ce3b5941eac52b8e5d255a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4138,16 +4138,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _51db4df26ea58b68c19901411e605b2e:
+  _b76c6c40ae03e6a8764f2546e04a6020:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4180,16 +4180,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _02922017f2cb19d45aba8492132c7804:
+  _24a02828373c02a9d349a03fab7edbb8:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4201,16 +4201,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8a7f0138d12509886a29c0b8b2b90e80:
+  _3f7ecca7b1ed43660ac6389359fde646:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4243,16 +4243,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _f67567decbe181f7dac1cebae6b752c2:
+  _0287fe965f5b39fdfef64647c19b664d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4264,16 +4264,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _40d38df5fba1ddfc0ada216733994225:
+  _7ab46834d7cc85742f3051c0305604d3:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4285,16 +4285,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _52911b17aeee5908f851ff37465065e7:
+  _4e372a3075f56b3d6e560b27966674ed:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4327,16 +4327,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _49b1b3bdbd9a67648407749094c083d4:
+  _174327284581ce9fc9319c12ab693a53:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4348,16 +4348,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _0445e3ea394f4e6c3ab23a8dfa84d3e4:
+  _c03fe66571c52e3db26832fde3572225:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: riscv
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4369,16 +4369,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ae767e9ca71f590a84808a724ec476e4:
+  _fa482dc7e25eed59da05016a93e8278c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4390,16 +4390,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _2dc2c1c0431802a1cd5273e93cf3a433:
+  _d742dae58084b6c129fe894dca38faba:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4432,16 +4432,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _2dff3a82fb364654e103e70b4b546e45:
+  _34a42eb37f34ff66ca3fcb80b692fc4d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4453,16 +4453,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _565b3ebd0db7f13bc44114dbc4ce6faa:
+  _a1932acc412460b9d73716e877b74b94:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4495,16 +4495,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e4b5a7cb392bd67d52690ece87b3e80f:
+  _0af3671327d46b593593448c6623f2c4:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4516,16 +4516,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _51e2eff457ec186a91964ee9c06f04f3:
+  _61405b5bc7dd59acad465db347d382a3:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4537,16 +4537,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _5eef23383e7e212e3e1b286524ee0926:
+  _c624842270d838712c9f7cda43ef1e2f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: arm64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4579,16 +4579,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8c8559e2e509a14a717cee01ec90bd39:
+  _de31c0d55408a0065c789754fe70d907:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4600,16 +4600,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _c71a33af9a96021296554421ae3e3cfb:
+  _69d3f7ff50eec793fc285247c8eaa128:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: riscv
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4621,16 +4621,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _315a83fa22517db93a5781d3052eb372:
+  _0d027f6d4a4d947cffb7496e1c16a135:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4642,16 +4642,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ad4a14cfdd7a60aff188af10540352b6:
+  _be008c19ad3aa8d719caa3a336df796a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4684,16 +4684,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _f93dc26c868cb14278bd57d172f7b70e:
+  _7325bb746df1b067e4e5f94ea088cb6d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4705,16 +4705,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _56f04e51c99a42d025a820038622edb0:
+  _0f12b7bfdc9c27936248be8116696e12:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 10
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4747,16 +4747,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _bc95ad4fabbd7c72e2ce72553f0aa944:
+  _c4427d05158c03a9b0a1cd302e8092e1:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 10
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -3991,16 +3991,16 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _017ca86b3e71799d51de2c8afd81c60b:
+  _972694df5ee8d4da71b17b0ab28548fd:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4033,16 +4033,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _914ab545990915881ac056c4d869e1f6:
+  _5bf2903b396e202f5ba34d9bb7b23d68:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4054,16 +4054,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _efbb08e8e064234fb6815e8f0019fb48:
+  _f6b527ec66316b0d133ad408849fbf42:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4075,16 +4075,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e626e8d9489fb8d26a2ceee9cf596dc5:
+  _4f9f4c4cd6b02004da6f45b00442a104:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4117,16 +4117,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _cd3b353c4d93128d6d06d81e4df38d43:
+  _3298ed7231f32a513243cd02fe45c064:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4138,16 +4138,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _29621856361ed320d093c47e1d789771:
+  _d95abc502ea347d9e174e4ada03a7ee5:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: riscv
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4159,16 +4159,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _fe2c9057aa7118b7ceddc2c7bbdc8e2d:
+  _992af5860bcc9a1c28b228d2673cfcde:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4180,16 +4180,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _fabeff65b904378ceac6cc67064323fe:
+  _e8497445432edceef823741fc78e44b2:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4222,16 +4222,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _fb32e519cea6f2c116bd013eec8409de:
+  _d1f6821de38423146e72153d995ad97f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4243,16 +4243,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _697acf7d42a48e3722c6145f69814f68:
+  _90e50b201f4f50c1f1feb26d2c87a1a9:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4285,16 +4285,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _3c8f7d269bad99a182ef6b8286ce326b:
+  _cf4e033c76b67da6682ed807aa8174de:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4306,16 +4306,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _bc93ab0a758b33cf3167fdbdeb2b0705:
+  _3b0dbbefa80e939e712f96093114744a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4327,16 +4327,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _d6ae4ccd325979d638473228b3dd8c17:
+  _4778e06fd32f2316790995910819e05b:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4369,16 +4369,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _a575b3a0efaafab3765963157dfe45f2:
+  _f0a7a9f1bf046cec44065ea240f66c98:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4390,16 +4390,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _3466aa72f105769b96bdc3e356c9d91a:
+  _c3c4f67a014e1c3e5f3e9dca28d684ea:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: riscv
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4411,16 +4411,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ff86d54e6acbce65590f71efbb2f826b:
+  _3d883b6dd7ce3b5941eac52b8e5d255a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4432,16 +4432,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _51db4df26ea58b68c19901411e605b2e:
+  _b76c6c40ae03e6a8764f2546e04a6020:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4474,16 +4474,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _02922017f2cb19d45aba8492132c7804:
+  _24a02828373c02a9d349a03fab7edbb8:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4495,16 +4495,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8a7f0138d12509886a29c0b8b2b90e80:
+  _3f7ecca7b1ed43660ac6389359fde646:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4537,16 +4537,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _f67567decbe181f7dac1cebae6b752c2:
+  _0287fe965f5b39fdfef64647c19b664d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4558,16 +4558,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _40d38df5fba1ddfc0ada216733994225:
+  _7ab46834d7cc85742f3051c0305604d3:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4579,16 +4579,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _52911b17aeee5908f851ff37465065e7:
+  _4e372a3075f56b3d6e560b27966674ed:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4621,16 +4621,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _49b1b3bdbd9a67648407749094c083d4:
+  _174327284581ce9fc9319c12ab693a53:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4642,16 +4642,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _0445e3ea394f4e6c3ab23a8dfa84d3e4:
+  _c03fe66571c52e3db26832fde3572225:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: riscv
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4663,16 +4663,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ae767e9ca71f590a84808a724ec476e4:
+  _fa482dc7e25eed59da05016a93e8278c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4684,16 +4684,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _2dc2c1c0431802a1cd5273e93cf3a433:
+  _d742dae58084b6c129fe894dca38faba:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4726,16 +4726,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _2dff3a82fb364654e103e70b4b546e45:
+  _34a42eb37f34ff66ca3fcb80b692fc4d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4747,16 +4747,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _565b3ebd0db7f13bc44114dbc4ce6faa:
+  _a1932acc412460b9d73716e877b74b94:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4789,16 +4789,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e4b5a7cb392bd67d52690ece87b3e80f:
+  _0af3671327d46b593593448c6623f2c4:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4810,16 +4810,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _51e2eff457ec186a91964ee9c06f04f3:
+  _61405b5bc7dd59acad465db347d382a3:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4831,16 +4831,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _5eef23383e7e212e3e1b286524ee0926:
+  _c624842270d838712c9f7cda43ef1e2f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: arm64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4873,16 +4873,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _8c8559e2e509a14a717cee01ec90bd39:
+  _de31c0d55408a0065c789754fe70d907:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4894,16 +4894,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _c71a33af9a96021296554421ae3e3cfb:
+  _69d3f7ff50eec793fc285247c8eaa128:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: riscv
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4915,16 +4915,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _315a83fa22517db93a5781d3052eb372:
+  _0d027f6d4a4d947cffb7496e1c16a135:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4936,16 +4936,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ad4a14cfdd7a60aff188af10540352b6:
+  _be008c19ad3aa8d719caa3a336df796a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4978,16 +4978,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _f93dc26c868cb14278bd57d172f7b70e:
+  _7325bb746df1b067e4e5f94ea088cb6d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -4999,16 +4999,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _56f04e51c99a42d025a820038622edb0:
+  _0f12b7bfdc9c27936248be8116696e12:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 10
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -5041,16 +5041,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _bc95ad4fabbd7c72e2ce72553f0aa944:
+  _c4427d05158c03a9b0a1cd302e8092e1:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=10 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 10
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -5104,16 +5104,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _b79dc2edc3fda12d85ac78ca2b081960:
+  _bcc4f57380794ab069ddb0e22c4e2db4:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=android allmodconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: android
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -5146,16 +5146,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _eef2fa4c94ab7adb8bb82dd2c8595893:
+  _a54f15bc1f9d8a262514f843f51ac42c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=android allyesconfig
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=android allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: android
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -5167,16 +5167,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _0a2662d69f899d9d4f0fecc38bed6d41:
+  _6461032e7e9ef44a53d643a1e5aadf8d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: android
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -5188,16 +5188,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _509b45bccf9f9caab84def233b90d81b:
+  _ad579b841d588a54782fe148aaf77e54:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: arm64
       LLVM_VERSION: android
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -5230,16 +5230,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e357ce8f7d2d716ba07663203d18eb52:
+  _1b746f8bebd70e07d77497de2ac2ca24:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allyesconfig
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: arm64
       LLVM_VERSION: android
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -5251,16 +5251,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _e38e51bfe42f6ce103710889aa946c01:
+  _191bb4a446201921f3ea6bfa0e9b122f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -5272,16 +5272,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _f7ee75927f0273e4652c17902a6dc812:
+  _bf13eb4d6ca658a087deadacb13963ec:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
     steps:
     - uses: actions/checkout@v2
       with:
@@ -5314,16 +5314,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _19dd04f50424074ba37661160bf0204c:
+  _40dc138ef3ff6bc3203c6d3c9a524e48:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allyesconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/tip.yml
+++ b/.github/workflows/tip.yml
@@ -216,16 +216,16 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _fe2c9057aa7118b7ceddc2c7bbdc8e2d:
+  _992af5860bcc9a1c28b228d2673cfcde:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -258,16 +258,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _fb32e519cea6f2c116bd013eec8409de:
+  _d1f6821de38423146e72153d995ad97f:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -279,16 +279,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ff86d54e6acbce65590f71efbb2f826b:
+  _3d883b6dd7ce3b5941eac52b8e5d255a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -321,16 +321,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _02922017f2cb19d45aba8492132c7804:
+  _24a02828373c02a9d349a03fab7edbb8:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -342,16 +342,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _ae767e9ca71f590a84808a724ec476e4:
+  _fa482dc7e25eed59da05016a93e8278c:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -384,16 +384,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _2dff3a82fb364654e103e70b4b546e45:
+  _34a42eb37f34ff66ca3fcb80b692fc4d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -405,16 +405,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _315a83fa22517db93a5781d3052eb372:
+  _0d027f6d4a4d947cffb7496e1c16a135:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -447,16 +447,16 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _f93dc26c868cb14278bd57d172f7b70e:
+  _7325bb746df1b067e4e5f94ea088cb6d:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
       BOOT: 0
-      CONFIG: allyesconfig
+      CONFIG: allyesconfig+CONFIG_WERROR=n
     steps:
     - uses: actions/checkout@v2
       with:

--- a/generator.yml
+++ b/generator.yml
@@ -87,9 +87,9 @@ configs:
   - &arm32_imx         {config: imx_v4_v5_defconfig,                                                                                       << : *arm-triple,           << : *kernel_modules}
   - &arm32_omap        {config: omap2plus_defconfig,                                                                                       << : *arm-triple,           << : *kernel_modules}
   - &arm32_lpae_fp     {config: [multi_v7_defconfig, CONFIG_ARM_LPAE=y, CONFIG_UNWINDER_FRAME_POINTER=y],                                  << : *arm-triple,           << : *kernel_modules}
-  - &arm32_allmod      {config: allmodconfig,                                                                                              << : *arm-triple,           << : *kernel_modules}
+  - &arm32_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                                                           << : *arm-triple,           << : *kernel_modules}
   - &arm32_allno       {config: allnoconfig,                                                                                               << : *arm-triple,           << : *kernel_modules}
-  - &arm32_allyes      {config: allyesconfig,                                                                                              << : *arm-triple,           << : *kernel_modules}
+  - &arm32_allyes      {config: [allyesconfig, CONFIG_WERROR=n],                                                                           << : *arm-triple,           << : *kernel_modules}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
   - &arm32_fedora      {config: [*arm32-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                          << : *arm-triple,           << : *kernel_modules}
   - &arm32_suse        {config: *arm32-suse-config-url,                                                                                    << : *arm-triple,           << : *kernel_modules}
@@ -103,10 +103,10 @@ configs:
   - &arm64_ubsan       {config: [defconfig, CONFIG_UBSAN=y],                                                                               << : *arm64-triple,         << : *kernel_modules}
   - &arm64_gki         {config: gki_defconfig,                                                                                             << : *arm64-triple,         << : *kernel_modules}
   - &arm64_cut         {config: cuttlefish_defconfig,                                                                                      << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_allmod      {config: allmodconfig,                                                                                              << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_allmod_lto  {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_LTO_CLANG_THIN=y],                             << : *arm64-triple,         << : *kernel_modules}
+  - &arm64_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                                                           << : *arm64-triple,         << : *kernel_modules}
+  - &arm64_allmod_lto  {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_WERROR=n, CONFIG_LTO_CLANG_THIN=y],            << : *arm64-triple,         << : *kernel_modules}
   - &arm64_allno       {config: allnoconfig,                                                                                               << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_allyes      {config: allyesconfig,                                                                                              << : *arm64-triple,         << : *kernel_modules}
+  - &arm64_allyes      {config: [allyesconfig, CONFIG_WERROR=n],                                                                           << : *arm64-triple,         << : *kernel_modules}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
   - &arm64_fedora      {config: [*arm64-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                          << : *arm64-triple,         << : *kernel_modules}
   # CONFIG_DEBUG_INFO_BTF disabled for certain SUSE configs due to pahole issue: https://lore.kernel.org/r/20210506205622.3663956-1-kafai@fb.com/
@@ -127,7 +127,7 @@ configs:
   - &ppc64le_fedora    {config: [*ppc64le-fedora-config-url, CONFIG_BPF_PRELOAD=n],                            kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel_modules}
   - &ppc64le_suse      {config: *ppc64le-suse-config-url,                                                      kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel_modules}
   - &riscv             {config: defconfig,                                                                     kernel_image: Image,        << : *riscv-triple,         << : *kernel_modules}
-  - &riscv_allmod      {config: allmodconfig,                                                                  kernel_image: Image,        << : *riscv-triple,         << : *kernel_modules}
+  - &riscv_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                               kernel_image: Image,        << : *riscv-triple,         << : *kernel_modules}
   #                                         https://github.com/ClangBuiltLinux/linux/issues/1143
   - &riscv_no_efi      {config: [defconfig, CONFIG_EFI=n],                                                     kernel_image: Image,        << : *riscv-triple,         << : *kernel_modules}
   - &s390              {config: defconfig,                                                                                                 << : *s390-triple,          << : *kernel_modules}
@@ -141,10 +141,10 @@ configs:
   - &x86_64_cfi        {config: [defconfig, CONFIG_LTO_CLANG_THIN=y, CONFIG_CFI_CLANG=y],                                                                              << : *kernel_modules}
   - &x86_64_gki        {config: gki_defconfig,                                                                                                                         << : *kernel_modules}
   - &x86_64_cut        {config: x86_64_cuttlefish_defconfig,                                                                                                           << : *kernel_modules}
-  - &x86_64_allmod     {config: allmodconfig,                                                                                                                          << : *kernel_modules}
-  - &x86_64_allmod_lto {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_LTO_CLANG_THIN=y],                                                         << : *kernel_modules}
+  - &x86_64_allmod     {config: [allmodconfig, CONFIG_WERROR=n],                                                                                                       << : *kernel_modules}
+  - &x86_64_allmod_lto {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_WERROR=n, CONFIG_LTO_CLANG_THIN=y],                                        << : *kernel_modules}
   - &x86_64_allno      {config: allnoconfig,                                                                                                                           << : *kernel_modules}
-  - &x86_64_allyes     {config: allyesconfig,                                                                                                                          << : *kernel_modules}
+  - &x86_64_allyes     {config: [allyesconfig, CONFIG_WERROR=n],                                                                                                       << : *kernel_modules}
   - &x86_64_gcov       {config: [defconfig, CONFIG_GCOV_KERNEL=y, CONFIG_GCOV_PROFILE_ALL=y],                                                                          << : *kernel_modules}
   - &x86_64_kasan      {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],                                        << : *kernel_modules}
   - &x86_64_kcsan      {config: [defconfig, CONFIG_KCSAN=y, CONFIG_KCSAN_KUNIT_TEST=y, CONFIG_KUNIT=y],                                                                << : *kernel_modules}

--- a/tuxsuite/5.10.tux.yml
+++ b/tuxsuite/5.10.tux.yml
@@ -765,7 +765,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: arm
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -789,7 +791,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: arm
     toolchain: clang-nightly
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -801,7 +805,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -826,7 +832,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -839,7 +847,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -863,7 +873,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -875,7 +887,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: arm
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -899,7 +913,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: arm
     toolchain: clang-13
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -911,7 +927,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: arm64
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -936,7 +954,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: arm64
     toolchain: clang-13
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -949,7 +969,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: x86_64
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -973,7 +995,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: x86_64
     toolchain: clang-13
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -985,7 +1009,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: arm
     toolchain: clang-12
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -1009,7 +1035,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: arm
     toolchain: clang-12
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -1021,7 +1049,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: arm64
     toolchain: clang-12
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -1046,7 +1076,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: arm64
     toolchain: clang-12
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -1059,7 +1091,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: x86_64
     toolchain: clang-12
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -1083,7 +1117,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: x86_64
     toolchain: clang-12
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -1095,7 +1131,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: arm
     toolchain: clang-11
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -1119,7 +1157,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: arm
     toolchain: clang-11
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -1131,7 +1171,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: arm64
     toolchain: clang-11
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -1156,7 +1198,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: arm64
     toolchain: clang-11
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -1169,7 +1213,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: x86_64
     toolchain: clang-11
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -1193,7 +1239,9 @@ sets:
     git_ref: linux-5.10.y
     target_arch: x86_64
     toolchain: clang-11
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel

--- a/tuxsuite/android-mainline.tux.yml
+++ b/tuxsuite/android-mainline.tux.yml
@@ -167,7 +167,9 @@ sets:
     git_ref: android-mainline
     target_arch: arm
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -179,7 +181,9 @@ sets:
     git_ref: android-mainline
     target_arch: arm
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -191,7 +195,9 @@ sets:
     git_ref: android-mainline
     target_arch: arm
     toolchain: clang-12
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -203,7 +209,9 @@ sets:
     git_ref: android-mainline
     target_arch: arm
     toolchain: clang-android
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel

--- a/tuxsuite/android12-5.10.tux.yml
+++ b/tuxsuite/android12-5.10.tux.yml
@@ -167,7 +167,9 @@ sets:
     git_ref: android12-5.10
     target_arch: arm
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -179,7 +181,9 @@ sets:
     git_ref: android12-5.10
     target_arch: arm
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -191,7 +195,9 @@ sets:
     git_ref: android12-5.10
     target_arch: arm
     toolchain: clang-12
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -203,7 +209,9 @@ sets:
     git_ref: android12-5.10
     target_arch: arm
     toolchain: clang-android
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel

--- a/tuxsuite/android12-5.4.tux.yml
+++ b/tuxsuite/android12-5.4.tux.yml
@@ -167,7 +167,9 @@ sets:
     git_ref: android12-5.4
     target_arch: arm
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -179,7 +181,9 @@ sets:
     git_ref: android12-5.4
     target_arch: arm
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -191,7 +195,9 @@ sets:
     git_ref: android12-5.4
     target_arch: arm
     toolchain: clang-12
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -203,7 +209,9 @@ sets:
     git_ref: android12-5.4
     target_arch: arm
     toolchain: clang-android
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel

--- a/tuxsuite/android13-5.10.tux.yml
+++ b/tuxsuite/android13-5.10.tux.yml
@@ -167,7 +167,9 @@ sets:
     git_ref: android13-5.10
     target_arch: arm
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -179,7 +181,9 @@ sets:
     git_ref: android13-5.10
     target_arch: arm
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -191,7 +195,9 @@ sets:
     git_ref: android13-5.10
     target_arch: arm
     toolchain: clang-12
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -203,7 +209,9 @@ sets:
     git_ref: android13-5.10
     target_arch: arm
     toolchain: clang-android
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel

--- a/tuxsuite/arm64-fixes.tux.yml
+++ b/tuxsuite/arm64-fixes.tux.yml
@@ -92,7 +92,9 @@ sets:
     git_ref: for-next/fixes
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -117,7 +119,9 @@ sets:
     git_ref: for-next/fixes
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -130,7 +134,9 @@ sets:
     git_ref: for-next/fixes
     target_arch: arm64
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -155,7 +161,9 @@ sets:
     git_ref: for-next/fixes
     target_arch: arm64
     toolchain: clang-13
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -168,7 +176,9 @@ sets:
     git_ref: for-next/fixes
     target_arch: arm64
     toolchain: clang-12
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -193,7 +203,9 @@ sets:
     git_ref: for-next/fixes
     target_arch: arm64
     toolchain: clang-12
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -206,7 +218,9 @@ sets:
     git_ref: for-next/fixes
     target_arch: arm64
     toolchain: clang-11
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -231,7 +245,9 @@ sets:
     git_ref: for-next/fixes
     target_arch: arm64
     toolchain: clang-11
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel

--- a/tuxsuite/arm64.tux.yml
+++ b/tuxsuite/arm64.tux.yml
@@ -92,7 +92,9 @@ sets:
     git_ref: for-next/core
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -117,7 +119,9 @@ sets:
     git_ref: for-next/core
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -130,7 +134,9 @@ sets:
     git_ref: for-next/core
     target_arch: arm64
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -155,7 +161,9 @@ sets:
     git_ref: for-next/core
     target_arch: arm64
     toolchain: clang-13
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -168,7 +176,9 @@ sets:
     git_ref: for-next/core
     target_arch: arm64
     toolchain: clang-12
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -193,7 +203,9 @@ sets:
     git_ref: for-next/core
     target_arch: arm64
     toolchain: clang-12
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -206,7 +218,9 @@ sets:
     git_ref: for-next/core
     target_arch: arm64
     toolchain: clang-11
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -231,7 +245,9 @@ sets:
     git_ref: for-next/core
     target_arch: arm64
     toolchain: clang-11
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel

--- a/tuxsuite/mainline.tux.yml
+++ b/tuxsuite/mainline.tux.yml
@@ -2415,7 +2415,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2439,7 +2441,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-nightly
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2451,7 +2455,9 @@ sets:
     git_ref: master
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2468,6 +2474,7 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
+    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - config
@@ -2493,7 +2500,9 @@ sets:
     git_ref: master
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2506,7 +2515,9 @@ sets:
     git_ref: master
     target_arch: riscv
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2519,7 +2530,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2535,6 +2548,7 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
+    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - config
@@ -2559,7 +2573,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2571,7 +2587,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2595,7 +2613,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-13
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2607,7 +2627,9 @@ sets:
     git_ref: master
     target_arch: arm64
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2624,6 +2646,7 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
+    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - config
@@ -2649,7 +2672,9 @@ sets:
     git_ref: master
     target_arch: arm64
     toolchain: clang-13
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2662,7 +2687,9 @@ sets:
     git_ref: master
     target_arch: riscv
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2675,7 +2702,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2691,6 +2720,7 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
+    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - config
@@ -2715,7 +2745,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-13
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2727,7 +2759,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-12
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2751,7 +2785,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-12
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2763,7 +2799,9 @@ sets:
     git_ref: master
     target_arch: arm64
     toolchain: clang-12
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2780,6 +2818,7 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
+    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - config
@@ -2805,7 +2844,9 @@ sets:
     git_ref: master
     target_arch: arm64
     toolchain: clang-12
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2818,7 +2859,9 @@ sets:
     git_ref: master
     target_arch: riscv
     toolchain: clang-12
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2831,7 +2874,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-12
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2847,6 +2892,7 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
+    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - config
@@ -2871,7 +2917,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-12
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2883,7 +2931,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-11
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2907,7 +2957,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-11
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2919,7 +2971,9 @@ sets:
     git_ref: master
     target_arch: arm64
     toolchain: clang-11
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2936,6 +2990,7 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
+    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - config
@@ -2961,7 +3016,9 @@ sets:
     git_ref: master
     target_arch: arm64
     toolchain: clang-11
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2974,7 +3031,9 @@ sets:
     git_ref: master
     target_arch: riscv
     toolchain: clang-11
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2987,7 +3046,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-11
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3003,6 +3064,7 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
+    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - config
@@ -3027,7 +3089,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-11
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3039,7 +3103,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-10
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3063,7 +3129,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-10
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -2604,7 +2604,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2628,7 +2630,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-nightly
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2640,7 +2644,9 @@ sets:
     git_ref: master
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2657,6 +2663,7 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
+    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - config
@@ -2682,7 +2689,9 @@ sets:
     git_ref: master
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2695,7 +2704,9 @@ sets:
     git_ref: master
     target_arch: riscv
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2708,7 +2719,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2724,6 +2737,7 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
+    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - config
@@ -2748,7 +2762,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2760,7 +2776,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2784,7 +2802,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-13
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2796,7 +2816,9 @@ sets:
     git_ref: master
     target_arch: arm64
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2813,6 +2835,7 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
+    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - config
@@ -2838,7 +2861,9 @@ sets:
     git_ref: master
     target_arch: arm64
     toolchain: clang-13
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2851,7 +2876,9 @@ sets:
     git_ref: master
     target_arch: riscv
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2864,7 +2891,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2880,6 +2909,7 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
+    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - config
@@ -2904,7 +2934,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-13
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2916,7 +2948,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-12
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2940,7 +2974,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-12
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2952,7 +2988,9 @@ sets:
     git_ref: master
     target_arch: arm64
     toolchain: clang-12
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -2969,6 +3007,7 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
+    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - config
@@ -2994,7 +3033,9 @@ sets:
     git_ref: master
     target_arch: arm64
     toolchain: clang-12
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3007,7 +3048,9 @@ sets:
     git_ref: master
     target_arch: riscv
     toolchain: clang-12
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3020,7 +3063,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-12
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3036,6 +3081,7 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
+    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - config
@@ -3060,7 +3106,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-12
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3072,7 +3120,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-11
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3096,7 +3146,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-11
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3108,7 +3160,9 @@ sets:
     git_ref: master
     target_arch: arm64
     toolchain: clang-11
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3125,6 +3179,7 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
+    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - config
@@ -3150,7 +3205,9 @@ sets:
     git_ref: master
     target_arch: arm64
     toolchain: clang-11
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3163,7 +3220,9 @@ sets:
     git_ref: master
     target_arch: riscv
     toolchain: clang-11
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3176,7 +3235,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-11
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3192,6 +3253,7 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
+    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - config
@@ -3216,7 +3278,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-11
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3228,7 +3292,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-10
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3252,7 +3318,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-10
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3288,7 +3356,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-android
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3312,7 +3382,9 @@ sets:
     git_ref: master
     target_arch: arm
     toolchain: clang-android
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3324,7 +3396,9 @@ sets:
     git_ref: master
     target_arch: arm64
     toolchain: clang-android
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3340,6 +3414,7 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
+    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - config
@@ -3364,7 +3439,9 @@ sets:
     git_ref: master
     target_arch: arm64
     toolchain: clang-android
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3376,7 +3453,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-android
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -3392,6 +3471,7 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
+    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - config
@@ -3416,7 +3496,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-android
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel

--- a/tuxsuite/tip.tux.yml
+++ b/tuxsuite/tip.tux.yml
@@ -108,7 +108,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -132,7 +134,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -144,7 +148,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -168,7 +174,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-13
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -180,7 +188,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-12
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -204,7 +214,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-12
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -216,7 +228,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-11
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel
@@ -240,7 +254,9 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-11
-    kconfig: allyesconfig
+    kconfig:
+    - allyesconfig
+    - CONFIG_WERROR=n
     targets:
     - config
     - kernel


### PR DESCRIPTION
`CONFIG_WERROR` is enabled by default when `CONFIG_COMPILE_TEST` is enabled.
Disable it explicitly so we can catch actual build breakage.

I am of the opinion we should prioritize getting warning clean so that
we can re-enable this, as this does not affect our boot tests anymore
but will make it obvious when there are potential issues due to
warnings.