### PR TITLE
patches: Add a series to fix ARCH=arm64 with mainline and next

### DIFF
--- a/patches/mainline/0001-pinctrl-thunderbay-comment-process-of-building-funct.patch
+++ b/patches/mainline/0001-pinctrl-thunderbay-comment-process-of-building-funct.patch
@@ -1,0 +1,75 @@
+From 65fb749ae8fe352269323eb456c1a5ba7545a406 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Rafa=C5=82=20Mi=C5=82ecki?= <rafal@milecki.pl>
+Date: Tue, 11 Jan 2022 18:29:18 +0100
+Subject: [PATCH 1/2] pinctrl: thunderbay: comment process of building
+ functions a bit
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This should make code a bit easier to follow. While at it use some "for"
+loops to simplify array iteration loops.
+
+Ref: 5d0674999cc5 ("pinctrl: keembay: comment process of building functions a bit")
+Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
+Link: https://lore.kernel.org/r/20220111172919.6567-1-zajec5@gmail.com
+---
+ drivers/pinctrl/pinctrl-thunderbay.c | 19 ++++++++++---------
+ 1 file changed, 10 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/pinctrl/pinctrl-thunderbay.c b/drivers/pinctrl/pinctrl-thunderbay.c
+index b5b47f4dd774..4756a23ca572 100644
+--- a/drivers/pinctrl/pinctrl-thunderbay.c
++++ b/drivers/pinctrl/pinctrl-thunderbay.c
+@@ -839,27 +839,30 @@ static int thunderbay_build_functions(struct thunderbay_pinctrl *tpc)
+ 	void *ptr;
+ 	int pin;
+ 
+-	/* Total number of functions is unknown at this point. Allocate first. */
++	/*
++	 * Allocate maximum possible number of functions. Assume every pin
++	 * being part of 8 (hw maximum) globally unique muxes.
++	 */
+ 	tpc->nfuncs = 0;
+ 	thunderbay_funcs = kcalloc(tpc->soc->npins * 8,
+ 				   sizeof(*thunderbay_funcs), GFP_KERNEL);
+ 	if (!thunderbay_funcs)
+ 		return -ENOMEM;
+ 
+-	/* Find total number of functions and each's properties */
++	/* Setup 1 function for each unique mux */
+ 	for (pin = 0; pin < tpc->soc->npins; pin++) {
+ 		const struct pinctrl_pin_desc *pin_info = thunderbay_pins + pin;
+-		struct thunderbay_mux_desc *pin_mux = pin_info->drv_data;
++		struct thunderbay_mux_desc *pin_mux;
+ 
+-		while (pin_mux->name) {
+-			struct function_desc *func = thunderbay_funcs;
++		for (pin_mux = pin_info->drv_data; pin_mux->name; pin_mux++) {
++			struct function_desc *func;
+ 
+-			while (func->name) {
++			/* Check if we already have function for this mux */
++			for (func = thunderbay_funcs; func->name; func++) {
+ 				if (!strcmp(pin_mux->name, func->name)) {
+ 					func->num_group_names++;
+ 					break;
+ 				}
+-				func++;
+ 			}
+ 
+ 			if (!func->name) {
+@@ -868,8 +871,6 @@ static int thunderbay_build_functions(struct thunderbay_pinctrl *tpc)
+ 				func->data = (int *)&pin_mux->mode;
+ 				tpc->nfuncs++;
+ 			}
+-
+-			pin_mux++;
+ 		}
+ 	}
+ 
+
+base-commit: 81ff0be4b9e3bcfee022d71cf89d72f7e2ed41ba
+-- 
+2.34.1
+

--- a/patches/mainline/0002-pinctrl-thunderbay-rework-loops-looking-for-groups-n.patch
+++ b/patches/mainline/0002-pinctrl-thunderbay-rework-loops-looking-for-groups-n.patch
@@ -1,0 +1,123 @@
+From ed2527bff91a9ea1f16902b40b6643576cdd2496 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Rafa=C5=82=20Mi=C5=82ecki?= <rafal@milecki.pl>
+Date: Tue, 11 Jan 2022 18:29:19 +0100
+Subject: [PATCH 2/2] pinctrl: thunderbay: rework loops looking for groups
+ names
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Make the outer loop iterate over functions as that's the real subject.
+This simplifies code (and reduces amount of lines of code) as allocating
+memory for names doesn't require extra checks anymore.
+
+While at it use local "group_names" variable. It fixes:
+drivers/pinctrl/pinctrl-thunderbay.c: In function 'thunderbay_add_functions':
+drivers/pinctrl/pinctrl-thunderbay.c:815:8: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
+  815 |    grp = func->group_names;
+      |        ^
+
+Ref: c26c4bfc1040 ("pinctrl: keembay: rework loops looking for groups names")
+Reported-by: Nathan Chancellor <nathan@kernel.org>
+Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
+Link: https://lore.kernel.org/r/20220111172919.6567-2-zajec5@gmail.com
+---
+ drivers/pinctrl/pinctrl-thunderbay.c | 71 ++++++++++------------------
+ 1 file changed, 25 insertions(+), 46 deletions(-)
+
+diff --git a/drivers/pinctrl/pinctrl-thunderbay.c b/drivers/pinctrl/pinctrl-thunderbay.c
+index 4756a23ca572..79d44bca039e 100644
+--- a/drivers/pinctrl/pinctrl-thunderbay.c
++++ b/drivers/pinctrl/pinctrl-thunderbay.c
+@@ -773,63 +773,42 @@ static int thunderbay_build_groups(struct thunderbay_pinctrl *tpc)
+ 
+ static int thunderbay_add_functions(struct thunderbay_pinctrl *tpc, struct function_desc *funcs)
+ {
+-	struct function_desc *function = funcs;
+ 	int i;
+ 
+ 	/* Assign the groups for each function */
+-	for (i = 0; i < tpc->soc->npins; i++) {
+-		const struct pinctrl_pin_desc *pin_info = thunderbay_pins + i;
+-		struct thunderbay_mux_desc *pin_mux = pin_info->drv_data;
+-
+-		while (pin_mux->name) {
+-			const char **grp;
+-			int j, grp_num, match = 0;
+-			size_t grp_size;
+-			struct function_desc *func;
+-
+-			for (j = 0; j < tpc->nfuncs; j++) {
+-				if (!strcmp(pin_mux->name, function[j].name)) {
+-					match = 1;
+-					break;
+-				}
+-			}
+-
+-			if (!match)
+-				return -EINVAL;
+-
+-			func = function + j;
+-			grp_num = func->num_group_names;
+-			grp_size = sizeof(*func->group_names);
+-
+-			if (!func->group_names) {
+-				func->group_names = devm_kcalloc(tpc->dev,
+-								 grp_num,
+-								 grp_size,
+-								 GFP_KERNEL);
+-				if (!func->group_names) {
+-					kfree(func);
+-					return -ENOMEM;
+-				}
++	for (i = 0; i < tpc->nfuncs; i++) {
++		struct function_desc *func = &funcs[i];
++		const char **group_names;
++		unsigned int grp_idx = 0;
++		int j;
++
++		group_names = devm_kcalloc(tpc->dev, func->num_group_names,
++					   sizeof(*group_names), GFP_KERNEL);
++		if (!group_names)
++			return -ENOMEM;
++
++		for (j = 0; j < tpc->soc->npins; j++) {
++			const struct pinctrl_pin_desc *pin_info = &thunderbay_pins[j];
++			struct thunderbay_mux_desc *pin_mux;
++
++			for (pin_mux = pin_info->drv_data; pin_mux->name; pin_mux++) {
++				if (!strcmp(pin_mux->name, func->name))
++					group_names[grp_idx++] = pin_info->name;
+ 			}
+-
+-			grp = func->group_names;
+-			while (*grp)
+-				grp++;
+-
+-			*grp = pin_info->name;
+-			pin_mux++;
+ 		}
++
++		func->group_names = group_names;
+ 	}
+ 
+ 	/* Add all functions */
+ 	for (i = 0; i < tpc->nfuncs; i++) {
+ 		pinmux_generic_add_function(tpc->pctrl,
+-					    function[i].name,
+-					    function[i].group_names,
+-					    function[i].num_group_names,
+-					    function[i].data);
++					    funcs[i].name,
++					    funcs[i].group_names,
++					    funcs[i].num_group_names,
++					    funcs[i].data);
+ 	}
+-	kfree(function);
++	kfree(funcs);
+ 	return 0;
+ }
+ 
+-- 
+2.34.1
+

--- a/patches/mainline/series
+++ b/patches/mainline/series
@@ -1,0 +1,2 @@
+0001-pinctrl-thunderbay-comment-process-of-building-funct.patch
+0002-pinctrl-thunderbay-rework-loops-looking-for-groups-n.patch

--- a/patches/next/0001-pinctrl-thunderbay-comment-process-of-building-funct.patch
+++ b/patches/next/0001-pinctrl-thunderbay-comment-process-of-building-funct.patch
@@ -1,0 +1,75 @@
+From bd66bd75478740d17e5620451d1e9bba2493df06 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Rafa=C5=82=20Mi=C5=82ecki?= <rafal@milecki.pl>
+Date: Tue, 11 Jan 2022 18:29:18 +0100
+Subject: [PATCH 1/2] pinctrl: thunderbay: comment process of building
+ functions a bit
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This should make code a bit easier to follow. While at it use some "for"
+loops to simplify array iteration loops.
+
+Ref: 5d0674999cc5 ("pinctrl: keembay: comment process of building functions a bit")
+Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
+Link: https://lore.kernel.org/r/20220111172919.6567-1-zajec5@gmail.com
+---
+ drivers/pinctrl/pinctrl-thunderbay.c | 19 ++++++++++---------
+ 1 file changed, 10 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/pinctrl/pinctrl-thunderbay.c b/drivers/pinctrl/pinctrl-thunderbay.c
+index b5b47f4dd774..4756a23ca572 100644
+--- a/drivers/pinctrl/pinctrl-thunderbay.c
++++ b/drivers/pinctrl/pinctrl-thunderbay.c
+@@ -839,27 +839,30 @@ static int thunderbay_build_functions(struct thunderbay_pinctrl *tpc)
+ 	void *ptr;
+ 	int pin;
+ 
+-	/* Total number of functions is unknown at this point. Allocate first. */
++	/*
++	 * Allocate maximum possible number of functions. Assume every pin
++	 * being part of 8 (hw maximum) globally unique muxes.
++	 */
+ 	tpc->nfuncs = 0;
+ 	thunderbay_funcs = kcalloc(tpc->soc->npins * 8,
+ 				   sizeof(*thunderbay_funcs), GFP_KERNEL);
+ 	if (!thunderbay_funcs)
+ 		return -ENOMEM;
+ 
+-	/* Find total number of functions and each's properties */
++	/* Setup 1 function for each unique mux */
+ 	for (pin = 0; pin < tpc->soc->npins; pin++) {
+ 		const struct pinctrl_pin_desc *pin_info = thunderbay_pins + pin;
+-		struct thunderbay_mux_desc *pin_mux = pin_info->drv_data;
++		struct thunderbay_mux_desc *pin_mux;
+ 
+-		while (pin_mux->name) {
+-			struct function_desc *func = thunderbay_funcs;
++		for (pin_mux = pin_info->drv_data; pin_mux->name; pin_mux++) {
++			struct function_desc *func;
+ 
+-			while (func->name) {
++			/* Check if we already have function for this mux */
++			for (func = thunderbay_funcs; func->name; func++) {
+ 				if (!strcmp(pin_mux->name, func->name)) {
+ 					func->num_group_names++;
+ 					break;
+ 				}
+-				func++;
+ 			}
+ 
+ 			if (!func->name) {
+@@ -868,8 +871,6 @@ static int thunderbay_build_functions(struct thunderbay_pinctrl *tpc)
+ 				func->data = (int *)&pin_mux->mode;
+ 				tpc->nfuncs++;
+ 			}
+-
+-			pin_mux++;
+ 		}
+ 	}
+ 
+
+base-commit: 32ce2abb03cfae17a9eb42bd6b1b619b72f23f20
+-- 
+2.34.1
+

--- a/patches/next/0002-pinctrl-thunderbay-rework-loops-looking-for-groups-n.patch
+++ b/patches/next/0002-pinctrl-thunderbay-rework-loops-looking-for-groups-n.patch
@@ -1,0 +1,123 @@
+From 155162f9161d1e483f3d25ac6af699fbe3e10735 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Rafa=C5=82=20Mi=C5=82ecki?= <rafal@milecki.pl>
+Date: Tue, 11 Jan 2022 18:29:19 +0100
+Subject: [PATCH 2/2] pinctrl: thunderbay: rework loops looking for groups
+ names
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Make the outer loop iterate over functions as that's the real subject.
+This simplifies code (and reduces amount of lines of code) as allocating
+memory for names doesn't require extra checks anymore.
+
+While at it use local "group_names" variable. It fixes:
+drivers/pinctrl/pinctrl-thunderbay.c: In function 'thunderbay_add_functions':
+drivers/pinctrl/pinctrl-thunderbay.c:815:8: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
+  815 |    grp = func->group_names;
+      |        ^
+
+Ref: c26c4bfc1040 ("pinctrl: keembay: rework loops looking for groups names")
+Reported-by: Nathan Chancellor <nathan@kernel.org>
+Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
+Link: https://lore.kernel.org/r/20220111172919.6567-2-zajec5@gmail.com
+---
+ drivers/pinctrl/pinctrl-thunderbay.c | 71 ++++++++++------------------
+ 1 file changed, 25 insertions(+), 46 deletions(-)
+
+diff --git a/drivers/pinctrl/pinctrl-thunderbay.c b/drivers/pinctrl/pinctrl-thunderbay.c
+index 4756a23ca572..79d44bca039e 100644
+--- a/drivers/pinctrl/pinctrl-thunderbay.c
++++ b/drivers/pinctrl/pinctrl-thunderbay.c
+@@ -773,63 +773,42 @@ static int thunderbay_build_groups(struct thunderbay_pinctrl *tpc)
+ 
+ static int thunderbay_add_functions(struct thunderbay_pinctrl *tpc, struct function_desc *funcs)
+ {
+-	struct function_desc *function = funcs;
+ 	int i;
+ 
+ 	/* Assign the groups for each function */
+-	for (i = 0; i < tpc->soc->npins; i++) {
+-		const struct pinctrl_pin_desc *pin_info = thunderbay_pins + i;
+-		struct thunderbay_mux_desc *pin_mux = pin_info->drv_data;
+-
+-		while (pin_mux->name) {
+-			const char **grp;
+-			int j, grp_num, match = 0;
+-			size_t grp_size;
+-			struct function_desc *func;
+-
+-			for (j = 0; j < tpc->nfuncs; j++) {
+-				if (!strcmp(pin_mux->name, function[j].name)) {
+-					match = 1;
+-					break;
+-				}
+-			}
+-
+-			if (!match)
+-				return -EINVAL;
+-
+-			func = function + j;
+-			grp_num = func->num_group_names;
+-			grp_size = sizeof(*func->group_names);
+-
+-			if (!func->group_names) {
+-				func->group_names = devm_kcalloc(tpc->dev,
+-								 grp_num,
+-								 grp_size,
+-								 GFP_KERNEL);
+-				if (!func->group_names) {
+-					kfree(func);
+-					return -ENOMEM;
+-				}
++	for (i = 0; i < tpc->nfuncs; i++) {
++		struct function_desc *func = &funcs[i];
++		const char **group_names;
++		unsigned int grp_idx = 0;
++		int j;
++
++		group_names = devm_kcalloc(tpc->dev, func->num_group_names,
++					   sizeof(*group_names), GFP_KERNEL);
++		if (!group_names)
++			return -ENOMEM;
++
++		for (j = 0; j < tpc->soc->npins; j++) {
++			const struct pinctrl_pin_desc *pin_info = &thunderbay_pins[j];
++			struct thunderbay_mux_desc *pin_mux;
++
++			for (pin_mux = pin_info->drv_data; pin_mux->name; pin_mux++) {
++				if (!strcmp(pin_mux->name, func->name))
++					group_names[grp_idx++] = pin_info->name;
+ 			}
+-
+-			grp = func->group_names;
+-			while (*grp)
+-				grp++;
+-
+-			*grp = pin_info->name;
+-			pin_mux++;
+ 		}
++
++		func->group_names = group_names;
+ 	}
+ 
+ 	/* Add all functions */
+ 	for (i = 0; i < tpc->nfuncs; i++) {
+ 		pinmux_generic_add_function(tpc->pctrl,
+-					    function[i].name,
+-					    function[i].group_names,
+-					    function[i].num_group_names,
+-					    function[i].data);
++					    funcs[i].name,
++					    funcs[i].group_names,
++					    funcs[i].num_group_names,
++					    funcs[i].data);
+ 	}
+-	kfree(function);
++	kfree(funcs);
+ 	return 0;
+ }
+ 
+-- 
+2.34.1
+

--- a/patches/next/series
+++ b/patches/next/series
@@ -1,0 +1,2 @@
+0001-pinctrl-thunderbay-comment-process-of-building-funct.patch
+0002-pinctrl-thunderbay-rework-loops-looking-for-groups-n.patch


### PR DESCRIPTION
This is not a clang specific build failure but it does impact our
ARCH=arm64 allmodconfig builds.

Link: https://lore.kernel.org/r/Yd2jcfXqqKHK%2FNaG@archlinux-ax161/
Link: https://lore.kernel.org/r/20220111172919.6567-1-zajec5@gmail.com/