### PR TITLE
remove expect package from install deps

### DIFF
--- a/install_deps.py
+++ b/install_deps.py
@@ -29,7 +29,7 @@ def install_deps():
         sys.exit(1)
     # Not specific to any arch.
     dependencies = [
-        "expect",  # unbuffer command used by boot-utils/boot-qemu.sh.
+        # Add arch agnostic dependencies here.
     ] + arch_dependencies[arch]
     print("Installing:", dependencies)
 


### PR DESCRIPTION
After https://github.com/ClangBuiltLinux/boot-utils/pull/49
we use stdbuf from coreutils.