### PR TITLE
Flush output buffers proactively

### DIFF
--- a/check_logs.py
+++ b/check_logs.py
@@ -132,6 +132,12 @@ def run_boot(build):
             boot_qemu += ["-t", "20m"]
         else:
             boot_qemu += ["-t", "10m"]
+
+    # Before spawning a process with potentially different IO buffering,
+    # flush the existing buffers so output is ordered correctly.
+    sys.stdout.flush()
+    sys.stderr.flush()
+
     try:
         subprocess.run(boot_qemu, check=True)
     except subprocess.CalledProcessError as e:

--- a/utils.py
+++ b/utils.py
@@ -126,10 +126,12 @@ def get_build():
 
 def print_red(msg):
     print("\033[91m%s\033[0m" % msg, file=sys.stderr)
+    sys.stderr.flush()
 
 
 def print_yellow(msg):
-    print("\033[93m%s\033[0m" % msg)
+    print("\033[93m%s\033[0m" % msg, file=sys.stdout)
+    sys.stdout.flush()
 
 
 def patch_series_flag(tree):


### PR DESCRIPTION
In the CI logs, QEMU output shows up before the rest of check_log.py
output. This is likely due to IO buffering, so explicitly flush buffers
in the helper routines and before spawning QEMU.

Signed-off-by: Kees Cook <keescook@google.com>