### PR TITLE
Change TuxSuite targets

### DIFF
--- a/generator.yml
+++ b/generator.yml
@@ -77,6 +77,7 @@ triples:
   - &riscv-triple       {CROSS_COMPILE: riscv64-linux-gnu,     ARCH: *riscv-arch}
   - &s390-triple        {CROSS_COMPILE: s390x-linux-gnu,       ARCH: *s390-arch}
 targets:
+  - &default     {targets: [default]}
   - &kernel      {targets: [kernel]}
   - &kernel_dtbs {targets: [kernel,dtbs]}
 configs:
@@ -85,12 +86,12 @@ configs:
   - &arm32_v6          {config: aspeed_g5_defconfig,                                                                                       << : *arm-triple,           << : *kernel_dtbs}
   - &arm32_v7          {config: multi_v7_defconfig,                                                                                        << : *arm-triple,           << : *kernel}
   - &arm32_v7_t        {config: [multi_v7_defconfig, CONFIG_THUMB2_KERNEL=y],                                                              << : *arm-triple,           << : *kernel}
-  - &arm32_imx         {config: imx_v4_v5_defconfig,                                                                                       << : *arm-triple,           << : *kernel}
-  - &arm32_omap        {config: omap2plus_defconfig,                                                                                       << : *arm-triple,           << : *kernel}
+  - &arm32_imx         {config: imx_v4_v5_defconfig,                                                                                       << : *arm-triple,           << : *default}
+  - &arm32_omap        {config: omap2plus_defconfig,                                                                                       << : *arm-triple,           << : *default}
   - &arm32_lpae_fp     {config: [multi_v7_defconfig, CONFIG_ARM_LPAE=y, CONFIG_UNWINDER_FRAME_POINTER=y],                                  << : *arm-triple,           << : *kernel}
-  - &arm32_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                                                           << : *arm-triple,           << : *kernel}
-  - &arm32_allno       {config: allnoconfig,                                                                                               << : *arm-triple,           << : *kernel}
-  - &arm32_allyes      {config: [allyesconfig, CONFIG_WERROR=n],                                                                           << : *arm-triple,           << : *kernel}
+  - &arm32_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                                                           << : *arm-triple,           << : *default}
+  - &arm32_allno       {config: allnoconfig,                                                                                               << : *arm-triple,           << : *default}
+  - &arm32_allyes      {config: [allyesconfig, CONFIG_WERROR=n],                                                                           << : *arm-triple,           << : *default}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
   - &arm32_fedora      {config: [*arm32-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                          << : *arm-triple,           << : *kernel}
   - &arm32_suse        {config: *arm32-suse-config-url,                                                                                    << : *arm-triple,           << : *kernel}
@@ -106,21 +107,21 @@ configs:
   - &arm64_ubsan       {config: [defconfig, CONFIG_UBSAN=y],                                                                               << : *arm64-triple,         << : *kernel}
   - &arm64_gki         {config: gki_defconfig,                                                                                             << : *arm64-triple,         << : *kernel}
   - &arm64_cut         {config: cuttlefish_defconfig,                                                                                      << : *arm64-triple,         << : *kernel}
-  - &arm64_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                                                           << : *arm64-triple,         << : *kernel}
-  - &arm64_allmod_lto  {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_WERROR=n, CONFIG_LTO_CLANG_THIN=y],            << : *arm64-triple,         << : *kernel}
-  - &arm64_allno       {config: allnoconfig,                                                                                               << : *arm64-triple,         << : *kernel}
-  - &arm64_allyes      {config: [allyesconfig, CONFIG_WERROR=n],                                                                           << : *arm64-triple,         << : *kernel}
+  - &arm64_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                                                           << : *arm64-triple,         << : *default}
+  - &arm64_allmod_lto  {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_WERROR=n, CONFIG_LTO_CLANG_THIN=y],            << : *arm64-triple,         << : *default}
+  - &arm64_allno       {config: allnoconfig,                                                                                               << : *arm64-triple,         << : *default}
+  - &arm64_allyes      {config: [allyesconfig, CONFIG_WERROR=n],                                                                           << : *arm64-triple,         << : *default}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
   - &arm64_fedora      {config: [*arm64-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                          << : *arm64-triple,         << : *kernel}
   # CONFIG_DEBUG_INFO_BTF disabled for certain SUSE configs due to pahole issue: https://lore.kernel.org/r/20210506205622.3663956-1-kafai@fb.com/
   - &arm64_suse        {config: [*arm64-suse-config-url, CONFIG_DEBUG_INFO_BTF=n],                                                         << : *arm64-triple,         << : *kernel}
-  - &hexagon           {config: defconfig,                                                                                                 << : *hexagon-triple,       << : *kernel}
-  - &hexagon_allmod    {config: allmodconfig,                                                                                              << : *hexagon-triple,       << : *kernel}
+  - &hexagon           {config: defconfig,                                                                                                 << : *hexagon-triple,       << : *default}
+  - &hexagon_allmod    {config: allmodconfig,                                                                                              << : *hexagon-triple,       << : *default}
   - &i386              {config: defconfig,                                                                                                 << : *i386-triple,          << : *kernel}
   # CONFIG_ATOMIC64_SELFTEST disabled: https://github.com/ClangBuiltLinux/linux/issues/1437
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
   - &i686_fedora       {config: [*i686-fedora-config-url, CONFIG_ATOMIC64_SELFTEST=n, CONFIG_BPF_PRELOAD=n],                               << : *i386-triple,          << : *kernel}
-  - &i386_suse         {config: *i386-suse-config-url,                                                                                     << : *i386-triple,          << : *kernel}
+  - &i386_suse         {config: *i386-suse-config-url,                                                                                     << : *i386-triple,          << : *default}
   - &mips              {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y, CONFIG_CPU_BIG_ENDIAN=y],           kernel_image: vmlinux,      << : *mips-triple,          << : *kernel}
   - &mipsel            {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y],                                    kernel_image: vmlinux,      << : *mipsel-triple,        << : *kernel}
   - &ppc32             {config: ppc44x_defconfig,                                                              kernel_image: uImage,       << : *powerpc-triple,       << : *kernel}
@@ -131,7 +132,7 @@ configs:
   - &ppc64le_fedora    {config: [*ppc64le-fedora-config-url, CONFIG_BPF_PRELOAD=n],                            kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel}
   - &ppc64le_suse      {config: *ppc64le-suse-config-url,                                                      kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel}
   - &riscv             {config: defconfig,                                                                     kernel_image: Image,        << : *riscv-triple,         << : *kernel}
-  - &riscv_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                               kernel_image: Image,        << : *riscv-triple,         << : *kernel}
+  - &riscv_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                               kernel_image: Image,        << : *riscv-triple,         << : *default}
   #                                         https://github.com/ClangBuiltLinux/linux/issues/1143
   - &riscv_no_efi      {config: [defconfig, CONFIG_EFI=n],                                                     kernel_image: Image,        << : *riscv-triple,         << : *kernel}
   - &s390              {config: defconfig,                                                                                                 << : *s390-triple,          << : *kernel}
@@ -145,10 +146,10 @@ configs:
   - &x86_64_cfi        {config: [defconfig, CONFIG_LTO_CLANG_THIN=y, CONFIG_CFI_CLANG=y],                                                                              << : *kernel}
   - &x86_64_gki        {config: gki_defconfig,                                                                                                                         << : *kernel}
   - &x86_64_cut        {config: x86_64_cuttlefish_defconfig,                                                                                                           << : *kernel}
-  - &x86_64_allmod     {config: [allmodconfig, CONFIG_WERROR=n],                                                                                                       << : *kernel}
-  - &x86_64_allmod_lto {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_WERROR=n, CONFIG_LTO_CLANG_THIN=y],                                        << : *kernel}
-  - &x86_64_allno      {config: allnoconfig,                                                                                                                           << : *kernel}
-  - &x86_64_allyes     {config: [allyesconfig, CONFIG_WERROR=n],                                                                                                       << : *kernel}
+  - &x86_64_allmod     {config: [allmodconfig, CONFIG_WERROR=n],                                                                                                       << : *default}
+  - &x86_64_allmod_lto {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_WERROR=n, CONFIG_LTO_CLANG_THIN=y],                                        << : *default}
+  - &x86_64_allno      {config: allnoconfig,                                                                                                                           << : *default}
+  - &x86_64_allyes     {config: [allyesconfig, CONFIG_WERROR=n],                                                                                                       << : *default}
   - &x86_64_gcov       {config: [defconfig, CONFIG_GCOV_KERNEL=y, CONFIG_GCOV_PROFILE_ALL=y],                                                                          << : *kernel}
   - &x86_64_kasan      {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],                                        << : *kernel}
   - &x86_64_kcsan      {config: [defconfig, CONFIG_KCSAN=y, CONFIG_KCSAN_KUNIT_TEST=y, CONFIG_KUNIT=y],                                                                << : *kernel}

--- a/generator.yml
+++ b/generator.yml
@@ -77,8 +77,8 @@ triples:
   - &riscv-triple       {CROSS_COMPILE: riscv64-linux-gnu,     ARCH: *riscv-arch}
   - &s390-triple        {CROSS_COMPILE: s390x-linux-gnu,       ARCH: *s390-arch}
 targets:
-  - &kernel      {targets: [config,kernel]}
-  - &kernel_dtbs {targets: [config,kernel,dtbs]}
+  - &kernel      {targets: [kernel]}
+  - &kernel_dtbs {targets: [kernel,dtbs]}
 configs:
   #                     config:                                                                                image target (optional)     [triples:] (Optional: x86)  targets to build
   - &arm32_v5          {config: multi_v5_defconfig,                                                                                        << : *arm-triple,           << : *kernel_dtbs}

--- a/generator.yml
+++ b/generator.yml
@@ -77,85 +77,85 @@ triples:
   - &riscv-triple       {CROSS_COMPILE: riscv64-linux-gnu,     ARCH: *riscv-arch}
   - &s390-triple        {CROSS_COMPILE: s390x-linux-gnu,       ARCH: *s390-arch}
 targets:
-  - &kernel_modules      {targets: [config,kernel,modules]}
-  - &kernel_modules_dtbs {targets: [config,kernel,modules,dtbs]}
+  - &kernel      {targets: [config,kernel]}
+  - &kernel_dtbs {targets: [config,kernel,dtbs]}
 configs:
   #                     config:                                                                                image target (optional)     [triples:] (Optional: x86)  targets to build
-  - &arm32_v5          {config: multi_v5_defconfig,                                                                                        << : *arm-triple,           << : *kernel_modules_dtbs}
-  - &arm32_v6          {config: aspeed_g5_defconfig,                                                                                       << : *arm-triple,           << : *kernel_modules_dtbs}
-  - &arm32_v7          {config: multi_v7_defconfig,                                                                                        << : *arm-triple,           << : *kernel_modules}
-  - &arm32_v7_t        {config: [multi_v7_defconfig, CONFIG_THUMB2_KERNEL=y],                                                              << : *arm-triple,           << : *kernel_modules}
-  - &arm32_imx         {config: imx_v4_v5_defconfig,                                                                                       << : *arm-triple,           << : *kernel_modules}
-  - &arm32_omap        {config: omap2plus_defconfig,                                                                                       << : *arm-triple,           << : *kernel_modules}
-  - &arm32_lpae_fp     {config: [multi_v7_defconfig, CONFIG_ARM_LPAE=y, CONFIG_UNWINDER_FRAME_POINTER=y],                                  << : *arm-triple,           << : *kernel_modules}
-  - &arm32_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                                                           << : *arm-triple,           << : *kernel_modules}
-  - &arm32_allno       {config: allnoconfig,                                                                                               << : *arm-triple,           << : *kernel_modules}
-  - &arm32_allyes      {config: [allyesconfig, CONFIG_WERROR=n],                                                                           << : *arm-triple,           << : *kernel_modules}
+  - &arm32_v5          {config: multi_v5_defconfig,                                                                                        << : *arm-triple,           << : *kernel_dtbs}
+  - &arm32_v6          {config: aspeed_g5_defconfig,                                                                                       << : *arm-triple,           << : *kernel_dtbs}
+  - &arm32_v7          {config: multi_v7_defconfig,                                                                                        << : *arm-triple,           << : *kernel}
+  - &arm32_v7_t        {config: [multi_v7_defconfig, CONFIG_THUMB2_KERNEL=y],                                                              << : *arm-triple,           << : *kernel}
+  - &arm32_imx         {config: imx_v4_v5_defconfig,                                                                                       << : *arm-triple,           << : *kernel}
+  - &arm32_omap        {config: omap2plus_defconfig,                                                                                       << : *arm-triple,           << : *kernel}
+  - &arm32_lpae_fp     {config: [multi_v7_defconfig, CONFIG_ARM_LPAE=y, CONFIG_UNWINDER_FRAME_POINTER=y],                                  << : *arm-triple,           << : *kernel}
+  - &arm32_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                                                           << : *arm-triple,           << : *kernel}
+  - &arm32_allno       {config: allnoconfig,                                                                                               << : *arm-triple,           << : *kernel}
+  - &arm32_allyes      {config: [allyesconfig, CONFIG_WERROR=n],                                                                           << : *arm-triple,           << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
-  - &arm32_fedora      {config: [*arm32-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                          << : *arm-triple,           << : *kernel_modules}
-  - &arm32_suse        {config: *arm32-suse-config-url,                                                                                    << : *arm-triple,           << : *kernel_modules}
-  - &arm64             {config: defconfig,                                                                                                 << : *arm64-triple,         << : *kernel_modules}
+  - &arm32_fedora      {config: [*arm32-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                          << : *arm-triple,           << : *kernel}
+  - &arm32_suse        {config: *arm32-suse-config-url,                                                                                    << : *arm-triple,           << : *kernel}
+  - &arm64             {config: defconfig,                                                                                                 << : *arm64-triple,         << : *kernel}
   #                                         https://github.com/ClangBuiltLinux/linux/issues/595
-  - &arm64_no_vdso32   {config: [defconfig, CONFIG_COMPAT_VDSO=n],                                                                         << : *arm64-triple,         << : *kernel_modules}
-  - &arm64be           {config: [defconfig, CONFIG_CPU_BIG_ENDIAN=y],                                                                      << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_lto_full    {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                      << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_lto_thin    {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                      << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_cfi         {config: [defconfig, CONFIG_LTO_CLANG_THIN=y, CONFIG_CFI_CLANG=y],                                                  << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_kasan       {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],            << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_kasan_sw    {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_SW_TAGS=y, CONFIG_KUNIT=y],            << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_ubsan       {config: [defconfig, CONFIG_UBSAN=y],                                                                               << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_gki         {config: gki_defconfig,                                                                                             << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_cut         {config: cuttlefish_defconfig,                                                                                      << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                                                           << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_allmod_lto  {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_WERROR=n, CONFIG_LTO_CLANG_THIN=y],            << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_allno       {config: allnoconfig,                                                                                               << : *arm64-triple,         << : *kernel_modules}
-  - &arm64_allyes      {config: [allyesconfig, CONFIG_WERROR=n],                                                                           << : *arm64-triple,         << : *kernel_modules}
+  - &arm64_no_vdso32   {config: [defconfig, CONFIG_COMPAT_VDSO=n],                                                                         << : *arm64-triple,         << : *kernel}
+  - &arm64be           {config: [defconfig, CONFIG_CPU_BIG_ENDIAN=y],                                                                      << : *arm64-triple,         << : *kernel}
+  - &arm64_lto_full    {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                      << : *arm64-triple,         << : *kernel}
+  - &arm64_lto_thin    {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                      << : *arm64-triple,         << : *kernel}
+  - &arm64_cfi         {config: [defconfig, CONFIG_LTO_CLANG_THIN=y, CONFIG_CFI_CLANG=y],                                                  << : *arm64-triple,         << : *kernel}
+  - &arm64_kasan       {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],            << : *arm64-triple,         << : *kernel}
+  - &arm64_kasan_sw    {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_SW_TAGS=y, CONFIG_KUNIT=y],            << : *arm64-triple,         << : *kernel}
+  - &arm64_ubsan       {config: [defconfig, CONFIG_UBSAN=y],                                                                               << : *arm64-triple,         << : *kernel}
+  - &arm64_gki         {config: gki_defconfig,                                                                                             << : *arm64-triple,         << : *kernel}
+  - &arm64_cut         {config: cuttlefish_defconfig,                                                                                      << : *arm64-triple,         << : *kernel}
+  - &arm64_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                                                           << : *arm64-triple,         << : *kernel}
+  - &arm64_allmod_lto  {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_WERROR=n, CONFIG_LTO_CLANG_THIN=y],            << : *arm64-triple,         << : *kernel}
+  - &arm64_allno       {config: allnoconfig,                                                                                               << : *arm64-triple,         << : *kernel}
+  - &arm64_allyes      {config: [allyesconfig, CONFIG_WERROR=n],                                                                           << : *arm64-triple,         << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
-  - &arm64_fedora      {config: [*arm64-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                          << : *arm64-triple,         << : *kernel_modules}
+  - &arm64_fedora      {config: [*arm64-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                          << : *arm64-triple,         << : *kernel}
   # CONFIG_DEBUG_INFO_BTF disabled for certain SUSE configs due to pahole issue: https://lore.kernel.org/r/20210506205622.3663956-1-kafai@fb.com/
-  - &arm64_suse        {config: [*arm64-suse-config-url, CONFIG_DEBUG_INFO_BTF=n],                                                         << : *arm64-triple,         << : *kernel_modules}
-  - &hexagon           {config: defconfig,                                                                                                 << : *hexagon-triple,       << : *kernel_modules}
-  - &hexagon_allmod    {config: allmodconfig,                                                                                              << : *hexagon-triple,       << : *kernel_modules}
-  - &i386              {config: defconfig,                                                                                                 << : *i386-triple,          << : *kernel_modules}
+  - &arm64_suse        {config: [*arm64-suse-config-url, CONFIG_DEBUG_INFO_BTF=n],                                                         << : *arm64-triple,         << : *kernel}
+  - &hexagon           {config: defconfig,                                                                                                 << : *hexagon-triple,       << : *kernel}
+  - &hexagon_allmod    {config: allmodconfig,                                                                                              << : *hexagon-triple,       << : *kernel}
+  - &i386              {config: defconfig,                                                                                                 << : *i386-triple,          << : *kernel}
   # CONFIG_ATOMIC64_SELFTEST disabled: https://github.com/ClangBuiltLinux/linux/issues/1437
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
-  - &i686_fedora       {config: [*i686-fedora-config-url, CONFIG_ATOMIC64_SELFTEST=n, CONFIG_BPF_PRELOAD=n],                               << : *i386-triple,          << : *kernel_modules}
-  - &i386_suse         {config: *i386-suse-config-url,                                                                                     << : *i386-triple,          << : *kernel_modules}
-  - &mips              {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y, CONFIG_CPU_BIG_ENDIAN=y],           kernel_image: vmlinux,      << : *mips-triple,          << : *kernel_modules}
-  - &mipsel            {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y],                                    kernel_image: vmlinux,      << : *mipsel-triple,        << : *kernel_modules}
-  - &ppc32             {config: ppc44x_defconfig,                                                              kernel_image: uImage,       << : *powerpc-triple,       << : *kernel_modules}
+  - &i686_fedora       {config: [*i686-fedora-config-url, CONFIG_ATOMIC64_SELFTEST=n, CONFIG_BPF_PRELOAD=n],                               << : *i386-triple,          << : *kernel}
+  - &i386_suse         {config: *i386-suse-config-url,                                                                                     << : *i386-triple,          << : *kernel}
+  - &mips              {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y, CONFIG_CPU_BIG_ENDIAN=y],           kernel_image: vmlinux,      << : *mips-triple,          << : *kernel}
+  - &mipsel            {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y],                                    kernel_image: vmlinux,      << : *mipsel-triple,        << : *kernel}
+  - &ppc32             {config: ppc44x_defconfig,                                                              kernel_image: uImage,       << : *powerpc-triple,       << : *kernel}
   # Disable -Werror for pseries_defconfig for now: https://github.com/ClangBuiltLinux/linux/issues/1445
-  - &ppc64             {config: [pseries_defconfig, CONFIG_PPC_DISABLE_WERROR=y],                              kernel_image: vmlinux,      << : *powerpc64-triple,     << : *kernel_modules}
-  - &ppc64le           {config: powernv_defconfig,                                                             kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel_modules}
+  - &ppc64             {config: [pseries_defconfig, CONFIG_PPC_DISABLE_WERROR=y],                              kernel_image: vmlinux,      << : *powerpc64-triple,     << : *kernel}
+  - &ppc64le           {config: powernv_defconfig,                                                             kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
-  - &ppc64le_fedora    {config: [*ppc64le-fedora-config-url, CONFIG_BPF_PRELOAD=n],                            kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel_modules}
-  - &ppc64le_suse      {config: *ppc64le-suse-config-url,                                                      kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel_modules}
-  - &riscv             {config: defconfig,                                                                     kernel_image: Image,        << : *riscv-triple,         << : *kernel_modules}
-  - &riscv_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                               kernel_image: Image,        << : *riscv-triple,         << : *kernel_modules}
+  - &ppc64le_fedora    {config: [*ppc64le-fedora-config-url, CONFIG_BPF_PRELOAD=n],                            kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel}
+  - &ppc64le_suse      {config: *ppc64le-suse-config-url,                                                      kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel}
+  - &riscv             {config: defconfig,                                                                     kernel_image: Image,        << : *riscv-triple,         << : *kernel}
+  - &riscv_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                               kernel_image: Image,        << : *riscv-triple,         << : *kernel}
   #                                         https://github.com/ClangBuiltLinux/linux/issues/1143
-  - &riscv_no_efi      {config: [defconfig, CONFIG_EFI=n],                                                     kernel_image: Image,        << : *riscv-triple,         << : *kernel_modules}
-  - &s390              {config: defconfig,                                                                                                 << : *s390-triple,          << : *kernel_modules}
-  - &s390_kasan        {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],            << : *s390-triple,          << : *kernel_modules}
+  - &riscv_no_efi      {config: [defconfig, CONFIG_EFI=n],                                                     kernel_image: Image,        << : *riscv-triple,         << : *kernel}
+  - &s390              {config: defconfig,                                                                                                 << : *s390-triple,          << : *kernel}
+  - &s390_kasan        {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],            << : *s390-triple,          << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
-  - &s390_fedora       {config: [*s390-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                           << : *s390-triple,          << : *kernel_modules}
-  - &s390_suse         {config: *s390-suse-config-url,                                                                                     << : *s390-triple,          << : *kernel_modules}
-  - &x86_64            {config: defconfig,                                                                                                                             << : *kernel_modules}
-  - &x86_64_lto_full   {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                                                  << : *kernel_modules}
-  - &x86_64_lto_thin   {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                                                  << : *kernel_modules}
-  - &x86_64_cfi        {config: [defconfig, CONFIG_LTO_CLANG_THIN=y, CONFIG_CFI_CLANG=y],                                                                              << : *kernel_modules}
-  - &x86_64_gki        {config: gki_defconfig,                                                                                                                         << : *kernel_modules}
-  - &x86_64_cut        {config: x86_64_cuttlefish_defconfig,                                                                                                           << : *kernel_modules}
-  - &x86_64_allmod     {config: [allmodconfig, CONFIG_WERROR=n],                                                                                                       << : *kernel_modules}
-  - &x86_64_allmod_lto {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_WERROR=n, CONFIG_LTO_CLANG_THIN=y],                                        << : *kernel_modules}
-  - &x86_64_allno      {config: allnoconfig,                                                                                                                           << : *kernel_modules}
-  - &x86_64_allyes     {config: [allyesconfig, CONFIG_WERROR=n],                                                                                                       << : *kernel_modules}
-  - &x86_64_gcov       {config: [defconfig, CONFIG_GCOV_KERNEL=y, CONFIG_GCOV_PROFILE_ALL=y],                                                                          << : *kernel_modules}
-  - &x86_64_kasan      {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],                                        << : *kernel_modules}
-  - &x86_64_kcsan      {config: [defconfig, CONFIG_KCSAN=y, CONFIG_KCSAN_KUNIT_TEST=y, CONFIG_KUNIT=y],                                                                << : *kernel_modules}
-  - &x86_64_ubsan      {config: [defconfig, CONFIG_UBSAN=y],                                                                                                           << : *kernel_modules}
-  - &x86_64_arch       {config: *x86_64-arch-config-url,                                                                                                               << : *kernel_modules}
-  - &x86_64_fedora     {config: *x86_64-fedora-config-url,                                                                                                             << : *kernel_modules}
-  - &x86_64_suse       {config: *x86_64-suse-config-url,                                                                                                               << : *kernel_modules}
+  - &s390_fedora       {config: [*s390-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                           << : *s390-triple,          << : *kernel}
+  - &s390_suse         {config: *s390-suse-config-url,                                                                                     << : *s390-triple,          << : *kernel}
+  - &x86_64            {config: defconfig,                                                                                                                             << : *kernel}
+  - &x86_64_lto_full   {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                                                  << : *kernel}
+  - &x86_64_lto_thin   {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                                                  << : *kernel}
+  - &x86_64_cfi        {config: [defconfig, CONFIG_LTO_CLANG_THIN=y, CONFIG_CFI_CLANG=y],                                                                              << : *kernel}
+  - &x86_64_gki        {config: gki_defconfig,                                                                                                                         << : *kernel}
+  - &x86_64_cut        {config: x86_64_cuttlefish_defconfig,                                                                                                           << : *kernel}
+  - &x86_64_allmod     {config: [allmodconfig, CONFIG_WERROR=n],                                                                                                       << : *kernel}
+  - &x86_64_allmod_lto {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_WERROR=n, CONFIG_LTO_CLANG_THIN=y],                                        << : *kernel}
+  - &x86_64_allno      {config: allnoconfig,                                                                                                                           << : *kernel}
+  - &x86_64_allyes     {config: [allyesconfig, CONFIG_WERROR=n],                                                                                                       << : *kernel}
+  - &x86_64_gcov       {config: [defconfig, CONFIG_GCOV_KERNEL=y, CONFIG_GCOV_PROFILE_ALL=y],                                                                          << : *kernel}
+  - &x86_64_kasan      {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],                                        << : *kernel}
+  - &x86_64_kcsan      {config: [defconfig, CONFIG_KCSAN=y, CONFIG_KCSAN_KUNIT_TEST=y, CONFIG_KUNIT=y],                                                                << : *kernel}
+  - &x86_64_ubsan      {config: [defconfig, CONFIG_UBSAN=y],                                                                                                           << : *kernel}
+  - &x86_64_arch       {config: *x86_64-arch-config-url,                                                                                                               << : *kernel}
+  - &x86_64_fedora     {config: *x86_64-fedora-config-url,                                                                                                             << : *kernel}
+  - &x86_64_suse       {config: *x86_64-suse-config-url,                                                                                                               << : *kernel}
 tiers:
   # Generic tiers       LLVM=1       LLVM_IAS=1        Make variables to pass to TuxSuite
   - &llvm_full          {llvm: true,  llvm_ias: true,  make_variables: {LLVM: 1, LLVM_IAS: 1}}

--- a/tuxsuite/4.14.tux.yml
+++ b/tuxsuite/4.14.tux.yml
@@ -12,9 +12,7 @@ sets:
     toolchain: clang-nightly
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -25,9 +23,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -36,9 +32,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0
@@ -50,9 +44,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0
@@ -62,9 +54,7 @@ sets:
     toolchain: clang-nightly
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -74,9 +64,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0
@@ -86,9 +74,7 @@ sets:
     toolchain: clang-13
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -99,9 +85,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -110,9 +94,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0
@@ -124,9 +106,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0
@@ -136,9 +116,7 @@ sets:
     toolchain: clang-13
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -148,9 +126,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0

--- a/tuxsuite/4.19.tux.yml
+++ b/tuxsuite/4.19.tux.yml
@@ -12,9 +12,7 @@ sets:
     toolchain: clang-nightly
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -26,9 +24,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -38,9 +34,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -52,9 +46,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -64,9 +56,7 @@ sets:
     toolchain: clang-nightly
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -76,9 +66,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -88,9 +76,7 @@ sets:
     toolchain: clang-13
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -102,9 +88,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -114,9 +98,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -128,9 +110,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -140,9 +120,7 @@ sets:
     toolchain: clang-13
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -152,9 +130,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0

--- a/tuxsuite/4.4.tux.yml
+++ b/tuxsuite/4.4.tux.yml
@@ -12,9 +12,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -25,9 +23,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -36,9 +32,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0
@@ -48,9 +42,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -61,9 +53,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -72,9 +62,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0

--- a/tuxsuite/4.9.tux.yml
+++ b/tuxsuite/4.9.tux.yml
@@ -12,9 +12,7 @@ sets:
     toolchain: clang-nightly
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -23,9 +21,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -36,9 +32,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -47,9 +41,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0
@@ -59,9 +51,7 @@ sets:
     toolchain: clang-13
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -70,9 +60,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -83,9 +71,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -94,9 +80,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0

--- a/tuxsuite/5.10.tux.yml
+++ b/tuxsuite/5.10.tux.yml
@@ -12,9 +12,7 @@ sets:
     toolchain: clang-nightly
     kconfig: multi_v5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -25,9 +23,7 @@ sets:
     toolchain: clang-nightly
     kconfig: aspeed_g5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -38,9 +34,7 @@ sets:
     toolchain: clang-nightly
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -52,9 +46,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -64,9 +56,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -78,9 +68,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -90,9 +78,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -105,9 +91,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -120,9 +104,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -133,9 +115,7 @@ sets:
     toolchain: clang-nightly
     kconfig: ppc44x_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: uImage
     make_variables:
       LLVM: 1
@@ -148,9 +128,7 @@ sets:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: powerpc64le-linux-gnu-ld
@@ -162,9 +140,7 @@ sets:
     toolchain: clang-nightly
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
@@ -175,9 +151,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: Image
     make_variables:
       LD: riscv64-linux-gnu-ld
@@ -189,9 +163,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -200,9 +172,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -212,9 +182,7 @@ sets:
     toolchain: clang-13
     kconfig: multi_v5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -225,9 +193,7 @@ sets:
     toolchain: clang-13
     kconfig: aspeed_g5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -238,9 +204,7 @@ sets:
     toolchain: clang-13
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -252,9 +216,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -264,9 +226,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -278,9 +238,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -290,9 +248,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -305,9 +261,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -320,9 +274,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -333,9 +285,7 @@ sets:
     toolchain: clang-13
     kconfig: ppc44x_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: uImage
     make_variables:
       LLVM: 1
@@ -348,9 +298,7 @@ sets:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: powerpc64le-linux-gnu-ld
@@ -362,9 +310,7 @@ sets:
     toolchain: clang-13
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
@@ -375,9 +321,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: Image
     make_variables:
       LD: riscv64-linux-gnu-ld
@@ -389,9 +333,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -400,9 +342,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -412,9 +352,7 @@ sets:
     toolchain: clang-12
     kconfig: multi_v5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -425,9 +363,7 @@ sets:
     toolchain: clang-12
     kconfig: aspeed_g5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -438,9 +374,7 @@ sets:
     toolchain: clang-12
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -452,9 +386,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -464,9 +396,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -476,9 +406,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -491,9 +419,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: mips-linux-gnu-ld
@@ -507,9 +433,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -520,9 +444,7 @@ sets:
     toolchain: clang-12
     kconfig: ppc44x_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: uImage
     make_variables:
       LLVM: 1
@@ -535,9 +457,7 @@ sets:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: powerpc64le-linux-gnu-ld
@@ -549,9 +469,7 @@ sets:
     toolchain: clang-12
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
@@ -564,9 +482,7 @@ sets:
     - defconfig
     - CONFIG_EFI=n
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: Image
     make_variables:
       LD: riscv64-linux-gnu-ld
@@ -578,9 +494,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -589,9 +503,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -601,9 +513,7 @@ sets:
     toolchain: clang-11
     kconfig: multi_v5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -614,9 +524,7 @@ sets:
     toolchain: clang-11
     kconfig: aspeed_g5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -627,9 +535,7 @@ sets:
     toolchain: clang-11
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -641,9 +547,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -653,9 +557,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -665,9 +567,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -680,9 +580,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: mips-linux-gnu-ld
@@ -696,9 +594,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -709,9 +605,7 @@ sets:
     toolchain: clang-11
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
@@ -724,9 +618,7 @@ sets:
     - defconfig
     - CONFIG_EFI=n
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: Image
     make_variables:
       LD: riscv64-linux-gnu-ld
@@ -738,9 +630,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -749,9 +639,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -765,9 +653,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -777,9 +663,7 @@ sets:
     toolchain: clang-nightly
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -791,9 +675,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -805,9 +687,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -817,9 +697,7 @@ sets:
     toolchain: clang-nightly
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -831,9 +709,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -845,9 +721,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -857,9 +731,7 @@ sets:
     toolchain: clang-nightly
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -871,9 +743,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -885,9 +755,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -897,9 +765,7 @@ sets:
     toolchain: clang-13
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -911,9 +777,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -925,9 +789,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -937,9 +799,7 @@ sets:
     toolchain: clang-13
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -951,9 +811,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -965,9 +823,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -977,9 +833,7 @@ sets:
     toolchain: clang-13
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -991,9 +845,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1005,9 +857,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1017,9 +867,7 @@ sets:
     toolchain: clang-12
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1031,9 +879,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1045,9 +891,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1057,9 +901,7 @@ sets:
     toolchain: clang-12
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1071,9 +913,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1085,9 +925,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1097,9 +935,7 @@ sets:
     toolchain: clang-12
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1111,9 +947,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1125,9 +959,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1137,9 +969,7 @@ sets:
     toolchain: clang-11
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1151,9 +981,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1165,9 +993,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1177,9 +1003,7 @@ sets:
     toolchain: clang-11
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1191,9 +1015,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1205,9 +1027,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1217,9 +1037,7 @@ sets:
     toolchain: clang-11
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1231,9 +1049,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1

--- a/tuxsuite/5.15.tux.yml
+++ b/tuxsuite/5.15.tux.yml
@@ -12,9 +12,7 @@ sets:
     toolchain: clang-nightly
     kconfig: multi_v5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -25,9 +23,7 @@ sets:
     toolchain: clang-nightly
     kconfig: aspeed_g5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -38,9 +34,7 @@ sets:
     toolchain: clang-nightly
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -52,9 +46,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -64,9 +56,7 @@ sets:
     toolchain: clang-nightly
     kconfig: imx_v4_v5_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -76,9 +66,7 @@ sets:
     toolchain: clang-nightly
     kconfig: omap2plus_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -91,9 +79,7 @@ sets:
     - CONFIG_ARM_LPAE=y
     - CONFIG_UNWINDER_FRAME_POINTER=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -103,9 +89,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -117,9 +101,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -131,9 +113,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -145,9 +125,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -160,9 +138,7 @@ sets:
     - CONFIG_LTO_CLANG_THIN=y
     - CONFIG_CFI_CLANG=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -177,9 +153,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -194,9 +168,7 @@ sets:
     - CONFIG_KASAN_SW_TAGS=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -208,9 +180,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -220,9 +190,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -232,9 +200,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -247,9 +213,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -262,9 +226,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -275,9 +237,7 @@ sets:
     toolchain: clang-nightly
     kconfig: ppc44x_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: uImage
     make_variables:
       LLVM: 1
@@ -290,9 +250,7 @@ sets:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: powerpc64le-linux-gnu-ld
@@ -304,9 +262,7 @@ sets:
     toolchain: clang-nightly
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
@@ -317,9 +273,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -330,9 +284,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -346,9 +298,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -357,9 +307,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -371,9 +319,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -385,9 +331,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -402,9 +346,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -418,9 +360,7 @@ sets:
     - CONFIG_KCSAN_KUNIT_TEST=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -432,9 +372,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -444,9 +382,7 @@ sets:
     toolchain: clang-13
     kconfig: multi_v5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -457,9 +393,7 @@ sets:
     toolchain: clang-13
     kconfig: aspeed_g5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -470,9 +404,7 @@ sets:
     toolchain: clang-13
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -484,9 +416,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -496,9 +426,7 @@ sets:
     toolchain: clang-13
     kconfig: imx_v4_v5_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -508,9 +436,7 @@ sets:
     toolchain: clang-13
     kconfig: omap2plus_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -523,9 +449,7 @@ sets:
     - CONFIG_ARM_LPAE=y
     - CONFIG_UNWINDER_FRAME_POINTER=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -535,9 +459,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -549,9 +471,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -563,9 +483,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -577,9 +495,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -592,9 +508,7 @@ sets:
     - CONFIG_LTO_CLANG_THIN=y
     - CONFIG_CFI_CLANG=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -609,9 +523,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -626,9 +538,7 @@ sets:
     - CONFIG_KASAN_SW_TAGS=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -640,9 +550,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -652,9 +560,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -664,9 +570,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -679,9 +583,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -694,9 +596,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -707,9 +607,7 @@ sets:
     toolchain: clang-13
     kconfig: ppc44x_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: uImage
     make_variables:
       LLVM: 1
@@ -722,9 +620,7 @@ sets:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: powerpc64le-linux-gnu-ld
@@ -736,9 +632,7 @@ sets:
     toolchain: clang-13
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
@@ -749,9 +643,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -762,9 +654,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -778,9 +668,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -789,9 +677,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -803,9 +689,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -817,9 +701,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -834,9 +716,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -850,9 +730,7 @@ sets:
     - CONFIG_KCSAN_KUNIT_TEST=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -864,9 +742,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -876,9 +752,7 @@ sets:
     toolchain: clang-12
     kconfig: multi_v5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -889,9 +763,7 @@ sets:
     toolchain: clang-12
     kconfig: aspeed_g5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -902,9 +774,7 @@ sets:
     toolchain: clang-12
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -916,9 +786,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -928,9 +796,7 @@ sets:
     toolchain: clang-12
     kconfig: imx_v4_v5_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -940,9 +806,7 @@ sets:
     toolchain: clang-12
     kconfig: omap2plus_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -955,9 +819,7 @@ sets:
     - CONFIG_ARM_LPAE=y
     - CONFIG_UNWINDER_FRAME_POINTER=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -967,9 +829,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -981,9 +841,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -995,9 +853,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1010,9 +866,7 @@ sets:
     - CONFIG_LTO_CLANG_THIN=y
     - CONFIG_CFI_CLANG=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1027,9 +881,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1044,9 +896,7 @@ sets:
     - CONFIG_KASAN_SW_TAGS=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1058,9 +908,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1070,9 +918,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1082,9 +928,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1097,9 +941,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: mips-linux-gnu-ld
@@ -1113,9 +955,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -1126,9 +966,7 @@ sets:
     toolchain: clang-12
     kconfig: ppc44x_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: uImage
     make_variables:
       LLVM: 1
@@ -1141,9 +979,7 @@ sets:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: powerpc64le-linux-gnu-ld
@@ -1155,9 +991,7 @@ sets:
     toolchain: clang-12
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
@@ -1168,9 +1002,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -1181,9 +1013,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1195,9 +1025,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1209,9 +1037,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1226,9 +1052,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1242,9 +1066,7 @@ sets:
     - CONFIG_KCSAN_KUNIT_TEST=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1256,9 +1078,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1268,9 +1088,7 @@ sets:
     toolchain: clang-11
     kconfig: multi_v5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -1281,9 +1099,7 @@ sets:
     toolchain: clang-11
     kconfig: aspeed_g5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -1294,9 +1110,7 @@ sets:
     toolchain: clang-11
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1308,9 +1122,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1320,9 +1132,7 @@ sets:
     toolchain: clang-11
     kconfig: imx_v4_v5_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1332,9 +1142,7 @@ sets:
     toolchain: clang-11
     kconfig: omap2plus_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1347,9 +1155,7 @@ sets:
     - CONFIG_ARM_LPAE=y
     - CONFIG_UNWINDER_FRAME_POINTER=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1359,9 +1165,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1373,9 +1177,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1387,9 +1189,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1404,9 +1204,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1421,9 +1219,7 @@ sets:
     - CONFIG_KASAN_SW_TAGS=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1435,9 +1231,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1447,9 +1241,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1459,9 +1251,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1474,9 +1264,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: mips-linux-gnu-ld
@@ -1490,9 +1278,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -1503,9 +1289,7 @@ sets:
     toolchain: clang-11
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LD: powerpc64le-linux-gnu-ld
@@ -1517,9 +1301,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -1530,9 +1312,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1544,9 +1324,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1558,9 +1336,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1575,9 +1351,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1591,9 +1365,7 @@ sets:
     - CONFIG_KCSAN_KUNIT_TEST=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1605,9 +1377,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1621,9 +1391,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1633,9 +1401,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1647,9 +1413,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1661,9 +1425,7 @@ sets:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1673,9 +1435,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1687,9 +1447,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -1699,9 +1457,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -1713,9 +1469,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1724,9 +1478,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1735,9 +1487,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1747,9 +1497,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1759,9 +1507,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1773,9 +1519,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1785,9 +1529,7 @@ sets:
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1799,9 +1541,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1813,9 +1553,7 @@ sets:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1825,9 +1563,7 @@ sets:
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1839,9 +1575,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -1851,9 +1585,7 @@ sets:
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -1865,9 +1597,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1876,9 +1606,7 @@ sets:
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
@@ -1887,9 +1615,7 @@ sets:
     toolchain: clang-13
     kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1899,9 +1625,7 @@ sets:
     toolchain: clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1911,9 +1635,7 @@ sets:
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1925,9 +1647,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1937,9 +1657,7 @@ sets:
     toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1951,9 +1669,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1965,9 +1681,7 @@ sets:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1977,9 +1691,7 @@ sets:
     toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1991,9 +1703,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -2003,9 +1713,7 @@ sets:
     toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -2015,9 +1723,7 @@ sets:
     toolchain: clang-12
     kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2027,9 +1733,7 @@ sets:
     toolchain: clang-12
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2039,9 +1743,7 @@ sets:
     toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2053,9 +1755,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2065,9 +1765,7 @@ sets:
     toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2079,9 +1777,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2093,9 +1789,7 @@ sets:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2108,9 +1802,7 @@ sets:
     - CONFIG_ATOMIC64_SELFTEST=n
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2120,9 +1812,7 @@ sets:
     toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2134,9 +1824,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -2146,9 +1834,7 @@ sets:
     toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -2158,9 +1844,7 @@ sets:
     toolchain: clang-11
     kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2170,9 +1854,7 @@ sets:
     toolchain: clang-11
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2182,9 +1864,7 @@ sets:
     toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2198,9 +1878,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2210,9 +1888,7 @@ sets:
     toolchain: clang-nightly
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2224,9 +1900,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2238,9 +1912,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2255,9 +1927,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2267,9 +1937,7 @@ sets:
     toolchain: clang-nightly
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2281,9 +1949,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2295,9 +1961,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -2310,9 +1974,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2327,9 +1989,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2339,9 +1999,7 @@ sets:
     toolchain: clang-nightly
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2353,9 +2011,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2367,9 +2023,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2379,9 +2033,7 @@ sets:
     toolchain: clang-13
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2393,9 +2045,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2407,9 +2057,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2424,9 +2072,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2436,9 +2082,7 @@ sets:
     toolchain: clang-13
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2450,9 +2094,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2464,9 +2106,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -2479,9 +2119,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2496,9 +2134,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2508,9 +2144,7 @@ sets:
     toolchain: clang-13
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2522,9 +2156,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2536,9 +2168,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2548,9 +2178,7 @@ sets:
     toolchain: clang-12
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2562,9 +2190,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2576,9 +2202,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2593,9 +2217,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2605,9 +2227,7 @@ sets:
     toolchain: clang-12
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2619,9 +2239,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2633,9 +2251,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -2648,9 +2264,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2665,9 +2279,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2677,9 +2289,7 @@ sets:
     toolchain: clang-12
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2691,9 +2301,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2705,9 +2313,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2717,9 +2323,7 @@ sets:
     toolchain: clang-11
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2731,9 +2335,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2745,9 +2347,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2762,9 +2362,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2774,9 +2372,7 @@ sets:
     toolchain: clang-11
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2788,9 +2384,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2802,9 +2396,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -2817,9 +2409,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2834,9 +2424,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2846,9 +2434,7 @@ sets:
     toolchain: clang-11
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2860,9 +2446,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1

--- a/tuxsuite/5.4.tux.yml
+++ b/tuxsuite/5.4.tux.yml
@@ -12,9 +12,7 @@ sets:
     toolchain: clang-nightly
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -26,9 +24,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -40,9 +36,7 @@ sets:
     - defconfig
     - CONFIG_COMPAT_VDSO=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -54,9 +48,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -69,9 +61,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -84,9 +74,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -97,9 +85,7 @@ sets:
     toolchain: clang-nightly
     kconfig: ppc44x_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: uImage
     make_variables:
       LLVM: 1
@@ -112,9 +98,7 @@ sets:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: powerpc64le-linux-gnu-ld
@@ -126,9 +110,7 @@ sets:
     toolchain: clang-nightly
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
@@ -139,9 +121,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -151,9 +131,7 @@ sets:
     toolchain: clang-13
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -165,9 +143,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -179,9 +155,7 @@ sets:
     - defconfig
     - CONFIG_COMPAT_VDSO=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -193,9 +167,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -208,9 +180,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -223,9 +193,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -236,9 +204,7 @@ sets:
     toolchain: clang-13
     kconfig: ppc44x_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: uImage
     make_variables:
       LLVM: 1
@@ -251,9 +217,7 @@ sets:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: powerpc64le-linux-gnu-ld
@@ -265,9 +229,7 @@ sets:
     toolchain: clang-13
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
@@ -278,9 +240,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1

--- a/tuxsuite/android-4.14.tux.yml
+++ b/tuxsuite/android-4.14.tux.yml
@@ -12,9 +12,7 @@ sets:
     toolchain: clang-nightly
     kconfig: cuttlefish_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0
@@ -24,9 +22,7 @@ sets:
     toolchain: clang-nightly
     kconfig: x86_64_cuttlefish_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0
@@ -36,9 +32,7 @@ sets:
     toolchain: clang-13
     kconfig: cuttlefish_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0
@@ -48,9 +42,7 @@ sets:
     toolchain: clang-13
     kconfig: x86_64_cuttlefish_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0
@@ -60,9 +52,7 @@ sets:
     toolchain: clang-12
     kconfig: cuttlefish_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0
@@ -72,9 +62,7 @@ sets:
     toolchain: clang-12
     kconfig: x86_64_cuttlefish_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0
@@ -84,9 +72,7 @@ sets:
     toolchain: clang-android
     kconfig: cuttlefish_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0
@@ -96,9 +82,7 @@ sets:
     toolchain: clang-android
     kconfig: x86_64_cuttlefish_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0

--- a/tuxsuite/android-4.19.tux.yml
+++ b/tuxsuite/android-4.19.tux.yml
@@ -12,9 +12,7 @@ sets:
     toolchain: clang-nightly
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -24,9 +22,7 @@ sets:
     toolchain: clang-nightly
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -36,9 +32,7 @@ sets:
     toolchain: clang-13
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -48,9 +42,7 @@ sets:
     toolchain: clang-13
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -60,9 +52,7 @@ sets:
     toolchain: clang-12
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -72,9 +62,7 @@ sets:
     toolchain: clang-12
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -84,9 +72,7 @@ sets:
     toolchain: clang-android
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -96,9 +82,7 @@ sets:
     toolchain: clang-android
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1

--- a/tuxsuite/android-4.9.tux.yml
+++ b/tuxsuite/android-4.9.tux.yml
@@ -12,9 +12,7 @@ sets:
     toolchain: clang-nightly
     kconfig: cuttlefish_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
@@ -23,9 +21,7 @@ sets:
     toolchain: clang-nightly
     kconfig: x86_64_cuttlefish_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
@@ -34,9 +30,7 @@ sets:
     toolchain: clang-13
     kconfig: cuttlefish_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
@@ -45,9 +39,7 @@ sets:
     toolchain: clang-13
     kconfig: x86_64_cuttlefish_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
@@ -56,9 +48,7 @@ sets:
     toolchain: clang-12
     kconfig: cuttlefish_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
@@ -67,9 +57,7 @@ sets:
     toolchain: clang-12
     kconfig: x86_64_cuttlefish_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
@@ -78,9 +66,7 @@ sets:
     toolchain: clang-android
     kconfig: cuttlefish_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://android.googlesource.com/kernel/common.git
@@ -89,9 +75,7 @@ sets:
     toolchain: clang-android
     kconfig: x86_64_cuttlefish_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
 

--- a/tuxsuite/android-mainline.tux.yml
+++ b/tuxsuite/android-mainline.tux.yml
@@ -14,9 +14,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -26,9 +24,7 @@ sets:
     toolchain: clang-nightly
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -38,9 +34,7 @@ sets:
     toolchain: clang-nightly
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -52,9 +46,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -64,9 +56,7 @@ sets:
     toolchain: clang-13
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -76,9 +66,7 @@ sets:
     toolchain: clang-13
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -90,9 +78,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -102,9 +88,7 @@ sets:
     toolchain: clang-12
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -114,9 +98,7 @@ sets:
     toolchain: clang-12
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -128,9 +110,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -140,9 +120,7 @@ sets:
     toolchain: clang-android
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -152,9 +130,7 @@ sets:
     toolchain: clang-android
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -168,9 +144,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -182,9 +156,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -196,9 +168,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -210,9 +180,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1

--- a/tuxsuite/android12-5.10.tux.yml
+++ b/tuxsuite/android12-5.10.tux.yml
@@ -14,9 +14,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -26,9 +24,7 @@ sets:
     toolchain: clang-nightly
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -38,9 +34,7 @@ sets:
     toolchain: clang-nightly
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -52,9 +46,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -64,9 +56,7 @@ sets:
     toolchain: clang-13
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -76,9 +66,7 @@ sets:
     toolchain: clang-13
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -90,9 +78,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -102,9 +88,7 @@ sets:
     toolchain: clang-12
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -114,9 +98,7 @@ sets:
     toolchain: clang-12
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -128,9 +110,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -140,9 +120,7 @@ sets:
     toolchain: clang-android
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -152,9 +130,7 @@ sets:
     toolchain: clang-android
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -168,9 +144,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -182,9 +156,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -196,9 +168,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -210,9 +180,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1

--- a/tuxsuite/android12-5.4.tux.yml
+++ b/tuxsuite/android12-5.4.tux.yml
@@ -14,9 +14,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -26,9 +24,7 @@ sets:
     toolchain: clang-nightly
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -38,9 +34,7 @@ sets:
     toolchain: clang-nightly
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -52,9 +46,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -64,9 +56,7 @@ sets:
     toolchain: clang-13
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -76,9 +66,7 @@ sets:
     toolchain: clang-13
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -90,9 +78,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -102,9 +88,7 @@ sets:
     toolchain: clang-12
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -114,9 +98,7 @@ sets:
     toolchain: clang-12
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -128,9 +110,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -140,9 +120,7 @@ sets:
     toolchain: clang-android
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -152,9 +130,7 @@ sets:
     toolchain: clang-android
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -168,9 +144,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -182,9 +156,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -196,9 +168,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -210,9 +180,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1

--- a/tuxsuite/android13-5.10.tux.yml
+++ b/tuxsuite/android13-5.10.tux.yml
@@ -14,9 +14,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -26,9 +24,7 @@ sets:
     toolchain: clang-nightly
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -38,9 +34,7 @@ sets:
     toolchain: clang-nightly
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -52,9 +46,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -64,9 +56,7 @@ sets:
     toolchain: clang-13
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -76,9 +66,7 @@ sets:
     toolchain: clang-13
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -90,9 +78,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -102,9 +88,7 @@ sets:
     toolchain: clang-12
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -114,9 +98,7 @@ sets:
     toolchain: clang-12
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -128,9 +110,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -140,9 +120,7 @@ sets:
     toolchain: clang-android
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -152,9 +130,7 @@ sets:
     toolchain: clang-android
     kconfig: gki_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -168,9 +144,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -182,9 +156,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -196,9 +168,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -210,9 +180,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1

--- a/tuxsuite/arm64-fixes.tux.yml
+++ b/tuxsuite/arm64-fixes.tux.yml
@@ -12,9 +12,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -26,9 +24,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -38,9 +34,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -52,9 +46,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -64,9 +56,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -76,9 +66,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -92,9 +80,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -104,9 +90,7 @@ sets:
     toolchain: clang-nightly
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -118,9 +102,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -132,9 +114,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -144,9 +124,7 @@ sets:
     toolchain: clang-13
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -158,9 +136,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -172,9 +148,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -184,9 +158,7 @@ sets:
     toolchain: clang-12
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -198,9 +170,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -212,9 +182,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -224,9 +192,7 @@ sets:
     toolchain: clang-11
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -238,9 +204,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1

--- a/tuxsuite/arm64.tux.yml
+++ b/tuxsuite/arm64.tux.yml
@@ -12,9 +12,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -26,9 +24,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -38,9 +34,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -52,9 +46,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -64,9 +56,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -76,9 +66,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -92,9 +80,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -104,9 +90,7 @@ sets:
     toolchain: clang-nightly
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -118,9 +102,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -132,9 +114,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -144,9 +124,7 @@ sets:
     toolchain: clang-13
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -158,9 +136,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -172,9 +148,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -184,9 +158,7 @@ sets:
     toolchain: clang-12
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -198,9 +170,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -212,9 +182,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -224,9 +192,7 @@ sets:
     toolchain: clang-11
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -238,9 +204,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1

--- a/tuxsuite/lto-cfi-tip.tux.yml
+++ b/tuxsuite/lto-cfi-tip.tux.yml
@@ -15,9 +15,7 @@ sets:
     - CONFIG_LTO_CLANG_THIN=y
     - CONFIG_CFI_CLANG=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -30,9 +28,7 @@ sets:
     - CONFIG_LTO_CLANG_THIN=y
     - CONFIG_CFI_CLANG=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1

--- a/tuxsuite/lto-cfi.tux.yml
+++ b/tuxsuite/lto-cfi.tux.yml
@@ -15,9 +15,7 @@ sets:
     - CONFIG_LTO_CLANG_THIN=y
     - CONFIG_CFI_CLANG=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -30,9 +28,7 @@ sets:
     - CONFIG_LTO_CLANG_THIN=y
     - CONFIG_CFI_CLANG=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1

--- a/tuxsuite/mainline.tux.yml
+++ b/tuxsuite/mainline.tux.yml
@@ -12,9 +12,7 @@ sets:
     toolchain: clang-nightly
     kconfig: multi_v5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -25,9 +23,7 @@ sets:
     toolchain: clang-nightly
     kconfig: aspeed_g5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -38,9 +34,7 @@ sets:
     toolchain: clang-nightly
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -52,9 +46,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -64,9 +56,7 @@ sets:
     toolchain: clang-nightly
     kconfig: imx_v4_v5_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -76,9 +66,7 @@ sets:
     toolchain: clang-nightly
     kconfig: omap2plus_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -91,9 +79,7 @@ sets:
     - CONFIG_ARM_LPAE=y
     - CONFIG_UNWINDER_FRAME_POINTER=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -103,9 +89,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -117,9 +101,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -131,9 +113,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -145,9 +125,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -160,9 +138,7 @@ sets:
     - CONFIG_LTO_CLANG_THIN=y
     - CONFIG_CFI_CLANG=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -177,9 +153,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -194,9 +168,7 @@ sets:
     - CONFIG_KASAN_SW_TAGS=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -208,9 +180,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -220,9 +190,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -232,9 +200,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -247,9 +213,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -262,9 +226,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -275,9 +237,7 @@ sets:
     toolchain: clang-nightly
     kconfig: ppc44x_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: uImage
     make_variables:
       LLVM: 1
@@ -290,9 +250,7 @@ sets:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: powerpc64le-linux-gnu-ld
@@ -304,9 +262,7 @@ sets:
     toolchain: clang-nightly
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
@@ -317,9 +273,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -330,9 +284,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -346,9 +298,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -357,9 +307,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -371,9 +319,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -385,9 +331,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -402,9 +346,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -418,9 +360,7 @@ sets:
     - CONFIG_KCSAN_KUNIT_TEST=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -432,9 +372,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -444,9 +382,7 @@ sets:
     toolchain: clang-13
     kconfig: multi_v5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -457,9 +393,7 @@ sets:
     toolchain: clang-13
     kconfig: aspeed_g5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -470,9 +404,7 @@ sets:
     toolchain: clang-13
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -484,9 +416,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -496,9 +426,7 @@ sets:
     toolchain: clang-13
     kconfig: imx_v4_v5_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -508,9 +436,7 @@ sets:
     toolchain: clang-13
     kconfig: omap2plus_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -523,9 +449,7 @@ sets:
     - CONFIG_ARM_LPAE=y
     - CONFIG_UNWINDER_FRAME_POINTER=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -535,9 +459,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -549,9 +471,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -563,9 +483,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -577,9 +495,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -592,9 +508,7 @@ sets:
     - CONFIG_LTO_CLANG_THIN=y
     - CONFIG_CFI_CLANG=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -609,9 +523,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -626,9 +538,7 @@ sets:
     - CONFIG_KASAN_SW_TAGS=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -640,9 +550,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -652,9 +560,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -664,9 +570,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -679,9 +583,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -694,9 +596,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -707,9 +607,7 @@ sets:
     toolchain: clang-13
     kconfig: ppc44x_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: uImage
     make_variables:
       LLVM: 1
@@ -722,9 +620,7 @@ sets:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: powerpc64le-linux-gnu-ld
@@ -736,9 +632,7 @@ sets:
     toolchain: clang-13
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
@@ -749,9 +643,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -762,9 +654,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -778,9 +668,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -789,9 +677,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -803,9 +689,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -817,9 +701,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -834,9 +716,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -850,9 +730,7 @@ sets:
     - CONFIG_KCSAN_KUNIT_TEST=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -864,9 +742,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -876,9 +752,7 @@ sets:
     toolchain: clang-12
     kconfig: multi_v5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -889,9 +763,7 @@ sets:
     toolchain: clang-12
     kconfig: aspeed_g5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -902,9 +774,7 @@ sets:
     toolchain: clang-12
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -916,9 +786,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -928,9 +796,7 @@ sets:
     toolchain: clang-12
     kconfig: imx_v4_v5_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -940,9 +806,7 @@ sets:
     toolchain: clang-12
     kconfig: omap2plus_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -955,9 +819,7 @@ sets:
     - CONFIG_ARM_LPAE=y
     - CONFIG_UNWINDER_FRAME_POINTER=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -967,9 +829,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -981,9 +841,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -995,9 +853,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1010,9 +866,7 @@ sets:
     - CONFIG_LTO_CLANG_THIN=y
     - CONFIG_CFI_CLANG=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1027,9 +881,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1044,9 +896,7 @@ sets:
     - CONFIG_KASAN_SW_TAGS=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1058,9 +908,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1070,9 +918,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1082,9 +928,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1097,9 +941,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: mips-linux-gnu-ld
@@ -1113,9 +955,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -1126,9 +966,7 @@ sets:
     toolchain: clang-12
     kconfig: ppc44x_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: uImage
     make_variables:
       LLVM: 1
@@ -1141,9 +979,7 @@ sets:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: powerpc64le-linux-gnu-ld
@@ -1155,9 +991,7 @@ sets:
     toolchain: clang-12
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
@@ -1168,9 +1002,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -1181,9 +1013,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1195,9 +1025,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1209,9 +1037,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1226,9 +1052,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1242,9 +1066,7 @@ sets:
     - CONFIG_KCSAN_KUNIT_TEST=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1256,9 +1078,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1268,9 +1088,7 @@ sets:
     toolchain: clang-11
     kconfig: multi_v5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -1281,9 +1099,7 @@ sets:
     toolchain: clang-11
     kconfig: aspeed_g5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -1294,9 +1110,7 @@ sets:
     toolchain: clang-11
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1308,9 +1122,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1320,9 +1132,7 @@ sets:
     toolchain: clang-11
     kconfig: imx_v4_v5_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1332,9 +1142,7 @@ sets:
     toolchain: clang-11
     kconfig: omap2plus_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1347,9 +1155,7 @@ sets:
     - CONFIG_ARM_LPAE=y
     - CONFIG_UNWINDER_FRAME_POINTER=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1359,9 +1165,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1373,9 +1177,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1387,9 +1189,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1404,9 +1204,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1421,9 +1219,7 @@ sets:
     - CONFIG_KASAN_SW_TAGS=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1435,9 +1231,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1447,9 +1241,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1459,9 +1251,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1474,9 +1264,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: mips-linux-gnu-ld
@@ -1490,9 +1278,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -1503,9 +1289,7 @@ sets:
     toolchain: clang-11
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LD: powerpc64le-linux-gnu-ld
@@ -1517,9 +1301,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -1530,9 +1312,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1544,9 +1324,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1558,9 +1336,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1575,9 +1351,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1591,9 +1365,7 @@ sets:
     - CONFIG_KCSAN_KUNIT_TEST=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1605,9 +1377,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1617,9 +1387,7 @@ sets:
     toolchain: clang-10
     kconfig: multi_v5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -1630,9 +1398,7 @@ sets:
     toolchain: clang-10
     kconfig: aspeed_g5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LD: arm-linux-gnueabihf-ld
@@ -1644,9 +1410,7 @@ sets:
     toolchain: clang-10
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1658,9 +1422,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1670,9 +1432,7 @@ sets:
     toolchain: clang-10
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1685,9 +1445,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: mips-linux-gnu-ld
@@ -1701,9 +1459,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -1714,9 +1470,7 @@ sets:
     toolchain: clang-10
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LD: powerpc64le-linux-gnu-ld
@@ -1728,9 +1482,7 @@ sets:
     toolchain: clang-10
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1744,9 +1496,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1756,9 +1506,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1770,9 +1518,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1784,9 +1530,7 @@ sets:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1796,9 +1540,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1810,9 +1552,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -1822,9 +1562,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -1836,9 +1574,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1847,9 +1583,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1858,9 +1592,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1870,9 +1602,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1882,9 +1612,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1896,9 +1624,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1908,9 +1634,7 @@ sets:
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1922,9 +1646,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1936,9 +1658,7 @@ sets:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1948,9 +1668,7 @@ sets:
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1962,9 +1680,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -1974,9 +1690,7 @@ sets:
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -1988,9 +1702,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -1999,9 +1711,7 @@ sets:
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -2010,9 +1720,7 @@ sets:
     toolchain: clang-13
     kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2022,9 +1730,7 @@ sets:
     toolchain: clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2034,9 +1740,7 @@ sets:
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2048,9 +1752,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2060,9 +1762,7 @@ sets:
     toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2074,9 +1774,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2088,9 +1786,7 @@ sets:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2100,9 +1796,7 @@ sets:
     toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2114,9 +1808,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -2126,9 +1818,7 @@ sets:
     toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -2138,9 +1828,7 @@ sets:
     toolchain: clang-12
     kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2150,9 +1838,7 @@ sets:
     toolchain: clang-12
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2162,9 +1848,7 @@ sets:
     toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2176,9 +1860,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2188,9 +1870,7 @@ sets:
     toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2202,9 +1882,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2216,9 +1894,7 @@ sets:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2231,9 +1907,7 @@ sets:
     - CONFIG_ATOMIC64_SELFTEST=n
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2243,9 +1917,7 @@ sets:
     toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2257,9 +1929,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -2269,9 +1939,7 @@ sets:
     toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -2281,9 +1949,7 @@ sets:
     toolchain: clang-11
     kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2293,9 +1959,7 @@ sets:
     toolchain: clang-11
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2305,9 +1969,7 @@ sets:
     toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2321,9 +1983,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2333,9 +1993,7 @@ sets:
     toolchain: clang-nightly
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2347,9 +2005,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2361,9 +2017,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2378,9 +2032,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2390,9 +2042,7 @@ sets:
     toolchain: clang-nightly
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2404,9 +2054,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2416,9 +2064,7 @@ sets:
     toolchain: clang-nightly
     kconfig: allmodconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2430,9 +2076,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -2445,9 +2089,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2462,9 +2104,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2474,9 +2114,7 @@ sets:
     toolchain: clang-nightly
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2488,9 +2126,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2502,9 +2138,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2514,9 +2148,7 @@ sets:
     toolchain: clang-13
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2528,9 +2160,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2542,9 +2172,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2559,9 +2187,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2571,9 +2197,7 @@ sets:
     toolchain: clang-13
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2585,9 +2209,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2597,9 +2219,7 @@ sets:
     toolchain: clang-13
     kconfig: allmodconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2611,9 +2231,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -2626,9 +2244,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2643,9 +2259,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2655,9 +2269,7 @@ sets:
     toolchain: clang-13
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2669,9 +2281,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2683,9 +2293,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2695,9 +2303,7 @@ sets:
     toolchain: clang-12
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2709,9 +2315,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2723,9 +2327,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2740,9 +2342,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2752,9 +2352,7 @@ sets:
     toolchain: clang-12
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2766,9 +2364,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2780,9 +2376,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -2795,9 +2389,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2812,9 +2404,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2824,9 +2414,7 @@ sets:
     toolchain: clang-12
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2838,9 +2426,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2852,9 +2438,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2864,9 +2448,7 @@ sets:
     toolchain: clang-11
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2878,9 +2460,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2892,9 +2472,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2909,9 +2487,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2921,9 +2497,7 @@ sets:
     toolchain: clang-11
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2935,9 +2509,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2949,9 +2521,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -2964,9 +2534,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2981,9 +2549,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2993,9 +2559,7 @@ sets:
     toolchain: clang-11
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -3007,9 +2571,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -3019,9 +2581,7 @@ sets:
     toolchain: clang-10
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -3031,9 +2591,7 @@ sets:
     toolchain: clang-10
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -3043,9 +2601,7 @@ sets:
     toolchain: clang-10
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -12,9 +12,7 @@ sets:
     toolchain: clang-nightly
     kconfig: multi_v5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -25,9 +23,7 @@ sets:
     toolchain: clang-nightly
     kconfig: aspeed_g5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -38,9 +34,7 @@ sets:
     toolchain: clang-nightly
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -52,9 +46,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -64,9 +56,7 @@ sets:
     toolchain: clang-nightly
     kconfig: imx_v4_v5_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -76,9 +66,7 @@ sets:
     toolchain: clang-nightly
     kconfig: omap2plus_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -91,9 +79,7 @@ sets:
     - CONFIG_ARM_LPAE=y
     - CONFIG_UNWINDER_FRAME_POINTER=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -103,9 +89,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -117,9 +101,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -131,9 +113,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -145,9 +125,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -160,9 +138,7 @@ sets:
     - CONFIG_LTO_CLANG_THIN=y
     - CONFIG_CFI_CLANG=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -177,9 +153,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -194,9 +168,7 @@ sets:
     - CONFIG_KASAN_SW_TAGS=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -208,9 +180,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -220,9 +190,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -232,9 +200,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -247,9 +213,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -262,9 +226,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -275,9 +237,7 @@ sets:
     toolchain: clang-nightly
     kconfig: ppc44x_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: uImage
     make_variables:
       LLVM: 1
@@ -290,9 +250,7 @@ sets:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: powerpc64le-linux-gnu-ld
@@ -304,9 +262,7 @@ sets:
     toolchain: clang-nightly
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
@@ -317,9 +273,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -330,9 +284,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -346,9 +298,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -357,9 +307,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -371,9 +319,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -385,9 +331,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -402,9 +346,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -418,9 +360,7 @@ sets:
     - CONFIG_KCSAN_KUNIT_TEST=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -432,9 +372,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -447,9 +385,7 @@ sets:
     - CONFIG_GCOV_KERNEL=y
     - CONFIG_GCOV_PROFILE_ALL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -459,9 +395,7 @@ sets:
     toolchain: clang-13
     kconfig: multi_v5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -472,9 +406,7 @@ sets:
     toolchain: clang-13
     kconfig: aspeed_g5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -485,9 +417,7 @@ sets:
     toolchain: clang-13
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -499,9 +429,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -511,9 +439,7 @@ sets:
     toolchain: clang-13
     kconfig: imx_v4_v5_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -523,9 +449,7 @@ sets:
     toolchain: clang-13
     kconfig: omap2plus_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -538,9 +462,7 @@ sets:
     - CONFIG_ARM_LPAE=y
     - CONFIG_UNWINDER_FRAME_POINTER=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -550,9 +472,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -564,9 +484,7 @@ sets:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -578,9 +496,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -592,9 +508,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -607,9 +521,7 @@ sets:
     - CONFIG_LTO_CLANG_THIN=y
     - CONFIG_CFI_CLANG=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -624,9 +536,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -641,9 +551,7 @@ sets:
     - CONFIG_KASAN_SW_TAGS=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -655,9 +563,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -667,9 +573,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -679,9 +583,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -694,9 +596,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -709,9 +609,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -722,9 +620,7 @@ sets:
     toolchain: clang-13
     kconfig: ppc44x_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: uImage
     make_variables:
       LLVM: 1
@@ -737,9 +633,7 @@ sets:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: powerpc64le-linux-gnu-ld
@@ -751,9 +645,7 @@ sets:
     toolchain: clang-13
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
@@ -764,9 +656,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -777,9 +667,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -793,9 +681,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -804,9 +690,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -818,9 +702,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -832,9 +714,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -849,9 +729,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -865,9 +743,7 @@ sets:
     - CONFIG_KCSAN_KUNIT_TEST=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -879,9 +755,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -894,9 +768,7 @@ sets:
     - CONFIG_GCOV_KERNEL=y
     - CONFIG_GCOV_PROFILE_ALL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -906,9 +778,7 @@ sets:
     toolchain: clang-12
     kconfig: multi_v5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -919,9 +789,7 @@ sets:
     toolchain: clang-12
     kconfig: aspeed_g5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -932,9 +800,7 @@ sets:
     toolchain: clang-12
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -946,9 +812,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -958,9 +822,7 @@ sets:
     toolchain: clang-12
     kconfig: imx_v4_v5_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -970,9 +832,7 @@ sets:
     toolchain: clang-12
     kconfig: omap2plus_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -985,9 +845,7 @@ sets:
     - CONFIG_ARM_LPAE=y
     - CONFIG_UNWINDER_FRAME_POINTER=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -997,9 +855,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1011,9 +867,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1025,9 +879,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1040,9 +892,7 @@ sets:
     - CONFIG_LTO_CLANG_THIN=y
     - CONFIG_CFI_CLANG=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1057,9 +907,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1074,9 +922,7 @@ sets:
     - CONFIG_KASAN_SW_TAGS=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1088,9 +934,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1100,9 +944,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1112,9 +954,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1127,9 +967,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: mips-linux-gnu-ld
@@ -1143,9 +981,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -1156,9 +992,7 @@ sets:
     toolchain: clang-12
     kconfig: ppc44x_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: uImage
     make_variables:
       LLVM: 1
@@ -1171,9 +1005,7 @@ sets:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: powerpc64le-linux-gnu-ld
@@ -1185,9 +1017,7 @@ sets:
     toolchain: clang-12
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
@@ -1198,9 +1028,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -1211,9 +1039,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1225,9 +1051,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1239,9 +1063,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1256,9 +1078,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1272,9 +1092,7 @@ sets:
     - CONFIG_KCSAN_KUNIT_TEST=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1286,9 +1104,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1298,9 +1114,7 @@ sets:
     toolchain: clang-11
     kconfig: multi_v5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -1311,9 +1125,7 @@ sets:
     toolchain: clang-11
     kconfig: aspeed_g5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -1324,9 +1136,7 @@ sets:
     toolchain: clang-11
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1338,9 +1148,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1350,9 +1158,7 @@ sets:
     toolchain: clang-11
     kconfig: imx_v4_v5_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1362,9 +1168,7 @@ sets:
     toolchain: clang-11
     kconfig: omap2plus_defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1377,9 +1181,7 @@ sets:
     - CONFIG_ARM_LPAE=y
     - CONFIG_UNWINDER_FRAME_POINTER=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -1389,9 +1191,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1403,9 +1203,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1417,9 +1215,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1434,9 +1230,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1451,9 +1245,7 @@ sets:
     - CONFIG_KASAN_SW_TAGS=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1465,9 +1257,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1477,9 +1267,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1489,9 +1277,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1504,9 +1290,7 @@ sets:
     - CONFIG_BLK_DEV_INITRD=y
     - CONFIG_CPU_BIG_ENDIAN=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LD: mips-linux-gnu-ld
@@ -1520,9 +1304,7 @@ sets:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: vmlinux
     make_variables:
       LLVM: 1
@@ -1533,9 +1315,7 @@ sets:
     toolchain: clang-11
     kconfig: powernv_defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LD: powerpc64le-linux-gnu-ld
@@ -1547,9 +1327,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -1560,9 +1338,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1574,9 +1350,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1588,9 +1362,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1605,9 +1377,7 @@ sets:
     - CONFIG_KASAN_VMALLOC=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1621,9 +1391,7 @@ sets:
     - CONFIG_KCSAN_KUNIT_TEST=y
     - CONFIG_KUNIT=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1635,9 +1403,7 @@ sets:
     - defconfig
     - CONFIG_UBSAN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1647,9 +1413,7 @@ sets:
     toolchain: clang-android
     kconfig: multi_v5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -1660,9 +1424,7 @@ sets:
     toolchain: clang-android
     kconfig: aspeed_g5_defconfig
     targets:
-    - config
     - kernel
-    - modules
     - dtbs
     make_variables:
       LLVM: 1
@@ -1673,9 +1435,7 @@ sets:
     toolchain: clang-android
     kconfig: multi_v7_defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1687,9 +1447,7 @@ sets:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1699,9 +1457,7 @@ sets:
     toolchain: clang-android
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1713,9 +1469,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1727,9 +1481,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1739,9 +1491,7 @@ sets:
     toolchain: clang-android
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1751,9 +1501,7 @@ sets:
     toolchain: clang-android
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1765,9 +1513,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1779,9 +1525,7 @@ sets:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1795,9 +1539,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1807,9 +1549,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1821,9 +1561,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1835,9 +1573,7 @@ sets:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1847,9 +1583,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1861,9 +1595,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -1873,9 +1605,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -1887,9 +1617,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -1898,9 +1626,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -1909,9 +1635,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1921,9 +1645,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1933,9 +1655,7 @@ sets:
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1947,9 +1667,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1959,9 +1677,7 @@ sets:
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1973,9 +1689,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1987,9 +1701,7 @@ sets:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -1999,9 +1711,7 @@ sets:
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2013,9 +1723,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -2025,9 +1733,7 @@ sets:
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -2039,9 +1745,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -2050,9 +1754,7 @@ sets:
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
@@ -2061,9 +1763,7 @@ sets:
     toolchain: clang-13
     kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2073,9 +1773,7 @@ sets:
     toolchain: clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2085,9 +1783,7 @@ sets:
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2099,9 +1795,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2111,9 +1805,7 @@ sets:
     toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2125,9 +1817,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2139,9 +1829,7 @@ sets:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2151,9 +1839,7 @@ sets:
     toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2165,9 +1851,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -2177,9 +1861,7 @@ sets:
     toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -2189,9 +1871,7 @@ sets:
     toolchain: clang-12
     kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2201,9 +1881,7 @@ sets:
     toolchain: clang-12
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2213,9 +1891,7 @@ sets:
     toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2227,9 +1903,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2239,9 +1913,7 @@ sets:
     toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2253,9 +1925,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2267,9 +1937,7 @@ sets:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2282,9 +1950,7 @@ sets:
     - CONFIG_ATOMIC64_SELFTEST=n
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2294,9 +1960,7 @@ sets:
     toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2308,9 +1972,7 @@ sets:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -2320,9 +1982,7 @@ sets:
     toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
-    - config
     - kernel
-    - modules
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
@@ -2332,9 +1992,7 @@ sets:
     toolchain: clang-11
     kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2344,9 +2002,7 @@ sets:
     toolchain: clang-11
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2356,9 +2012,7 @@ sets:
     toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2372,9 +2026,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2384,9 +2036,7 @@ sets:
     toolchain: clang-nightly
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2398,9 +2048,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2412,9 +2060,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2429,9 +2075,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2441,9 +2085,7 @@ sets:
     toolchain: clang-nightly
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2455,9 +2097,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2467,9 +2107,7 @@ sets:
     toolchain: clang-nightly
     kconfig: allmodconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2481,9 +2119,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -2496,9 +2132,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2513,9 +2147,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2525,9 +2157,7 @@ sets:
     toolchain: clang-nightly
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2539,9 +2169,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2553,9 +2181,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2565,9 +2191,7 @@ sets:
     toolchain: clang-13
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2579,9 +2203,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2593,9 +2215,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2610,9 +2230,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2622,9 +2240,7 @@ sets:
     toolchain: clang-13
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2636,9 +2252,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2648,9 +2262,7 @@ sets:
     toolchain: clang-13
     kconfig: allmodconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2662,9 +2274,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -2677,9 +2287,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2694,9 +2302,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2706,9 +2312,7 @@ sets:
     toolchain: clang-13
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2720,9 +2324,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2734,9 +2336,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2746,9 +2346,7 @@ sets:
     toolchain: clang-12
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2760,9 +2358,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2774,9 +2370,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2791,9 +2385,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2803,9 +2395,7 @@ sets:
     toolchain: clang-12
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2817,9 +2407,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2831,9 +2419,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -2846,9 +2432,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2863,9 +2447,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2875,9 +2457,7 @@ sets:
     toolchain: clang-12
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2889,9 +2469,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2903,9 +2481,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2915,9 +2491,7 @@ sets:
     toolchain: clang-11
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2929,9 +2503,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -2943,9 +2515,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2960,9 +2530,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2972,9 +2540,7 @@ sets:
     toolchain: clang-11
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -2986,9 +2552,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -3000,9 +2564,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     kernel_image: Image
     make_variables:
       LLVM: 1
@@ -3015,9 +2577,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -3032,9 +2592,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -3044,9 +2602,7 @@ sets:
     toolchain: clang-11
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -3058,9 +2614,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -3072,9 +2626,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -3084,9 +2636,7 @@ sets:
     toolchain: clang-android
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -3098,9 +2648,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
@@ -3112,9 +2660,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -3129,9 +2675,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -3141,9 +2685,7 @@ sets:
     toolchain: clang-android
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -3155,9 +2697,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -3169,9 +2709,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -3186,9 +2724,7 @@ sets:
     - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -3198,9 +2734,7 @@ sets:
     toolchain: clang-android
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -3212,9 +2746,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1

--- a/tuxsuite/tip.tux.yml
+++ b/tuxsuite/tip.tux.yml
@@ -12,9 +12,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -24,9 +22,7 @@ sets:
     toolchain: clang-nightly
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -36,9 +32,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -48,9 +42,7 @@ sets:
     toolchain: clang-13
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -60,9 +52,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -72,9 +62,7 @@ sets:
     toolchain: clang-12
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -84,9 +72,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -96,9 +82,7 @@ sets:
     toolchain: clang-11
     kconfig: defconfig
     targets:
-    - config
     - kernel
-    - modules
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -112,9 +96,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -124,9 +106,7 @@ sets:
     toolchain: clang-nightly
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -138,9 +118,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -152,9 +130,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -164,9 +140,7 @@ sets:
     toolchain: clang-13
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -178,9 +152,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -192,9 +164,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -204,9 +174,7 @@ sets:
     toolchain: clang-12
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -218,9 +186,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -232,9 +198,7 @@ sets:
     - allmodconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -244,9 +208,7 @@ sets:
     toolchain: clang-11
     kconfig: allnoconfig
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
@@ -258,9 +220,7 @@ sets:
     - allyesconfig
     - CONFIG_WERROR=n
     targets:
-    - config
-    - kernel
-    - modules
+    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1


### PR DESCRIPTION
This series updates the targets that we call for TuxSuite, which will save us a little bit of work (maybe more for modules). See the individual commits for each change to understand the rationale.