### PR TITLE
patches: mainline: Add a patch for drivers/regulator/max20086-regulator.c

### DIFF
--- a/patches/mainline/b4c18c18ebf7cf1e602af88c12ef9cb0d6e5ce51.patch
+++ b/patches/mainline/b4c18c18ebf7cf1e602af88c12ef9cb0d6e5ce51.patch
@@ -1,0 +1,51 @@
+From b4c18c18ebf7cf1e602af88c12ef9cb0d6e5ce51 Mon Sep 17 00:00:00 2001
+From: Randy Dunlap <rdunlap@infradead.org>
+Date: Fri, 14 Jan 2022 19:36:03 -0800
+Subject: regulator: MAX20086: add gpio/consumer.h
+
+max20086-regulator.c needs <linux/gpio/consumer.h> for an enum, some
+macros, and a function prototype. (seen on ARCH=m68k)
+
+Adding this header file fixes multiple build errors:
+
+../drivers/regulator/max20086-regulator.c: In function 'max20086_i2c_probe':
+../drivers/regulator/max20086-regulator.c:217:26: error: storage size of 'flags' isn't known
+  217 |         enum gpiod_flags flags;
+../drivers/regulator/max20086-regulator.c:261:27: error: 'GPIOD_OUT_HIGH' undeclared (first use in this function); did you mean 'GPIOF_INIT_HIGH'?
+  261 |         flags = boot_on ? GPIOD_OUT_HIGH : GPIOD_OUT_LOW;
+      |                           ^~~~~~~~~~~~~~
+../drivers/regulator/max20086-regulator.c:261:44: error: 'GPIOD_OUT_LOW' undeclared (first use in this function); did you mean 'GPIOF_INIT_LOW'?
+  261 |         flags = boot_on ? GPIOD_OUT_HIGH : GPIOD_OUT_LOW;
+../drivers/regulator/max20086-regulator.c:262:27: error: implicit declaration of function 'devm_gpiod_get'; did you mean 'devm_gpio_free'? [-Werror=implicit-function-declaration]
+  262 |         chip->ena_gpiod = devm_gpiod_get(chip->dev, "enable", flags);
+../drivers/regulator/max20086-regulator.c:217:26: warning: unused variable 'flags' [-Wunused-variable]
+  217 |         enum gpiod_flags flags;
+
+Fixes: bfff546aae50 ("regulator: Add MAX20086-MAX20089 driver")
+Signed-off-by: Randy Dunlap <rdunlap@infradead.org>
+Reported-by: kernel test robot <lkp@intel.com>
+Cc: Watson Chow <watson.chow@avnet.com>
+Cc: Mark Brown <broonie@kernel.org>
+Cc: Laurent Pinchart <laurent.pinchart@ideasonboard.com>
+Reviewed-by: Laurent Pinchart <laurent.pinchart@ideasonboard.com>
+Link: https://lore.kernel.org/r/20220115033603.24473-1-rdunlap@infradead.org
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ drivers/regulator/max20086-regulator.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/regulator/max20086-regulator.c b/drivers/regulator/max20086-regulator.c
+index 63aa6ec3254ac..b8bf76c170fea 100644
+--- a/drivers/regulator/max20086-regulator.c
++++ b/drivers/regulator/max20086-regulator.c
+@@ -7,6 +7,7 @@
+ 
+ #include <linux/err.h>
+ #include <linux/gpio.h>
++#include <linux/gpio/consumer.h>
+ #include <linux/i2c.h>
+ #include <linux/module.h>
+ #include <linux/regmap.h>
+-- 
+cgit 1.2.3-1.el7
+

--- a/patches/mainline/series
+++ b/patches/mainline/series
@@ -1,2 +1,3 @@
 0001-pinctrl-thunderbay-comment-process-of-building-funct.patch
 0002-pinctrl-thunderbay-rework-loops-looking-for-groups-n.patch
+b4c18c18ebf7cf1e602af88c12ef9cb0d6e5ce51.patch


### PR DESCRIPTION
The build is failing with OpenSUSE's s390x configuration:

https://builds.tuxbuild.com/24908cVXrmMMnMdKNyRVMRCO1sP/build.log

This was not noticed during the merge window because this configuration
had not been updated to build this driver; this only happened after
5.17-rc1 was released.