### PR TITLE
fully qualify error classes from urllib

### DIFF
--- a/check_logs.py
+++ b/check_logs.py
@@ -29,7 +29,7 @@ def _fetch(title, url, dest):
             print_yellow('%s download error ("%s"), retrying...' %
                          (title, str(err)))
             pass
-        except HTTPError as err:
+        except urllib.error.HTTPError as err:
             if err.code in retry_codes:
                 print_yellow("%s download error (%d), retrying..." %
                              (title, err.code))
@@ -42,7 +42,7 @@ def _fetch(title, url, dest):
             else:
                 print_red("%d error trying to download %s" % (err.code, title))
                 sys.exit(1)
-        except URLError as err:
+        except urllib.error.URLError as err:
             print_yellow('%s download error ("%s"), retrying...' %
                          (title, str(err)))
             pass


### PR DESCRIPTION
Otherwise we're referring to classes not in scope, as seen in:
https://github.com/ClangBuiltLinux/continuous-integration2/runs/3767136408?check_suite_focus=true

Link: #213
Link: #214
Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>