### PR TITLE
check_logs.py: Increase timeout for CONFIG_KASAN (part 2)

### DIFF
--- a/check_logs.py
+++ b/check_logs.py
@@ -81,7 +81,7 @@ def run_boot(build):
        "CONFIG_UBSAN=y" in build["kconfig"]:
         boot_qemu += ["-s", "4"]
         if "CONFIG_KASAN=y" in build["kconfig"]:
-            boot_qemu += ["-t", "15m"]
+            boot_qemu += ["-t", "20m"]
         else:
             boot_qemu += ["-t", "10m"]
     try:


### PR DESCRIPTION
A follow up to #185 as there was another build that timed out at 15m.

Closes: #193