### PR TITLE
Disable CONFIG_CFI_CLANG=y x86_64 builds with clang-12

### DIFF
--- a/.github/workflows/lto-cfi-tip.yml
+++ b/.github/workflows/lto-cfi-tip.yml
@@ -74,25 +74,4 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _be409d8468fc6bfdb5d967daf5c9da6d:
-    runs-on: ubuntu-20.04
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
-    env:
-      ARCH: x86_64
-      LLVM_VERSION: 12
-      INSTALL_DEPS: 1
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact_defconfigs
-    - name: Register clang error/warning problem matcher
-      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
-    - name: Boot Test
-      run: ./check_logs.py
 

--- a/.github/workflows/lto-cfi.yml
+++ b/.github/workflows/lto-cfi.yml
@@ -74,25 +74,4 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _be409d8468fc6bfdb5d967daf5c9da6d:
-    runs-on: ubuntu-20.04
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
-    env:
-      ARCH: x86_64
-      LLVM_VERSION: 12
-      INSTALL_DEPS: 1
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact_defconfigs
-    - name: Register clang error/warning problem matcher
-      run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
-    - name: Boot Test
-      run: ./check_logs.py
 

--- a/generator.yml
+++ b/generator.yml
@@ -835,11 +835,6 @@ builds:
   - {<< : *x86_64_cut,        << : *android-4_14,     << : *lld,             boot: true,  llvm_version: *llvm_12}
   - {<< : *arm64_cut,         << : *android-4_9,      << : *clang,           boot: true,  llvm_version: *llvm_12}
   - {<< : *x86_64_cut,        << : *android-4_9,      << : *clang,           boot: true,  llvm_version: *llvm_12}
-  #############
-  #  LTO/CFI  #
-  #############
-  - {<< : *x86_64_cfi,        << : *lto-cfi,          << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_cfi,        << : *lto-cfi-tip,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
   #########
   #  TIP  #
   #########

--- a/tuxsuite/lto-cfi-tip.tux.yml
+++ b/tuxsuite/lto-cfi-tip.tux.yml
@@ -36,19 +36,4 @@ sets:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - git_repo: https://github.com/samitolvanen/linux.git
-    git_ref: tip/clang-cfi
-    target_arch: x86_64
-    toolchain: clang-12
-    kconfig:
-    - defconfig
-    - CONFIG_LTO_CLANG_THIN=y
-    - CONFIG_CFI_CLANG=y
-    targets:
-    - config
-    - kernel
-    - modules
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
 

--- a/tuxsuite/lto-cfi.tux.yml
+++ b/tuxsuite/lto-cfi.tux.yml
@@ -36,19 +36,4 @@ sets:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - git_repo: https://github.com/samitolvanen/linux.git
-    git_ref: clang-cfi
-    target_arch: x86_64
-    toolchain: clang-12
-    kconfig:
-    - defconfig
-    - CONFIG_LTO_CLANG_THIN=y
-    - CONFIG_CFI_CLANG=y
-    targets:
-    - config
-    - kernel
-    - modules
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
 


### PR DESCRIPTION
CONFIG_CFI_CLANG for x86_64 requires clang-13, meaning these builds
serve no purpose.