### PR TITLE
Enable arm64 big endian build on -next with AOSP LLVM

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -2350,6 +2350,25 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _66d5f7613f33d6225179b4f74b52c782:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    env:
+      ARCH: arm64
+      LLVM_VERSION: android
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
+    container: ghcr.io/clangbuiltlinux/qemu
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _012f9698c8641a28bfe42b1f88c3eeed:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/generator.yml
+++ b/generator.yml
@@ -1260,8 +1260,7 @@ builds:
   - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_android}
   - {<< : *arm32_allyes,      << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_android}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  # https://github.com/ClangBuiltLinux/continuous-integration2/issues/141
-  # - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
+  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
   - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
   - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_android}

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -1467,6 +1467,18 @@ sets:
     toolchain: clang-android
     kconfig:
     - defconfig
+    - CONFIG_CPU_BIG_ENDIAN=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+    git_ref: master
+    target_arch: arm64
+    toolchain: clang-android
+    kconfig:
+    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel


### PR DESCRIPTION
Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/141