### PR TITLE
Disable CONFIG_DEBUG_INFO_BTF for gki_defconfig

### DIFF
--- a/.github/workflows/android-4.19.yml
+++ b/.github/workflows/android-4.19.yml
@@ -32,15 +32,15 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  _b7027adc4194874a4adbc49c0f26629d:
+  _3ecbacc4ac907ba664c582e6eac8b921:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -51,15 +51,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _47edec95bc64a51c97e8a11cc2ed40c2:
+  _332992428430d2f64ed2ee731657807d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -70,15 +70,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _bf41f851fcdaba3f8ff5598ee5a62c07:
+  _136139b3a38547048b2c6d79a59b64f7:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -89,15 +89,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _35a5ee570535cd317c3ecd44077c7035:
+  _356e2184648c1ac6d50c1429d5d01ff7:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -108,15 +108,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e2d7c97a744bb18b18038623898956f6:
+  _dcdb9462fcc866fc9f0668ea3b808428:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -127,15 +127,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _4fb2521d605de5401fc145b2b8a80bc8:
+  _76fa51b6a80b73827223975c2b73f039:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -146,15 +146,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _092d18d4defe742a9f23a18a7d2eebc6:
+  _2a6c0e600633df0a34e64f802f4751be:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -165,15 +165,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e8eaa6c4609c31891f40230b3aa2339f:
+  _51af07cbcd4acab7d515eb122fc5902b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/android-mainline.yml
+++ b/.github/workflows/android-mainline.yml
@@ -51,15 +51,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b7027adc4194874a4adbc49c0f26629d:
+  _3ecbacc4ac907ba664c582e6eac8b921:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -70,15 +70,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _47edec95bc64a51c97e8a11cc2ed40c2:
+  _332992428430d2f64ed2ee731657807d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -108,15 +108,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _bf41f851fcdaba3f8ff5598ee5a62c07:
+  _136139b3a38547048b2c6d79a59b64f7:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -127,15 +127,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _35a5ee570535cd317c3ecd44077c7035:
+  _356e2184648c1ac6d50c1429d5d01ff7:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -165,15 +165,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e2d7c97a744bb18b18038623898956f6:
+  _dcdb9462fcc866fc9f0668ea3b808428:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -184,15 +184,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _4fb2521d605de5401fc145b2b8a80bc8:
+  _76fa51b6a80b73827223975c2b73f039:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -222,15 +222,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _092d18d4defe742a9f23a18a7d2eebc6:
+  _2a6c0e600633df0a34e64f802f4751be:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -241,15 +241,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e8eaa6c4609c31891f40230b3aa2339f:
+  _51af07cbcd4acab7d515eb122fc5902b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/android12-5.10.yml
+++ b/.github/workflows/android12-5.10.yml
@@ -51,15 +51,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b7027adc4194874a4adbc49c0f26629d:
+  _3ecbacc4ac907ba664c582e6eac8b921:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -70,15 +70,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _47edec95bc64a51c97e8a11cc2ed40c2:
+  _332992428430d2f64ed2ee731657807d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -108,15 +108,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _bf41f851fcdaba3f8ff5598ee5a62c07:
+  _136139b3a38547048b2c6d79a59b64f7:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -127,15 +127,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _35a5ee570535cd317c3ecd44077c7035:
+  _356e2184648c1ac6d50c1429d5d01ff7:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -165,15 +165,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e2d7c97a744bb18b18038623898956f6:
+  _dcdb9462fcc866fc9f0668ea3b808428:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -184,15 +184,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _4fb2521d605de5401fc145b2b8a80bc8:
+  _76fa51b6a80b73827223975c2b73f039:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -222,15 +222,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _092d18d4defe742a9f23a18a7d2eebc6:
+  _2a6c0e600633df0a34e64f802f4751be:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -241,15 +241,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e8eaa6c4609c31891f40230b3aa2339f:
+  _51af07cbcd4acab7d515eb122fc5902b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/android12-5.4.yml
+++ b/.github/workflows/android12-5.4.yml
@@ -51,15 +51,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b7027adc4194874a4adbc49c0f26629d:
+  _3ecbacc4ac907ba664c582e6eac8b921:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -70,15 +70,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _47edec95bc64a51c97e8a11cc2ed40c2:
+  _332992428430d2f64ed2ee731657807d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -108,15 +108,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _bf41f851fcdaba3f8ff5598ee5a62c07:
+  _136139b3a38547048b2c6d79a59b64f7:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -127,15 +127,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _35a5ee570535cd317c3ecd44077c7035:
+  _356e2184648c1ac6d50c1429d5d01ff7:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -165,15 +165,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e2d7c97a744bb18b18038623898956f6:
+  _dcdb9462fcc866fc9f0668ea3b808428:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -184,15 +184,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _4fb2521d605de5401fc145b2b8a80bc8:
+  _76fa51b6a80b73827223975c2b73f039:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -222,15 +222,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _092d18d4defe742a9f23a18a7d2eebc6:
+  _2a6c0e600633df0a34e64f802f4751be:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -241,15 +241,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e8eaa6c4609c31891f40230b3aa2339f:
+  _51af07cbcd4acab7d515eb122fc5902b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/android13-5.10.yml
+++ b/.github/workflows/android13-5.10.yml
@@ -51,15 +51,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b7027adc4194874a4adbc49c0f26629d:
+  _3ecbacc4ac907ba664c582e6eac8b921:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -70,15 +70,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _47edec95bc64a51c97e8a11cc2ed40c2:
+  _332992428430d2f64ed2ee731657807d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -108,15 +108,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _bf41f851fcdaba3f8ff5598ee5a62c07:
+  _136139b3a38547048b2c6d79a59b64f7:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -127,15 +127,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _35a5ee570535cd317c3ecd44077c7035:
+  _356e2184648c1ac6d50c1429d5d01ff7:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -165,15 +165,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e2d7c97a744bb18b18038623898956f6:
+  _dcdb9462fcc866fc9f0668ea3b808428:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -184,15 +184,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _4fb2521d605de5401fc145b2b8a80bc8:
+  _76fa51b6a80b73827223975c2b73f039:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -222,15 +222,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _092d18d4defe742a9f23a18a7d2eebc6:
+  _2a6c0e600633df0a34e64f802f4751be:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -241,15 +241,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e8eaa6c4609c31891f40230b3aa2339f:
+  _51af07cbcd4acab7d515eb122fc5902b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2

--- a/generator.yml
+++ b/generator.yml
@@ -101,7 +101,7 @@ configs:
   - &arm64_kasan       {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],            << : *arm64-triple,         << : *kernel}
   - &arm64_kasan_sw    {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_SW_TAGS=y, CONFIG_KUNIT=y],            << : *arm64-triple,         << : *kernel}
   - &arm64_ubsan       {config: [defconfig, CONFIG_UBSAN=y],                                                                               << : *arm64-triple,         << : *kernel}
-  - &arm64_gki         {config: gki_defconfig,                                                                                             << : *arm64-triple,         << : *kernel}
+  - &arm64_gki         {config: [gki_defconfig, CONFIG_DEBUG_INFO_BTF=n],                                                                  << : *arm64-triple,         << : *kernel}
   - &arm64_cut         {config: cuttlefish_defconfig,                                                                                      << : *arm64-triple,         << : *kernel}
   - &arm64_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                                                           << : *arm64-triple,         << : *default}
   - &arm64_allmod_lto  {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_WERROR=n, CONFIG_LTO_CLANG_THIN=y],            << : *arm64-triple,         << : *default}
@@ -140,7 +140,7 @@ configs:
   - &x86_64_lto_full   {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                                                  << : *kernel}
   - &x86_64_lto_thin   {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                                                  << : *kernel}
   - &x86_64_cfi        {config: [defconfig, CONFIG_LTO_CLANG_THIN=y, CONFIG_CFI_CLANG=y],                                                                              << : *kernel}
-  - &x86_64_gki        {config: gki_defconfig,                                                                                                                         << : *kernel}
+  - &x86_64_gki        {config: [gki_defconfig, CONFIG_DEBUG_INFO_BTF=n],                                                                                              << : *kernel}
   - &x86_64_cut        {config: x86_64_cuttlefish_defconfig,                                                                                                           << : *kernel}
   - &x86_64_allmod     {config: [allmodconfig, CONFIG_WERROR=n],                                                                                                       << : *default}
   - &x86_64_allmod_lto {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_WERROR=n, CONFIG_LTO_CLANG_THIN=y],                                        << : *default}

--- a/tuxsuite/android-4.19.tux.yml
+++ b/tuxsuite/android-4.19.tux.yml
@@ -10,7 +10,9 @@ sets:
     git_ref: android-4.19-stable
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -20,7 +22,9 @@ sets:
     git_ref: android-4.19-stable
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -30,7 +34,9 @@ sets:
     git_ref: android-4.19-stable
     target_arch: arm64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -40,7 +46,9 @@ sets:
     git_ref: android-4.19-stable
     target_arch: x86_64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -50,7 +58,9 @@ sets:
     git_ref: android-4.19-stable
     target_arch: arm64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -60,7 +70,9 @@ sets:
     git_ref: android-4.19-stable
     target_arch: x86_64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -70,7 +82,9 @@ sets:
     git_ref: android-4.19-stable
     target_arch: arm64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -80,7 +94,9 @@ sets:
     git_ref: android-4.19-stable
     target_arch: x86_64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-mainline.tux.yml
+++ b/tuxsuite/android-mainline.tux.yml
@@ -22,7 +22,9 @@ sets:
     git_ref: android-mainline
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ sets:
     git_ref: android-mainline
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -54,7 +58,9 @@ sets:
     git_ref: android-mainline
     target_arch: arm64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -64,7 +70,9 @@ sets:
     git_ref: android-mainline
     target_arch: x86_64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -86,7 +94,9 @@ sets:
     git_ref: android-mainline
     target_arch: arm64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -96,7 +106,9 @@ sets:
     git_ref: android-mainline
     target_arch: x86_64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -118,7 +130,9 @@ sets:
     git_ref: android-mainline
     target_arch: arm64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -128,7 +142,9 @@ sets:
     git_ref: android-mainline
     target_arch: x86_64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.10.tux.yml
+++ b/tuxsuite/android12-5.10.tux.yml
@@ -22,7 +22,9 @@ sets:
     git_ref: android12-5.10
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ sets:
     git_ref: android12-5.10
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -54,7 +58,9 @@ sets:
     git_ref: android12-5.10
     target_arch: arm64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -64,7 +70,9 @@ sets:
     git_ref: android12-5.10
     target_arch: x86_64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -86,7 +94,9 @@ sets:
     git_ref: android12-5.10
     target_arch: arm64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -96,7 +106,9 @@ sets:
     git_ref: android12-5.10
     target_arch: x86_64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -118,7 +130,9 @@ sets:
     git_ref: android12-5.10
     target_arch: arm64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -128,7 +142,9 @@ sets:
     git_ref: android12-5.10
     target_arch: x86_64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.4.tux.yml
+++ b/tuxsuite/android12-5.4.tux.yml
@@ -22,7 +22,9 @@ sets:
     git_ref: android12-5.4
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ sets:
     git_ref: android12-5.4
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -54,7 +58,9 @@ sets:
     git_ref: android12-5.4
     target_arch: arm64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -64,7 +70,9 @@ sets:
     git_ref: android12-5.4
     target_arch: x86_64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -86,7 +94,9 @@ sets:
     git_ref: android12-5.4
     target_arch: arm64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -96,7 +106,9 @@ sets:
     git_ref: android12-5.4
     target_arch: x86_64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -118,7 +130,9 @@ sets:
     git_ref: android12-5.4
     target_arch: arm64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -128,7 +142,9 @@ sets:
     git_ref: android12-5.4
     target_arch: x86_64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.10.tux.yml
+++ b/tuxsuite/android13-5.10.tux.yml
@@ -22,7 +22,9 @@ sets:
     git_ref: android13-5.10
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ sets:
     git_ref: android13-5.10
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -54,7 +58,9 @@ sets:
     git_ref: android13-5.10
     target_arch: arm64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -64,7 +70,9 @@ sets:
     git_ref: android13-5.10
     target_arch: x86_64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -86,7 +94,9 @@ sets:
     git_ref: android13-5.10
     target_arch: arm64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -96,7 +106,9 @@ sets:
     git_ref: android13-5.10
     target_arch: x86_64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -118,7 +130,9 @@ sets:
     git_ref: android13-5.10
     target_arch: arm64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -128,7 +142,9 @@ sets:
     git_ref: android13-5.10
     target_arch: x86_64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:


### PR DESCRIPTION
There are issues with the pahole version that TuxMake ships, which is
causing infrastructure issues. Until a fix can be developed, disable
BTF generation so that pahole does not run.
