### PR TITLE
Disable boot for CONFIG_KASAN_SW_TAGS=y on clang-11 and clang-12

### DIFF
--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -1586,15 +1586,15 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _699d70a50776211d29041fd5ca9f26fd:
+  _4e3389b203c49366195a1e6d1c5ece04:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 1
+      BOOT: 0
       CONFIG: defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     steps:
     - uses: actions/checkout@v2
@@ -2153,15 +2153,15 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _63fd664fc5f0f7f6089936a2813611b3:
+  _4d6512a58351392073ed9c47c86fab3a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     env:
       ARCH: arm64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
-      BOOT: 1
+      BOOT: 0
       CONFIG: defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -1628,15 +1628,15 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _699d70a50776211d29041fd5ca9f26fd:
+  _4e3389b203c49366195a1e6d1c5ece04:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       INSTALL_DEPS: 1
-      BOOT: 1
+      BOOT: 0
       CONFIG: defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     steps:
     - uses: actions/checkout@v2
@@ -2195,15 +2195,15 @@ jobs:
       run: echo "::add-matcher::.github/problem-matchers/clang-errors-warnings.json"
     - name: Boot Test
       run: ./check_logs.py
-  _63fd664fc5f0f7f6089936a2813611b3:
+  _4d6512a58351392073ed9c47c86fab3a:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
+    name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     env:
       ARCH: arm64
       LLVM_VERSION: 11
       INSTALL_DEPS: 1
-      BOOT: 1
+      BOOT: 0
       CONFIG: defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     steps:
     - uses: actions/checkout@v2

--- a/generator.yml
+++ b/generator.yml
@@ -684,7 +684,7 @@ builds:
   - {<< : *arm64_lto_thin,    << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
   - {<< : *arm64_cfi,         << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
   - {<< : *arm64_kasan,       << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
   - {<< : *arm64_ubsan,       << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
   - {<< : *arm64_allmod,      << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
   - {<< : *arm64_allmod_lto,  << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
@@ -743,7 +743,7 @@ builds:
   - {<< : *arm64_lto_thin,    << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
   - {<< : *arm64_cfi,         << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
   - {<< : *arm64_kasan,       << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_kasan_sw,    << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_kasan_sw,    << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
   - {<< : *arm64_ubsan,       << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
   - {<< : *arm64_allmod,      << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
   - {<< : *arm64_allmod_lto,  << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
@@ -876,7 +876,7 @@ builds:
   - {<< : *arm64_lto_full,    << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
   - {<< : *arm64_lto_thin,    << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
   - {<< : *arm64_kasan,       << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
   - {<< : *arm64_ubsan,       << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
   - {<< : *arm64_allmod,      << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
   - {<< : *arm64_allmod_lto,  << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
@@ -934,7 +934,7 @@ builds:
   - {<< : *arm64_lto_full,    << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
   - {<< : *arm64_lto_thin,    << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
   - {<< : *arm64_kasan,       << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_kasan_sw,    << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_kasan_sw,    << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
   - {<< : *arm64_ubsan,       << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
   - {<< : *arm64_allmod,      << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
   - {<< : *arm64_allmod_lto,  << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}


### PR DESCRIPTION
After increasing the timeout to 20m, there are still boot timeouts for
clang-11 and clang-12. It is likely that we would need to increase the
timeout to 40+ minutes so instead, just disable the boot tests.