### PR TITLE
patches/mainline: Add a SCSI patch from -next

### DIFF
--- a/patches/mainline/5d9224fb076e9a2023e0b06d6a164d644612c0c0.patch
+++ b/patches/mainline/5d9224fb076e9a2023e0b06d6a164d644612c0c0.patch
@@ -1,0 +1,48 @@
+From 5d9224fb076e9a2023e0b06d6a164d644612c0c0 Mon Sep 17 00:00:00 2001
+From: Xiang Chen <chenxiang66@hisilicon.com>
+Date: Tue, 4 Jan 2022 20:42:06 +0800
+Subject: scsi: hisi_sas: Remove unused variable and check in
+ hisi_sas_send_ata_reset_each_phy()
+
+In commit 29e2bac87421 ("scsi: hisi_sas: Fix some issues related to
+asd_sas_port->phy_list"), we use asd_sas_port->phy_mask instead of
+accessing asd_sas_port->phy_list, and it is enough to use
+asd_sas_port->phy_mask to check the state of phy, so remove the unused
+check and variable.
+
+Link: https://lore.kernel.org/r/1641300126-53574-1-git-send-email-chenxiang66@hisilicon.com
+Fixes: 29e2bac87421 ("scsi: hisi_sas: Fix some issues related to asd_sas_port->phy_list")
+Reported-by: Nathan Chancellor <nathan@kernel.org>
+Reported-by: Colin King <colin.i.king@gmail.com>
+Acked-by: John Garry <john.garry@huawei.com>
+Signed-off-by: Xiang Chen <chenxiang66@hisilicon.com>
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+Link: https://git.kernel.org/mkp/scsi/c/5d9224fb076e9a2023e0b06d6a164d644612c0c0
+---
+ drivers/scsi/hisi_sas/hisi_sas_main.c | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/drivers/scsi/hisi_sas/hisi_sas_main.c b/drivers/scsi/hisi_sas/hisi_sas_main.c
+index f46f679fe8258..a05ec7aece5ac 100644
+--- a/drivers/scsi/hisi_sas/hisi_sas_main.c
++++ b/drivers/scsi/hisi_sas/hisi_sas_main.c
+@@ -1525,16 +1525,11 @@ static void hisi_sas_send_ata_reset_each_phy(struct hisi_hba *hisi_hba,
+ 	struct device *dev = hisi_hba->dev;
+ 	int s = sizeof(struct host_to_dev_fis);
+ 	int rc = TMF_RESP_FUNC_FAILED;
+-	struct asd_sas_phy *sas_phy;
+ 	struct ata_link *link;
+ 	u8 fis[20] = {0};
+-	u32 state;
+ 	int i;
+ 
+-	state = hisi_hba->hw->get_phys_state(hisi_hba);
+ 	for (i = 0; i < hisi_hba->n_phy; i++) {
+-		if (!(state & BIT(sas_phy->id)))
+-			continue;
+ 		if (!(sas_port->phy_mask & BIT(i)))
+ 			continue;
+ 
+-- 
+cgit 1.2.3-1.el7
+

--- a/patches/mainline/series
+++ b/patches/mainline/series
@@ -1,2 +1,3 @@
 0001-pinctrl-thunderbay-comment-process-of-building-funct.patch
 0002-pinctrl-thunderbay-rework-loops-looking-for-groups-n.patch
+5d9224fb076e9a2023e0b06d6a164d644612c0c0.patch


### PR DESCRIPTION
This resolves a -Wuninitialized warning, which breaks our hexagon
allmodconfig build because -Werror is enabled (to catch problems like
this).

https://builds.tuxbuild.com/23hS2caXpXboLsIdKN7hdaLThbt/build.log

This patch is in the 5.17 branch so it should make it to Linus soon.