### PR TITLE
Remove CROSS_COMPILE_COMPAT and add CONFIG_COMPAT_VDSO=n build

### DIFF
--- a/.github/workflows/5.4.yml
+++ b/.github/workflows/5.4.yml
@@ -70,16 +70,16 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _8b6514fc2e63bf7f97f781e252c04550:
+  _b47eaab7c36202f985db8ea18a308034:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_COMPAT_VDSO=n
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: defconfig
+      CONFIG: defconfig+CONFIG_COMPAT_VDSO=n
     steps:
     - uses: actions/checkout@v2
       with:
@@ -260,16 +260,16 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _210faf86b075b31ec48b4fa5276daa01:
+  _916863380983edf50c119ce943b212ff:
     runs-on: ubuntu-20.04
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_COMPAT_VDSO=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       INSTALL_DEPS: 1
       BOOT: 1
-      CONFIG: defconfig
+      CONFIG: defconfig+CONFIG_COMPAT_VDSO=n
     steps:
     - uses: actions/checkout@v2
       with:

--- a/generator.yml
+++ b/generator.yml
@@ -95,6 +95,8 @@ configs:
   - &arm32_fedora      {config: [*arm32-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                          << : *arm-triple,           << : *kernel_modules}
   - &arm32_suse        {config: *arm32-suse-config-url,                                                                                    << : *arm-triple,           << : *kernel_modules}
   - &arm64             {config: defconfig,                                                                                                 << : *arm64-triple,         << : *kernel_modules}
+  #                                         https://github.com/ClangBuiltLinux/linux/issues/595
+  - &arm64_no_vdso32   {config: [defconfig, CONFIG_COMPAT_VDSO=n],                                                                         << : *arm64-triple,         << : *kernel_modules}
   - &arm64be           {config: [defconfig, CONFIG_CPU_BIG_ENDIAN=y],                                                                      << : *arm64-triple,         << : *kernel_modules}
   - &arm64_lto_full    {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                      << : *arm64-triple,         << : *kernel_modules}
   - &arm64_lto_thin    {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                      << : *arm64-triple,         << : *kernel_modules}
@@ -162,8 +164,6 @@ tiers:
   # Architecture specific tiers
   # ARM32 aspeed_g5_defconfig                                           https://github.com/ClangBuiltLinux/linux/issues/732
   - &arm32_v6_llvm      {llvm: true,  llvm_ias: false, make_variables: {LD: arm-linux-gnueabihf-ld, LLVM: 1, LLVM_IAS: 0}}
-  # ARM64 for CROSS_COMPILE_COMPAT
-  - &arm64_llvm_full    {llvm: true,  llvm_ias: true,  make_variables: {CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-, LLVM: 1, LLVM_IAS: 1}}
   # MIPS big endian                                                     https://github.com/ClangBuiltLinux/linux/issues/1025
   - &mips_llvm          {llvm: true,  llvm_ias: false, make_variables: {LD: mips-linux-gnu-ld, LLVM: 1, LLVM_IAS: 0}}
   - &mips_llvm_full     {llvm: true,  llvm_ias: true,  make_variables: {LD: mips-linux-gnu-ld, LLVM: 1, LLVM_IAS: 1}}
@@ -191,20 +191,20 @@ builds:
   - {<< : *arm32_allyes,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm32_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64,             << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_lto_full,    << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_lto_thin,    << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_cfi,         << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_kasan,       << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_ubsan,       << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_allmod,      << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allmod_lto,  << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_kasan,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_ubsan,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm64_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64_allno,       << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allyes,      << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_fedora,      << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_suse,        << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm64_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_suse,        << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *hexagon,           << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
@@ -251,20 +251,20 @@ builds:
   - {<< : *arm32_allyes,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm32_fedora,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64,             << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_lto_full,    << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_lto_thin,    << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_cfi,         << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_kasan,       << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_kasan_sw,    << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_ubsan,       << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_allmod,      << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allmod_lto,  << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_kasan_sw,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_ubsan,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allyes,      << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_fedora,      << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_suse,        << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm64_fedora,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_suse,        << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
@@ -312,20 +312,20 @@ builds:
   - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64,             << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_cfi,         << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_kasan,       << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_allmod,      << : *stable-5_15,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allmod_lto,  << : *stable-5_15,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_cfi,         << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm64_allmod_lto,  << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allyes,      << : *stable-5_15,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_fedora,      << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_suse,        << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm64_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
@@ -367,11 +367,11 @@ builds:
   - {<< : *arm32_allmod,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_tot}
   - {<< : *arm32_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm32_allyes,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64,             << : *stable-5_10,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64,             << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64be,           << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_allmod,      << : *stable-5_10,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allyes,      << : *stable-5_10,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *mips,              << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
@@ -389,7 +389,7 @@ builds:
   ###########
   - {<< : *arm32_v7,          << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_v7_t,        << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64,             << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_no_vdso32,   << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64be,           << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *mips,              << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
   - {<< : *mipsel,            << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
@@ -433,19 +433,19 @@ builds:
   #############
   - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_gki,         << : *android-mainline, << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_allmod,      << : *android13-5_10,   << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm32_v7_t,        << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_gki,         << : *android13-5_10,   << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_gki,         << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_gki,        << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_allmod,      << : *android12-5_10,   << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm32_v7_t,        << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_gki,         << : *android12-5_10,   << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_gki,         << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_gki,        << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm32_allmod,      << : *android12-5_4,    << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm32_v7_t,        << : *android12-5_4,    << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_gki,         << : *android12-5_4,    << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_gki,         << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_gki,        << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64_gki,         << : *android-4_19,     << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *x86_64_gki,        << : *android-4_19,     << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
@@ -469,16 +469,16 @@ builds:
   ###########
   #  ARM64  #
   ###########
-  - {<< : *arm64,             << : *arm64-core,       << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64,             << : *arm64-core,       << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64be,           << : *arm64-core,       << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_allmod,      << : *arm64-core,       << : *arm64_llvm_full, boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm64_allmod,      << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64_allno,       << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allyes,      << : *arm64-core,       << : *arm64_llvm_full, boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64,             << : *arm64-fixes,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm64_allyes,      << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm64,             << : *arm64-fixes,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
   - {<< : *arm64be,           << : *arm64-fixes,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   - {<< : *arm64_allno,       << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
   #########################
   #  Latest LLVM release  #
   #########################
@@ -498,20 +498,20 @@ builds:
   - {<< : *arm32_allyes,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm32_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64,             << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_lto_full,    << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_lto_thin,    << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_cfi,         << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_kasan,       << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_ubsan,       << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_allmod,      << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allmod_lto,  << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_kasan,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_ubsan,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm64_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm64_allno,       << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allyes,      << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_fedora,      << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_suse,        << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm64_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_suse,        << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *hexagon,           << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
@@ -558,20 +558,20 @@ builds:
   - {<< : *arm32_allyes,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm32_fedora,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64,             << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_lto_full,    << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_lto_thin,    << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_cfi,         << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_kasan,       << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_kasan_sw,    << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_ubsan,       << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_allmod,      << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allmod_lto,  << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_kasan_sw,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_ubsan,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allyes,      << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_fedora,      << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_suse,        << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm64_fedora,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_suse,        << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
@@ -619,20 +619,20 @@ builds:
   - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64,             << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_cfi,         << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_kasan,       << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_allmod,      << : *stable-5_15,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allmod_lto,  << : *stable-5_15,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_cfi,         << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm64_allmod_lto,  << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm64_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allyes,      << : *stable-5_15,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_fedora,      << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_suse,        << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm64_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
@@ -674,11 +674,11 @@ builds:
   - {<< : *arm32_allmod,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_latest}
   - {<< : *arm32_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm32_allyes,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64,             << : *stable-5_10,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64,             << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64be,           << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_allmod,      << : *stable-5_10,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allyes,      << : *stable-5_10,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *mips,              << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
@@ -696,7 +696,7 @@ builds:
   ###########
   - {<< : *arm32_v7,          << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm32_v7_t,        << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64,             << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_no_vdso32,   << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64be,           << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *mips,              << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_latest}
   - {<< : *mipsel,            << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_latest}
@@ -740,19 +740,19 @@ builds:
   #############
   - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_gki,         << : *android-mainline, << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm32_allmod,      << : *android13-5_10,   << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm32_v7_t,        << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_gki,         << : *android13-5_10,   << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_gki,         << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_gki,        << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm32_allmod,      << : *android12-5_10,   << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm32_v7_t,        << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_gki,         << : *android12-5_10,   << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_gki,         << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_gki,        << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm32_allmod,      << : *android12-5_4,    << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm32_v7_t,        << : *android12-5_4,    << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_gki,         << : *android12-5_4,    << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_gki,         << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_gki,        << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64_gki,         << : *android-4_19,     << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *x86_64_gki,        << : *android-4_19,     << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
@@ -776,16 +776,16 @@ builds:
   ###########
   #  ARM64  #
   ###########
-  - {<< : *arm64,             << : *arm64-core,       << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64,             << : *arm64-core,       << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64be,           << : *arm64-core,       << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_allmod,      << : *arm64-core,       << : *arm64_llvm_full, boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm64_allmod,      << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm64_allno,       << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allyes,      << : *arm64-core,       << : *arm64_llvm_full, boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64,             << : *arm64-fixes,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm64_allyes,      << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm64,             << : *arm64-fixes,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
   - {<< : *arm64be,           << : *arm64-fixes,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   - {<< : *arm64_allno,       << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
   #############
   #  LLVM 12  #
   #############
@@ -804,19 +804,19 @@ builds:
   - {<< : *arm32_allyes,      << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_12}
   - {<< : *arm32_fedora,      << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_12}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64,             << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_lto_full,    << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_lto_thin,    << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_cfi,         << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_kasan,       << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_ubsan,       << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_allmod,      << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allmod_lto,  << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_kasan,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64_ubsan,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_12}
   - {<< : *arm64_allno,       << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allyes,      << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_fedora,      << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_suse,        << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_suse,        << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
   - {<< : *hexagon,           << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_12}
   - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
@@ -862,19 +862,19 @@ builds:
   - {<< : *arm32_allyes,      << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_12}
   - {<< : *arm32_fedora,      << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_12}
   - {<< : *arm32_suse,        << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64,             << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_lto_full,    << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_lto_thin,    << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_cfi,         << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_kasan,       << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_kasan_sw,    << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_ubsan,       << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_allmod,      << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allmod_lto,  << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_kasan_sw,    << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64_ubsan,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_12}
   - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allyes,      << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_fedora,      << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_suse,        << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64_fedora,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_suse,        << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
   - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_12}
   - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
@@ -920,19 +920,19 @@ builds:
   - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm,            boot: false, llvm_version: *llvm_12}
   - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
   - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64,             << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_cfi,         << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_kasan,       << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_allmod,      << : *stable-5_15,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allmod_lto,  << : *stable-5_15,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_cfi,         << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64_allmod_lto,  << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
   - {<< : *arm64_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allyes,      << : *stable-5_15,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_fedora,      << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_suse,        << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
   - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
   - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
@@ -973,10 +973,10 @@ builds:
   - {<< : *arm32_allmod,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_12}
   - {<< : *arm32_allno,       << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_12}
   - {<< : *arm32_allyes,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64,             << : *stable-5_10,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_allmod,      << : *stable-5_10,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64,             << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
   - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allyes,      << : *stable-5_10,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
   - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
   - {<< : *mips,              << : *stable-5_10,      << : *mips_llvm,       boot: true,  llvm_version: *llvm_12}
   - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
@@ -996,19 +996,19 @@ builds:
   #############
   - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm,            boot: false, llvm_version: *llvm_12}
   - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_gki,         << : *android-mainline, << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
   - {<< : *arm32_allmod,      << : *android13-5_10,   << : *llvm,            boot: false, llvm_version: *llvm_12}
   - {<< : *arm32_v7_t,        << : *android13-5_10,   << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_gki,         << : *android13-5_10,   << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_gki,         << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
   - {<< : *x86_64_gki,        << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
   - {<< : *arm32_allmod,      << : *android12-5_10,   << : *llvm,            boot: false, llvm_version: *llvm_12}
   - {<< : *arm32_v7_t,        << : *android12-5_10,   << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_gki,         << : *android12-5_10,   << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_gki,         << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
   - {<< : *x86_64_gki,        << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
   - {<< : *arm32_allmod,      << : *android12-5_4,    << : *llvm,            boot: false, llvm_version: *llvm_12}
   - {<< : *arm32_v7_t,        << : *android12-5_4,    << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_gki,         << : *android12-5_4,    << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_gki,         << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
   - {<< : *x86_64_gki,        << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
   - {<< : *arm64_gki,         << : *android-4_19,     << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
   - {<< : *x86_64_gki,        << : *android-4_19,     << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
@@ -1027,14 +1027,14 @@ builds:
   ###########
   #  ARM64  #
   ###########
-  - {<< : *arm64,             << : *arm64-core,       << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_allmod,      << : *arm64-core,       << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64,             << : *arm64-core,       << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_allmod,      << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_12}
   - {<< : *arm64_allno,       << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allyes,      << : *arm64-core,       << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64,             << : *arm64-fixes,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64_allyes,      << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64,             << : *arm64-fixes,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
   - {<< : *arm64_allno,       << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
   #############
   #  LLVM 11  #
   #############
@@ -1053,18 +1053,18 @@ builds:
   - {<< : *arm32_allyes,      << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_11}
   - {<< : *arm32_fedora,      << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_11}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64,             << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_lto_full,    << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_lto_thin,    << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_kasan,       << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_ubsan,       << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_allmod,      << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allmod_lto,  << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_kasan,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64_ubsan,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_11}
   - {<< : *arm64_allno,       << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allyes,      << : *mainline,         << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_fedora,      << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_suse,        << : *mainline,         << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_suse,        << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
   - {<< : *hexagon,           << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_11}
   - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
   - {<< : *i686_fedora,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
@@ -1109,18 +1109,18 @@ builds:
   - {<< : *arm32_allyes,      << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_11}
   - {<< : *arm32_fedora,      << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_11}
   - {<< : *arm32_suse,        << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64,             << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_lto_full,    << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_lto_thin,    << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_kasan,       << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_kasan_sw,    << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_ubsan,       << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_allmod,      << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allmod_lto,  << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_kasan_sw,    << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64_ubsan,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
   - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allyes,      << : *next,             << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_fedora,      << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_suse,        << : *next,             << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64_fedora,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_suse,        << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
   - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
   - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
   - {<< : *i686_fedora,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
@@ -1165,18 +1165,18 @@ builds:
   - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm,            boot: false, llvm_version: *llvm_11}
   - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
   - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64,             << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_kasan,       << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_allmod,      << : *stable-5_15,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allmod_lto,  << : *stable-5_15,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64_allmod_lto,  << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
   - {<< : *arm64_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allyes,      << : *stable-5_15,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_fedora,      << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_suse,        << : *stable-5_15,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
   - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
   - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
   - {<< : *i686_fedora,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
@@ -1216,10 +1216,10 @@ builds:
   - {<< : *arm32_allmod,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_11}
   - {<< : *arm32_allno,       << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_11}
   - {<< : *arm32_allyes,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64,             << : *stable-5_10,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_allmod,      << : *stable-5_10,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64,             << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
   - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allyes,      << : *stable-5_10,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
   - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
   - {<< : *mips,              << : *stable-5_10,      << : *mips_llvm,       boot: true,  llvm_version: *llvm_11}
   - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
@@ -1246,14 +1246,14 @@ builds:
   ###########
   #  ARM64  #
   ###########
-  - {<< : *arm64,             << : *arm64-core,       << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_allmod,      << : *arm64-core,       << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64,             << : *arm64-core,       << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_allmod,      << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_11}
   - {<< : *arm64_allno,       << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allyes,      << : *arm64-core,       << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64,             << : *arm64-fixes,      << : *arm64_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64_allyes,      << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64,             << : *arm64-fixes,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
   - {<< : *arm64_allno,       << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *arm64_llvm_full, boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
   #############
   #  LLVM 10  #
   #############

--- a/tuxsuite/5.10.tux.yml
+++ b/tuxsuite/5.10.tux.yml
@@ -68,7 +68,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -269,7 +268,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -470,7 +468,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -660,7 +657,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -813,7 +809,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -840,7 +835,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -935,7 +929,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -962,7 +955,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1057,7 +1049,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1084,7 +1075,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1179,7 +1169,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1206,7 +1195,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git

--- a/tuxsuite/5.15.tux.yml
+++ b/tuxsuite/5.15.tux.yml
@@ -107,7 +107,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -136,7 +135,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -151,7 +149,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -167,7 +164,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -185,7 +181,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -203,7 +198,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -218,7 +212,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -546,7 +539,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -575,7 +567,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -590,7 +581,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -606,7 +596,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -624,7 +613,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -642,7 +630,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -657,7 +644,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -985,7 +971,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1000,7 +985,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1015,7 +999,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1031,7 +1014,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1049,7 +1031,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1067,7 +1048,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1082,7 +1062,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1384,7 +1363,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1399,7 +1377,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1414,7 +1391,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1432,7 +1408,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1450,7 +1425,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1465,7 +1439,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1678,7 +1651,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1693,7 +1665,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1832,7 +1803,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1847,7 +1817,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1986,7 +1955,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -2001,7 +1969,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -2116,7 +2083,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -2131,7 +2097,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -2277,7 +2242,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -2295,7 +2259,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -2322,7 +2285,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -2449,7 +2411,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -2467,7 +2428,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -2494,7 +2454,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -2621,7 +2580,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -2639,7 +2597,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -2666,7 +2623,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -2793,7 +2749,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -2811,7 +2766,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -2838,7 +2792,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git

--- a/tuxsuite/5.4.tux.yml
+++ b/tuxsuite/5.4.tux.yml
@@ -36,7 +36,9 @@ sets:
     git_ref: linux-5.4.y
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig: defconfig
+    kconfig:
+    - defconfig
+    - CONFIG_COMPAT_VDSO=n
     targets:
     - config
     - kernel
@@ -173,7 +175,9 @@ sets:
     git_ref: linux-5.4.y
     target_arch: arm64
     toolchain: clang-13
-    kconfig: defconfig
+    kconfig:
+    - defconfig
+    - CONFIG_COMPAT_VDSO=n
     targets:
     - config
     - kernel

--- a/tuxsuite/android-mainline.tux.yml
+++ b/tuxsuite/android-mainline.tux.yml
@@ -30,7 +30,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git
@@ -69,7 +68,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git
@@ -108,7 +106,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git

--- a/tuxsuite/android12-5.10.tux.yml
+++ b/tuxsuite/android12-5.10.tux.yml
@@ -30,7 +30,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git
@@ -69,7 +68,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git
@@ -108,7 +106,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git

--- a/tuxsuite/android12-5.4.tux.yml
+++ b/tuxsuite/android12-5.4.tux.yml
@@ -30,7 +30,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git
@@ -69,7 +68,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git
@@ -108,7 +106,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git

--- a/tuxsuite/android13-5.10.tux.yml
+++ b/tuxsuite/android13-5.10.tux.yml
@@ -30,7 +30,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git
@@ -69,7 +68,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git
@@ -108,7 +106,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://android.googlesource.com/kernel/common.git

--- a/tuxsuite/arm64-fixes.tux.yml
+++ b/tuxsuite/arm64-fixes.tux.yml
@@ -16,7 +16,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -43,7 +42,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -70,7 +68,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -83,7 +80,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
 - name: allconfigs
@@ -100,7 +96,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -127,7 +122,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -142,7 +136,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -169,7 +162,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -184,7 +176,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -211,7 +202,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -226,7 +216,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -253,7 +242,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
 

--- a/tuxsuite/arm64.tux.yml
+++ b/tuxsuite/arm64.tux.yml
@@ -16,7 +16,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -43,7 +42,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -70,7 +68,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -83,7 +80,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
 - name: allconfigs
@@ -100,7 +96,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -127,7 +122,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -142,7 +136,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -169,7 +162,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -184,7 +176,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -211,7 +202,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -226,7 +216,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
@@ -253,7 +242,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
 

--- a/tuxsuite/mainline.tux.yml
+++ b/tuxsuite/mainline.tux.yml
@@ -107,7 +107,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -136,7 +135,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -151,7 +149,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -167,7 +164,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -185,7 +181,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -203,7 +198,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -218,7 +212,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -546,7 +539,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -575,7 +567,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -590,7 +581,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -606,7 +596,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -624,7 +613,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -642,7 +630,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -657,7 +644,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -985,7 +971,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1000,7 +985,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1015,7 +999,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1031,7 +1014,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1049,7 +1031,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1067,7 +1048,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1082,7 +1062,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1384,7 +1363,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1399,7 +1377,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1414,7 +1391,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1432,7 +1408,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1450,7 +1425,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1465,7 +1439,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1801,7 +1774,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1816,7 +1788,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1955,7 +1926,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1970,7 +1940,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -2109,7 +2078,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -2124,7 +2092,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -2239,7 +2206,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -2254,7 +2220,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -2400,7 +2365,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -2418,7 +2382,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -2445,7 +2408,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -2572,7 +2534,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -2590,7 +2551,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -2617,7 +2577,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -2744,7 +2703,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -2762,7 +2720,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -2789,7 +2746,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -2916,7 +2872,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -2934,7 +2889,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -2961,7 +2915,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -107,7 +107,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -136,7 +135,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -151,7 +149,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -167,7 +164,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -185,7 +181,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -203,7 +198,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -218,7 +212,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -561,7 +554,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -590,7 +582,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -605,7 +596,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -621,7 +611,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -639,7 +628,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -657,7 +645,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -672,7 +659,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -1015,7 +1001,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -1030,7 +1015,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -1045,7 +1029,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -1061,7 +1044,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -1079,7 +1061,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -1097,7 +1078,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -1112,7 +1092,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -1414,7 +1393,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -1429,7 +1407,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -1444,7 +1421,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -1462,7 +1438,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -1480,7 +1455,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -1495,7 +1469,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -1975,7 +1948,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -1990,7 +1962,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -2129,7 +2100,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -2144,7 +2114,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -2283,7 +2252,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -2298,7 +2266,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -2413,7 +2380,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -2428,7 +2394,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -2574,7 +2539,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -2592,7 +2556,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -2619,7 +2582,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -2746,7 +2708,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -2764,7 +2725,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -2791,7 +2751,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -2918,7 +2877,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -2936,7 +2894,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -2963,7 +2920,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -3090,7 +3046,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -3108,7 +3063,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -3135,7 +3089,6 @@ sets:
     - kernel
     - modules
     make_variables:
-      CROSS_COMPILE_COMPAT: arm-linux-gnueabihf-
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git


### PR DESCRIPTION
TuxMake added CROSS_COMPILE_COMPAT to all arm64 make invocations,
meaning that CONFIG_COMPAT_VDSO is now enabled for all arm64 builds by
default. We had previously been adding CROSS_COMPILE_COMPAT to builds we
knew worked. Now, we have to disable CONFIG_COMPAT_VDSO for ones that we
know do not work, which is just 5.4.

This ends up simplifying our matrix as we will automatically get the
compat vDSO for any future builds we enable.

Link: https://gitlab.com/Linaro/tuxmake/-/commit/91cd7f1a85f76b7b120268362664c501157bb90e