### PR TITLE
patches: Add futex patch to android-mainline

### DIFF
--- a/patches/android-mainline/20210830_ndesaulniers_arm_select_have_futex_cmpxchg.patch
+++ b/patches/android-mainline/20210830_ndesaulniers_arm_select_have_futex_cmpxchg.patch
@@ -1,0 +1,53 @@
+From git@z Thu Jan  1 00:00:00 1970
+Subject: [PATCH] ARM: select HAVE_FUTEX_CMPXCHG
+From: Nick Desaulniers <ndesaulniers@google.com>
+Date: Mon, 30 Aug 2021 14:38:43 -0700
+Message-Id: <20210830213846.2609349-1-ndesaulniers@google.com>
+To: linux-arm-kernel@lists.infradead.org
+Cc: llvm@lists.linux.dev, Nick Desaulniers <ndesaulniers@google.com>, Arnd Bergmann <arnd@arndb.de>, Nathan Chancellor <nathan@kernel.org>, Thomas Gleixner <tglx@linutronix.de>, Russell King <linux@armlinux.org.uk>, Geert Uytterhoeven <geert+renesas@glider.be>, Linus Walleij <linus.walleij@linaro.org>, Andrew Morton <akpm@linux-foundation.org>, Anshuman Khandual <anshuman.khandual@arm.com>, Ard Biesheuvel <ardb@kernel.org>, YiFei Zhu <yifeifz2@illinois.edu>, "Uwe Kleine-König" <u.kleine-koenig@pengutronix.de>, Mike Rapoport <rppt@kernel.org>, linux-kernel@vger.kernel.org, clang-built-linux@googlegroups.com
+List-Id: <linux-kernel.vger.kernel.org>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+tglx notes:
+  This function [futex_detect_cmpxchg] is only needed when an
+  architecture has to runtime discover whether the CPU supports it or
+  not.  ARM has unconditional support for this, so the obvious thing to
+  do is the below.
+
+Fixes linkage failure from Clang randconfigs:
+kernel/futex.o:(.text.fixup+0x5c): relocation truncated to fit: R_ARM_JUMP24 against `.init.text'
+and boot failures for CONFIG_THUMB2_KERNEL.
+
+Link: https://github.com/ClangBuiltLinux/linux/issues/325
+Reported-by: Arnd Bergmann <arnd@arndb.de>
+Reported-by: Nathan Chancellor <nathan@kernel.org>
+Suggested-by: Thomas Gleixner <tglx@linutronix.de>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Reviewed-by: Arnd Bergmann <arnd@arndb.de>
+Reviewed-by: Linus Walleij <linus.walleij@linaro.org>
+Tested-by: Nathan Chancellor <nathan@kernel.org>
+Reviewed-by: Thomas Gleixner <tglx@linutronix.de>
+Link: https://lore.kernel.org/r/20210830213846.2609349-1-ndesaulniers@google.com
+---
+ arch/arm/Kconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm/Kconfig b/arch/arm/Kconfig
+index fc196421b2ce..b760dd45b734 100644
+--- a/arch/arm/Kconfig
++++ b/arch/arm/Kconfig
+@@ -92,6 +92,7 @@ config ARM
+ 	select HAVE_FTRACE_MCOUNT_RECORD if !XIP_KERNEL
+ 	select HAVE_FUNCTION_GRAPH_TRACER if !THUMB2_KERNEL && !CC_IS_CLANG
+ 	select HAVE_FUNCTION_TRACER if !XIP_KERNEL
++	select HAVE_FUTEX_CMPXCHG if FUTEX
+ 	select HAVE_GCC_PLUGINS
+ 	select HAVE_HW_BREAKPOINT if PERF_EVENTS && (CPU_V6 || CPU_V6K || CPU_V7)
+ 	select HAVE_IRQ_TIME_ACCOUNTING
+
+-- 
+2.33.0.259.gc128427fd7-goog
+
+

--- a/patches/android-mainline/series
+++ b/patches/android-mainline/series
@@ -1,1 +1,2 @@
+20210830_ndesaulniers_arm_select_have_futex_cmpxchg.patch
 20210920_ndesaulniers_nbd_use_shifts_rather_than_multiplies.patch


### PR DESCRIPTION
We are testing THUMB2 on android-mainline so we need this patch to avoid
boot failures.