### PR TITLE
patches: android12-5.10: Add patch to fix Thumb2 kernel boot on newer QEMU

### DIFF
--- a/patches/android12-5.10/6ad8bbc9d301145335c35f29ed7878b61b0ad81f.patch
+++ b/patches/android12-5.10/6ad8bbc9d301145335c35f29ed7878b61b0ad81f.patch
@@ -1,0 +1,44 @@
+From 6ad8bbc9d301145335c35f29ed7878b61b0ad81f Mon Sep 17 00:00:00 2001
+From: Nick Desaulniers <ndesaulniers@google.com>
+Date: Mon, 4 Oct 2021 18:03:28 +0100
+Subject: [PATCH] ARM: 9133/1: mm: proc-macros: ensure *_tlb_fns are 4B aligned
+
+commit e6a0c958bdf9b2e1b57501fc9433a461f0a6aadd upstream.
+
+A kernel built with CONFIG_THUMB2_KERNEL=y and using clang as the
+assembler could generate non-naturally-aligned v7wbi_tlb_fns which
+results in a boot failure. The original commit adding the macro missed
+the .align directive on this data.
+
+Link: https://github.com/ClangBuiltLinux/linux/issues/1447
+Link: https://lore.kernel.org/all/0699da7b-354f-aecc-a62f-e25693209af4@linaro.org/
+Debugged-by: Ard Biesheuvel <ardb@kernel.org>
+Debugged-by: Nathan Chancellor <nathan@kernel.org>
+Debugged-by: Richard Henderson <richard.henderson@linaro.org>
+
+Fixes: 66a625a88174 ("ARM: mm: proc-macros: Add generic proc/cache/tlb struct definition macros")
+Suggested-by: Ard Biesheuvel <ardb@kernel.org>
+Acked-by: Ard Biesheuvel <ardb@kernel.org>
+Signed-off-by: Nick Desaulniers <ndesaulniers@google.com>
+Tested-by: Nathan Chancellor <nathan@kernel.org>
+Signed-off-by: Russell King (Oracle) <rmk+kernel@armlinux.org.uk>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ arch/arm/mm/proc-macros.S | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm/mm/proc-macros.S b/arch/arm/mm/proc-macros.S
+index e2c743aa2eb2..d9f7dfe2a7ed 100644
+--- a/arch/arm/mm/proc-macros.S
++++ b/arch/arm/mm/proc-macros.S
+@@ -340,6 +340,7 @@ ENTRY(\name\()_cache_fns)
+ 
+ .macro define_tlb_functions name:req, flags_up:req, flags_smp
+ 	.type	\name\()_tlb_fns, #object
++	.align 2
+ ENTRY(\name\()_tlb_fns)
+ 	.long	\name\()_flush_user_tlb_range
+ 	.long	\name\()_flush_kern_tlb_range
+-- 
+2.34.1
+

--- a/patches/android12-5.10/series
+++ b/patches/android12-5.10/series
@@ -1,2 +1,3 @@
+6ad8bbc9d301145335c35f29ed7878b61b0ad81f.patch
 20211115_nathan_scripts_lld_version_sh_rewrite_based_on_upstream_ld_version_sh.patch
 kvm-x86-avoid-warning-with-wbitwise-instead-of-logical.patch


### PR DESCRIPTION
This is in 5.10.77 but that version has not been merged into
android12-5.10 yet (as it is a released branch), which is currently at
5.10.66.

Apply this patch in the meantime so that the kernel continues to boot.
