### PR TITLE
Enable x86_64 GCOV build with AOSP LLVM 

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -2464,6 +2464,25 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _b0ecbe2a369a0aaf6357ba0cbe25a175:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android defconfig+CONFIG_GCOV_KERNEL=y+CONFIG_GCOV_PROFILE_ALL=y
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: android
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_GCOV_KERNEL=y+CONFIG_GCOV_PROFILE_ALL=y
+    container: ghcr.io/clangbuiltlinux/qemu
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest

--- a/generator.yml
+++ b/generator.yml
@@ -1276,9 +1276,7 @@ builds:
   - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_android}
   - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_android}
   - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_android}
-  # CONFIG_GCOV_KERNEL requires __attribute__((no_profile_instrument_function)),
-  # which AOSP LLVM does not currently have
-  # - {<< : *x86_64_gcov,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
+  - {<< : *x86_64_gcov,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
   #############
   #  Android  #
   #############

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -1529,6 +1529,19 @@ sets:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+    git_ref: master
+    target_arch: x86_64
+    toolchain: clang-android
+    kconfig:
+    - defconfig
+    - CONFIG_GCOV_KERNEL=y
+    - CONFIG_GCOV_PROFILE_ALL=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
 - name: distribution_configs
   builds:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git


### PR DESCRIPTION
AOSP clang has been updated to a revision that supports `__attribute__((no_profile_instrument_function))`:

```
$ clang --version
Android (8075178, based on r437112b) clang version 14.0.1 (https://android.googlesource.com/toolchain/llvm-project 8671348b81b95fc603505dfc881b45103bee1731)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /usr/local/bin

$ echo "__attribute__((no_profile_instrument_function)) int x();" | clang -x c - -c -o /dev/null -Werror

$ echo $?
0
```
