### PR TITLE
Enable CONFIG_DEBUG_INFO_BTF for Android and Fedora configs

### DIFF
--- a/.github/workflows/5.15.yml
+++ b/.github/workflows/5.15.yml
@@ -2271,15 +2271,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ee85ba95e77d51e03022e6bc3df33963:
+  _15f09d87befdc007c799b98740f7207b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2328,15 +2328,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _8c16141a63361f84d70e22c76684ebc7:
+  _08fb5d721ebe5360162eab624a731362:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2366,15 +2366,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _75d5c5532fe6d0d816a18490cc02eb0c:
+  _df746f3ce8be382b98e15c3a1265591b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: s390
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2423,15 +2423,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _93da9c080110f301080139da61bef381:
+  _47850a955ed08cdc1af5df3b1ebf229a:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2499,15 +2499,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _6582128ba39f8a17cd3b5830bb914d8a:
+  _0ed6feea25f3902a8c968a744a0240f2:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2556,15 +2556,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _007390e63d5c6fa4c3e3efe6efe93a23:
+  _17f0345420b6ade6aeacc3497eb5fe79:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2594,15 +2594,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5a10b834e5cff80e001c1ed465c4e180:
+  _306cd6f0d8de501c4ecfdc903ce9f4a1:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: s390
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2651,15 +2651,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3114f3581d7ff6191d2f66460ca8262e:
+  _1eb07c3aa26899e71a54a11f89ca7e32:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2727,15 +2727,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2f2720ee76ef90ec364a0935abdc5ee7:
+  _0a44165bfd4228a9d39675e56d3c53cd:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2784,15 +2784,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e9511a126a03947340ed7a6185de4673:
+  _6f15f90c890fd785747516d4c39c77a6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2841,15 +2841,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _763f7e8d5362165d7b0a316da6a5665c:
+  _7c8ef3a6268a98f6b98b58a56bd4164e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2917,15 +2917,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5f3fead84b9e6323d3baf5b285715362:
+  _9f6b4e77f8d82842e93b9fa15e162f15:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: arm64
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2993,15 +2993,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _31f8db600236f817d288b1fa60653ad9:
+  _33c4e124f55a998679c38207caccf044:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -3050,15 +3050,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _419c2439d3eebdd0dc7ff19b59a0b9b2:
+  _dcce07616b216e4083cf8d3583f67061:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/android-4.19.yml
+++ b/.github/workflows/android-4.19.yml
@@ -32,15 +32,15 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  _137e8958602c2a5a2dfa25b067a941eb:
+  _27913b883a7b3927289cd723c5e6b1c6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -51,15 +51,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d51a68e6a98a52a680b2c50c852963eb:
+  _7b8336846bde11413c4d6dc9a7e31743:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -70,15 +70,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _136139b3a38547048b2c6d79a59b64f7:
+  _bf41f851fcdaba3f8ff5598ee5a62c07:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -89,15 +89,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _356e2184648c1ac6d50c1429d5d01ff7:
+  _35a5ee570535cd317c3ecd44077c7035:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -108,15 +108,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _dcdb9462fcc866fc9f0668ea3b808428:
+  _e2d7c97a744bb18b18038623898956f6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -127,15 +127,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _76fa51b6a80b73827223975c2b73f039:
+  _4fb2521d605de5401fc145b2b8a80bc8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -146,15 +146,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2a6c0e600633df0a34e64f802f4751be:
+  _092d18d4defe742a9f23a18a7d2eebc6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -165,15 +165,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _51af07cbcd4acab7d515eb122fc5902b:
+  _e8eaa6c4609c31891f40230b3aa2339f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/android-mainline.yml
+++ b/.github/workflows/android-mainline.yml
@@ -51,15 +51,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _137e8958602c2a5a2dfa25b067a941eb:
+  _27913b883a7b3927289cd723c5e6b1c6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -70,15 +70,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d51a68e6a98a52a680b2c50c852963eb:
+  _7b8336846bde11413c4d6dc9a7e31743:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -108,15 +108,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _136139b3a38547048b2c6d79a59b64f7:
+  _bf41f851fcdaba3f8ff5598ee5a62c07:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -127,15 +127,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _356e2184648c1ac6d50c1429d5d01ff7:
+  _35a5ee570535cd317c3ecd44077c7035:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -165,15 +165,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _dcdb9462fcc866fc9f0668ea3b808428:
+  _e2d7c97a744bb18b18038623898956f6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -184,15 +184,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _76fa51b6a80b73827223975c2b73f039:
+  _4fb2521d605de5401fc145b2b8a80bc8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -222,15 +222,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2a6c0e600633df0a34e64f802f4751be:
+  _092d18d4defe742a9f23a18a7d2eebc6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -241,15 +241,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _51af07cbcd4acab7d515eb122fc5902b:
+  _e8eaa6c4609c31891f40230b3aa2339f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/android12-5.10.yml
+++ b/.github/workflows/android12-5.10.yml
@@ -51,15 +51,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _137e8958602c2a5a2dfa25b067a941eb:
+  _27913b883a7b3927289cd723c5e6b1c6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -70,15 +70,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d51a68e6a98a52a680b2c50c852963eb:
+  _7b8336846bde11413c4d6dc9a7e31743:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -108,15 +108,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _136139b3a38547048b2c6d79a59b64f7:
+  _bf41f851fcdaba3f8ff5598ee5a62c07:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -127,15 +127,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _356e2184648c1ac6d50c1429d5d01ff7:
+  _35a5ee570535cd317c3ecd44077c7035:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -165,15 +165,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _dcdb9462fcc866fc9f0668ea3b808428:
+  _e2d7c97a744bb18b18038623898956f6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -184,15 +184,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _76fa51b6a80b73827223975c2b73f039:
+  _4fb2521d605de5401fc145b2b8a80bc8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -222,15 +222,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2a6c0e600633df0a34e64f802f4751be:
+  _092d18d4defe742a9f23a18a7d2eebc6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -241,15 +241,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _51af07cbcd4acab7d515eb122fc5902b:
+  _e8eaa6c4609c31891f40230b3aa2339f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/android12-5.4.yml
+++ b/.github/workflows/android12-5.4.yml
@@ -51,15 +51,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _137e8958602c2a5a2dfa25b067a941eb:
+  _27913b883a7b3927289cd723c5e6b1c6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -70,15 +70,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d51a68e6a98a52a680b2c50c852963eb:
+  _7b8336846bde11413c4d6dc9a7e31743:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -108,15 +108,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _136139b3a38547048b2c6d79a59b64f7:
+  _bf41f851fcdaba3f8ff5598ee5a62c07:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -127,15 +127,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _356e2184648c1ac6d50c1429d5d01ff7:
+  _35a5ee570535cd317c3ecd44077c7035:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -165,15 +165,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _dcdb9462fcc866fc9f0668ea3b808428:
+  _e2d7c97a744bb18b18038623898956f6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -184,15 +184,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _76fa51b6a80b73827223975c2b73f039:
+  _4fb2521d605de5401fc145b2b8a80bc8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -222,15 +222,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2a6c0e600633df0a34e64f802f4751be:
+  _092d18d4defe742a9f23a18a7d2eebc6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -241,15 +241,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _51af07cbcd4acab7d515eb122fc5902b:
+  _e8eaa6c4609c31891f40230b3aa2339f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/android13-5.10.yml
+++ b/.github/workflows/android13-5.10.yml
@@ -51,15 +51,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _137e8958602c2a5a2dfa25b067a941eb:
+  _27913b883a7b3927289cd723c5e6b1c6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -70,15 +70,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d51a68e6a98a52a680b2c50c852963eb:
+  _7b8336846bde11413c4d6dc9a7e31743:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -108,15 +108,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _136139b3a38547048b2c6d79a59b64f7:
+  _bf41f851fcdaba3f8ff5598ee5a62c07:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -127,15 +127,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _356e2184648c1ac6d50c1429d5d01ff7:
+  _35a5ee570535cd317c3ecd44077c7035:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -165,15 +165,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _dcdb9462fcc866fc9f0668ea3b808428:
+  _e2d7c97a744bb18b18038623898956f6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -184,15 +184,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _76fa51b6a80b73827223975c2b73f039:
+  _4fb2521d605de5401fc145b2b8a80bc8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -222,15 +222,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2a6c0e600633df0a34e64f802f4751be:
+  _092d18d4defe742a9f23a18a7d2eebc6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -241,15 +241,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _51af07cbcd4acab7d515eb122fc5902b:
+  _e8eaa6c4609c31891f40230b3aa2339f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/android13-5.15.yml
+++ b/.github/workflows/android13-5.15.yml
@@ -51,15 +51,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _137e8958602c2a5a2dfa25b067a941eb:
+  _27913b883a7b3927289cd723c5e6b1c6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -70,15 +70,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d51a68e6a98a52a680b2c50c852963eb:
+  _7b8336846bde11413c4d6dc9a7e31743:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -108,15 +108,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _136139b3a38547048b2c6d79a59b64f7:
+  _bf41f851fcdaba3f8ff5598ee5a62c07:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -127,15 +127,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _356e2184648c1ac6d50c1429d5d01ff7:
+  _35a5ee570535cd317c3ecd44077c7035:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -165,15 +165,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _dcdb9462fcc866fc9f0668ea3b808428:
+  _e2d7c97a744bb18b18038623898956f6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -184,15 +184,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _76fa51b6a80b73827223975c2b73f039:
+  _4fb2521d605de5401fc145b2b8a80bc8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -222,15 +222,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2a6c0e600633df0a34e64f802f4751be:
+  _092d18d4defe742a9f23a18a7d2eebc6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -241,15 +241,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _51af07cbcd4acab7d515eb122fc5902b:
+  _e8eaa6c4609c31891f40230b3aa2339f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: gki_defconfig
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/mainline.yml
+++ b/.github/workflows/mainline.yml
@@ -2271,15 +2271,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ee85ba95e77d51e03022e6bc3df33963:
+  _15f09d87befdc007c799b98740f7207b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2328,15 +2328,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _8c16141a63361f84d70e22c76684ebc7:
+  _08fb5d721ebe5360162eab624a731362:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2366,15 +2366,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _75d5c5532fe6d0d816a18490cc02eb0c:
+  _df746f3ce8be382b98e15c3a1265591b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: s390
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2423,15 +2423,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _93da9c080110f301080139da61bef381:
+  _47850a955ed08cdc1af5df3b1ebf229a:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2499,15 +2499,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _6582128ba39f8a17cd3b5830bb914d8a:
+  _0ed6feea25f3902a8c968a744a0240f2:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2556,15 +2556,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _007390e63d5c6fa4c3e3efe6efe93a23:
+  _17f0345420b6ade6aeacc3497eb5fe79:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2594,15 +2594,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5a10b834e5cff80e001c1ed465c4e180:
+  _306cd6f0d8de501c4ecfdc903ce9f4a1:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: s390
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2651,15 +2651,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3114f3581d7ff6191d2f66460ca8262e:
+  _1eb07c3aa26899e71a54a11f89ca7e32:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2727,15 +2727,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2f2720ee76ef90ec364a0935abdc5ee7:
+  _0a44165bfd4228a9d39675e56d3c53cd:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2784,15 +2784,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e9511a126a03947340ed7a6185de4673:
+  _6f15f90c890fd785747516d4c39c77a6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2841,15 +2841,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _763f7e8d5362165d7b0a316da6a5665c:
+  _7c8ef3a6268a98f6b98b58a56bd4164e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2917,15 +2917,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5f3fead84b9e6323d3baf5b285715362:
+  _9f6b4e77f8d82842e93b9fa15e162f15:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: arm64
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2993,15 +2993,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _31f8db600236f817d288b1fa60653ad9:
+  _33c4e124f55a998679c38207caccf044:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -3050,15 +3050,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _419c2439d3eebdd0dc7ff19b59a0b9b2:
+  _dcce07616b216e4083cf8d3583f67061:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -2556,15 +2556,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ee85ba95e77d51e03022e6bc3df33963:
+  _15f09d87befdc007c799b98740f7207b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2613,15 +2613,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _8c16141a63361f84d70e22c76684ebc7:
+  _08fb5d721ebe5360162eab624a731362:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2651,15 +2651,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _75d5c5532fe6d0d816a18490cc02eb0c:
+  _df746f3ce8be382b98e15c3a1265591b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: s390
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2708,15 +2708,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _93da9c080110f301080139da61bef381:
+  _47850a955ed08cdc1af5df3b1ebf229a:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2784,15 +2784,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _6582128ba39f8a17cd3b5830bb914d8a:
+  _0ed6feea25f3902a8c968a744a0240f2:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2841,15 +2841,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _007390e63d5c6fa4c3e3efe6efe93a23:
+  _17f0345420b6ade6aeacc3497eb5fe79:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2879,15 +2879,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5a10b834e5cff80e001c1ed465c4e180:
+  _306cd6f0d8de501c4ecfdc903ce9f4a1:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: s390
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -2936,15 +2936,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3114f3581d7ff6191d2f66460ca8262e:
+  _1eb07c3aa26899e71a54a11f89ca7e32:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -3012,15 +3012,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2f2720ee76ef90ec364a0935abdc5ee7:
+  _0a44165bfd4228a9d39675e56d3c53cd:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -3069,15 +3069,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e9511a126a03947340ed7a6185de4673:
+  _6f15f90c890fd785747516d4c39c77a6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -3126,15 +3126,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _763f7e8d5362165d7b0a316da6a5665c:
+  _7c8ef3a6268a98f6b98b58a56bd4164e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -3202,15 +3202,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5f3fead84b9e6323d3baf5b285715362:
+  _9f6b4e77f8d82842e93b9fa15e162f15:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: arm64
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -3278,15 +3278,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _31f8db600236f817d288b1fa60653ad9:
+  _33c4e124f55a998679c38207caccf044:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2
@@ -3335,15 +3335,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _419c2439d3eebdd0dc7ff19b59a0b9b2:
+  _dcce07616b216e4083cf8d3583f67061:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_DEBUG_INFO_BTF=n
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2

--- a/generator.yml
+++ b/generator.yml
@@ -101,15 +101,14 @@ configs:
   - &arm64_kasan       {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],            << : *arm64-triple,         << : *kernel}
   - &arm64_kasan_sw    {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_SW_TAGS=y, CONFIG_KUNIT=y],            << : *arm64-triple,         << : *kernel}
   - &arm64_ubsan       {config: [defconfig, CONFIG_UBSAN=y],                                                                               << : *arm64-triple,         << : *kernel}
-  - &arm64_gki         {config: [gki_defconfig, CONFIG_DEBUG_INFO_BTF=n],                                                                  << : *arm64-triple,         << : *kernel}
+  - &arm64_gki         {config: gki_defconfig,                                                                                             << : *arm64-triple,         << : *kernel}
   - &arm64_cut         {config: cuttlefish_defconfig,                                                                                      << : *arm64-triple,         << : *kernel}
   - &arm64_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                                                           << : *arm64-triple,         << : *default}
   - &arm64_allmod_lto  {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_WERROR=n, CONFIG_LTO_CLANG_THIN=y],            << : *arm64-triple,         << : *default}
   - &arm64_allno       {config: allnoconfig,                                                                                               << : *arm64-triple,         << : *default}
   - &arm64_allyes      {config: [allyesconfig, CONFIG_WERROR=n],                                                                           << : *arm64-triple,         << : *default}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
-  # CONFIG_DEBUG_INFO_BTF disabled: https://github.com/ClangBuiltLinux/continuous-integration2/issues/290
-  - &arm64_fedora      {config: [*arm64-fedora-config-url, CONFIG_BPF_PRELOAD=n, CONFIG_DEBUG_INFO_BTF=n],                                 << : *arm64-triple,         << : *kernel}
+  - &arm64_fedora      {config: [*arm64-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                          << : *arm64-triple,         << : *kernel}
   # CONFIG_DEBUG_INFO_BTF disabled for certain SUSE configs due to pahole issue: https://lore.kernel.org/r/20210506205622.3663956-1-kafai@fb.com/
   - &arm64_suse        {config: [*arm64-suse-config-url, CONFIG_DEBUG_INFO_BTF=n],                                                         << : *arm64-triple,         << : *kernel}
   - &hexagon           {config: defconfig,                                                                                                 << : *hexagon-triple,       << : *default}
@@ -126,8 +125,7 @@ configs:
   - &ppc64             {config: [pseries_defconfig, CONFIG_PPC_DISABLE_WERROR=y],                              kernel_image: vmlinux,      << : *powerpc64-triple,     << : *kernel}
   - &ppc64le           {config: powernv_defconfig,                                                             kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
-  # CONFIG_DEBUG_INFO_BTF disabled: https://github.com/ClangBuiltLinux/continuous-integration2/issues/290
-  - &ppc64le_fedora    {config: [*ppc64le-fedora-config-url, CONFIG_BPF_PRELOAD=n, CONFIG_DEBUG_INFO_BTF=n],   kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel}
+  - &ppc64le_fedora    {config: [*ppc64le-fedora-config-url, CONFIG_BPF_PRELOAD=n],                            kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel}
   - &ppc64le_suse      {config: *ppc64le-suse-config-url,                                                      kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel}
   - &riscv             {config: defconfig,                                                                     kernel_image: Image,        << : *riscv-triple,         << : *kernel}
   - &riscv_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                               kernel_image: Image,        << : *riscv-triple,         << : *default}
@@ -136,14 +134,13 @@ configs:
   - &s390              {config: defconfig,                                                                                                 << : *s390-triple,          << : *kernel}
   - &s390_kasan        {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],            << : *s390-triple,          << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
-  # CONFIG_DEBUG_INFO_BTF disabled: https://github.com/ClangBuiltLinux/continuous-integration2/issues/290
-  - &s390_fedora       {config: [*s390-fedora-config-url, CONFIG_BPF_PRELOAD=n, CONFIG_DEBUG_INFO_BTF=n],                                  << : *s390-triple,          << : *kernel}
+  - &s390_fedora       {config: [*s390-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                           << : *s390-triple,          << : *kernel}
   - &s390_suse         {config: *s390-suse-config-url,                                                                                     << : *s390-triple,          << : *kernel}
   - &x86_64            {config: defconfig,                                                                                                                             << : *kernel}
   - &x86_64_lto_full   {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                                                  << : *kernel}
   - &x86_64_lto_thin   {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                                                  << : *kernel}
   - &x86_64_cfi        {config: [defconfig, CONFIG_LTO_CLANG_THIN=y, CONFIG_CFI_CLANG=y],                                                                              << : *kernel}
-  - &x86_64_gki        {config: [gki_defconfig, CONFIG_DEBUG_INFO_BTF=n],                                                                                              << : *kernel}
+  - &x86_64_gki        {config: gki_defconfig,                                                                                                                         << : *kernel}
   - &x86_64_cut        {config: x86_64_cuttlefish_defconfig,                                                                                                           << : *kernel}
   - &x86_64_allmod     {config: [allmodconfig, CONFIG_WERROR=n],                                                                                                       << : *default}
   - &x86_64_allmod_lto {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_WERROR=n, CONFIG_LTO_CLANG_THIN=y],                                        << : *default}
@@ -154,8 +151,7 @@ configs:
   - &x86_64_kcsan      {config: [defconfig, CONFIG_KCSAN=y, CONFIG_KCSAN_KUNIT_TEST=y, CONFIG_KUNIT=y],                                                                << : *kernel}
   - &x86_64_ubsan      {config: [defconfig, CONFIG_UBSAN=y],                                                                                                           << : *kernel}
   - &x86_64_arch       {config: *x86_64-arch-config-url,                                                                                                               << : *kernel}
-  # CONFIG_DEBUG_INFO_BTF disabled: https://github.com/ClangBuiltLinux/continuous-integration2/issues/290
-  - &x86_64_fedora     {config: [*x86_64-fedora-config-url, CONFIG_DEBUG_INFO_BTF=n],                                                                                  << : *kernel}
+  - &x86_64_fedora     {config: *x86_64-fedora-config-url,                                                                                                             << : *kernel}
   - &x86_64_suse       {config: *x86_64-suse-config-url,                                                                                                               << : *kernel}
 tiers:
   # Generic tiers       LLVM=1       LLVM_IAS=1        Make variables to pass to TuxSuite

--- a/tuxsuite/5.15.tux.yml
+++ b/tuxsuite/5.15.tux.yml
@@ -1412,7 +1412,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -1447,7 +1446,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -1470,7 +1468,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -1498,9 +1495,7 @@ sets:
     git_ref: linux-5.15.y
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
     make_variables:
@@ -1545,7 +1540,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -1580,7 +1574,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -1603,7 +1596,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -1631,9 +1623,7 @@ sets:
     git_ref: linux-5.15.y
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
     make_variables:
@@ -1678,7 +1668,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -1713,7 +1702,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -1743,9 +1731,7 @@ sets:
     git_ref: linux-5.15.y
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
     make_variables:
@@ -1790,7 +1776,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -1838,7 +1823,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -1868,9 +1852,7 @@ sets:
     git_ref: linux-5.15.y
     target_arch: x86_64
     toolchain: clang-11
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-4.19.tux.yml
+++ b/tuxsuite/android-4.19.tux.yml
@@ -10,9 +10,7 @@ sets:
     git_ref: android-4.19-stable
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -22,9 +20,7 @@ sets:
     git_ref: android-4.19-stable
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -34,9 +30,7 @@ sets:
     git_ref: android-4.19-stable
     target_arch: arm64
     toolchain: clang-13
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -46,9 +40,7 @@ sets:
     git_ref: android-4.19-stable
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -58,9 +50,7 @@ sets:
     git_ref: android-4.19-stable
     target_arch: arm64
     toolchain: clang-12
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -70,9 +60,7 @@ sets:
     git_ref: android-4.19-stable
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -82,9 +70,7 @@ sets:
     git_ref: android-4.19-stable
     target_arch: arm64
     toolchain: clang-android
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -94,9 +80,7 @@ sets:
     git_ref: android-4.19-stable
     target_arch: x86_64
     toolchain: clang-android
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-mainline.tux.yml
+++ b/tuxsuite/android-mainline.tux.yml
@@ -22,9 +22,7 @@ sets:
     git_ref: android-mainline
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -34,9 +32,7 @@ sets:
     git_ref: android-mainline
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -58,9 +54,7 @@ sets:
     git_ref: android-mainline
     target_arch: arm64
     toolchain: clang-13
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -70,9 +64,7 @@ sets:
     git_ref: android-mainline
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -94,9 +86,7 @@ sets:
     git_ref: android-mainline
     target_arch: arm64
     toolchain: clang-12
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -106,9 +96,7 @@ sets:
     git_ref: android-mainline
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -130,9 +118,7 @@ sets:
     git_ref: android-mainline
     target_arch: arm64
     toolchain: clang-android
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -142,9 +128,7 @@ sets:
     git_ref: android-mainline
     target_arch: x86_64
     toolchain: clang-android
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.10.tux.yml
+++ b/tuxsuite/android12-5.10.tux.yml
@@ -22,9 +22,7 @@ sets:
     git_ref: android12-5.10
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -34,9 +32,7 @@ sets:
     git_ref: android12-5.10
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -58,9 +54,7 @@ sets:
     git_ref: android12-5.10
     target_arch: arm64
     toolchain: clang-13
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -70,9 +64,7 @@ sets:
     git_ref: android12-5.10
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -94,9 +86,7 @@ sets:
     git_ref: android12-5.10
     target_arch: arm64
     toolchain: clang-12
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -106,9 +96,7 @@ sets:
     git_ref: android12-5.10
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -130,9 +118,7 @@ sets:
     git_ref: android12-5.10
     target_arch: arm64
     toolchain: clang-android
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -142,9 +128,7 @@ sets:
     git_ref: android12-5.10
     target_arch: x86_64
     toolchain: clang-android
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.4.tux.yml
+++ b/tuxsuite/android12-5.4.tux.yml
@@ -22,9 +22,7 @@ sets:
     git_ref: android12-5.4
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -34,9 +32,7 @@ sets:
     git_ref: android12-5.4
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -58,9 +54,7 @@ sets:
     git_ref: android12-5.4
     target_arch: arm64
     toolchain: clang-13
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -70,9 +64,7 @@ sets:
     git_ref: android12-5.4
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -94,9 +86,7 @@ sets:
     git_ref: android12-5.4
     target_arch: arm64
     toolchain: clang-12
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -106,9 +96,7 @@ sets:
     git_ref: android12-5.4
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -130,9 +118,7 @@ sets:
     git_ref: android12-5.4
     target_arch: arm64
     toolchain: clang-android
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -142,9 +128,7 @@ sets:
     git_ref: android12-5.4
     target_arch: x86_64
     toolchain: clang-android
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.10.tux.yml
+++ b/tuxsuite/android13-5.10.tux.yml
@@ -22,9 +22,7 @@ sets:
     git_ref: android13-5.10
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -34,9 +32,7 @@ sets:
     git_ref: android13-5.10
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -58,9 +54,7 @@ sets:
     git_ref: android13-5.10
     target_arch: arm64
     toolchain: clang-13
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -70,9 +64,7 @@ sets:
     git_ref: android13-5.10
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -94,9 +86,7 @@ sets:
     git_ref: android13-5.10
     target_arch: arm64
     toolchain: clang-12
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -106,9 +96,7 @@ sets:
     git_ref: android13-5.10
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -130,9 +118,7 @@ sets:
     git_ref: android13-5.10
     target_arch: arm64
     toolchain: clang-android
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -142,9 +128,7 @@ sets:
     git_ref: android13-5.10
     target_arch: x86_64
     toolchain: clang-android
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.15.tux.yml
+++ b/tuxsuite/android13-5.15.tux.yml
@@ -22,9 +22,7 @@ sets:
     git_ref: android13-5.15
     target_arch: arm64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -34,9 +32,7 @@ sets:
     git_ref: android13-5.15
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -58,9 +54,7 @@ sets:
     git_ref: android13-5.15
     target_arch: arm64
     toolchain: clang-13
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -70,9 +64,7 @@ sets:
     git_ref: android13-5.15
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -94,9 +86,7 @@ sets:
     git_ref: android13-5.15
     target_arch: arm64
     toolchain: clang-12
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -106,9 +96,7 @@ sets:
     git_ref: android13-5.15
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -130,9 +118,7 @@ sets:
     git_ref: android13-5.15
     target_arch: arm64
     toolchain: clang-android
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -142,9 +128,7 @@ sets:
     git_ref: android13-5.15
     target_arch: x86_64
     toolchain: clang-android
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/mainline.tux.yml
+++ b/tuxsuite/mainline.tux.yml
@@ -1412,7 +1412,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -1447,7 +1446,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -1470,7 +1468,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -1498,9 +1495,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
     make_variables:
@@ -1545,7 +1540,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -1580,7 +1574,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -1603,7 +1596,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -1631,9 +1623,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
     make_variables:
@@ -1678,7 +1668,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -1713,7 +1702,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -1743,9 +1731,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
     make_variables:
@@ -1790,7 +1776,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -1838,7 +1823,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -1868,9 +1852,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-11
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/next.tux.yml
+++ b/tuxsuite/next.tux.yml
@@ -1585,7 +1585,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -1620,7 +1619,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -1643,7 +1641,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -1671,9 +1668,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
     make_variables:
@@ -1718,7 +1713,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -1753,7 +1747,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -1776,7 +1769,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -1804,9 +1796,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
     make_variables:
@@ -1851,7 +1841,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -1886,7 +1875,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -1916,9 +1904,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
     make_variables:
@@ -1963,7 +1949,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     make_variables:
@@ -2011,7 +1996,6 @@ sets:
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
-    - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -2041,9 +2025,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-11
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
-    - CONFIG_DEBUG_INFO_BTF=n
+    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
     make_variables:


### PR DESCRIPTION
pahole 1.22 has been backported to the tuxmake images so there should be
no more build failures.

Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/290
