### PR TITLE
check_logs.py: Handle equals sign in configuration value

### DIFF
--- a/check_logs.py
+++ b/check_logs.py
@@ -82,7 +82,7 @@ def check_built_config(build):
         name = None
         state = None
         if '=' in line:
-            name, state = line.split('=')
+            name, state = line.split('=', 1)
         elif line.startswith("# CONFIG_"):
             name, state = line.split(" ", 2)[1:]
             if state != "is not set":


### PR DESCRIPTION
The current code chokes when there is an equals sign in the
configuration value:

`CONFIG_CMDLINE="console=ttyAMA0"`

```
Traceback (most recent call last):
  File "./check_logs.py", line 169, in <module>
    check_built_config(build)
  File "./check_logs.py", line 85, in check_built_config
    name, state = line.split('=')
ValueError: too many values to unpack (expected 2)
```

We just want to split on the first equals sign so add a max split of 1.