### PR TITLE
check_logs.py: Print build log and exit when patch fails to apply

### DIFF
--- a/check_logs.py
+++ b/check_logs.py
@@ -82,6 +82,13 @@ def verify_build():
         print_red("status.json did not give a pass/fail result!")
         sys.exit(1)
 
+    if build["status_message"] == "Unable to apply kernel patch":
+        print_red(
+            "Patch failed to apply to current kernel tree, does it need to be removed or updated?"
+        )
+        fetch_logs(build)
+        sys.exit(1)
+
     return build
 
 


### PR DESCRIPTION
TuxSuite's build.log shows the output of patch when a patch fails to
apply; print that log so that we can easily triage patch failures.

Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/261