### PR TITLE
Move and update cron logic

### DIFF
--- a/.github/workflows/4.14-clang-13.yml
+++ b/.github/workflows/4.14-clang-13.yml
@@ -13,7 +13,7 @@ name: 4.14 (clang-13)
     - tuxsuite/4.14-clang-13.tux.yml
     - .github/workflows/4.14-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/4.14-clang-14.yml
+++ b/.github/workflows/4.14-clang-14.yml
@@ -13,7 +13,7 @@ name: 4.14 (clang-14)
     - tuxsuite/4.14-clang-14.tux.yml
     - .github/workflows/4.14-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/4.14-clang-15.yml
+++ b/.github/workflows/4.14-clang-15.yml
@@ -13,7 +13,7 @@ name: 4.14 (clang-15)
     - tuxsuite/4.14-clang-15.tux.yml
     - .github/workflows/4.14-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/4.19-clang-13.yml
+++ b/.github/workflows/4.19-clang-13.yml
@@ -13,7 +13,7 @@ name: 4.19 (clang-13)
     - tuxsuite/4.19-clang-13.tux.yml
     - .github/workflows/4.19-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/4.19-clang-14.yml
+++ b/.github/workflows/4.19-clang-14.yml
@@ -13,7 +13,7 @@ name: 4.19 (clang-14)
     - tuxsuite/4.19-clang-14.tux.yml
     - .github/workflows/4.19-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/4.19-clang-15.yml
+++ b/.github/workflows/4.19-clang-15.yml
@@ -13,7 +13,7 @@ name: 4.19 (clang-15)
     - tuxsuite/4.19-clang-15.tux.yml
     - .github/workflows/4.19-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/4.9-clang-13.yml
+++ b/.github/workflows/4.9-clang-13.yml
@@ -13,7 +13,7 @@ name: 4.9 (clang-13)
     - tuxsuite/4.9-clang-13.tux.yml
     - .github/workflows/4.9-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/4.9-clang-14.yml
+++ b/.github/workflows/4.9-clang-14.yml
@@ -13,7 +13,7 @@ name: 4.9 (clang-14)
     - tuxsuite/4.9-clang-14.tux.yml
     - .github/workflows/4.9-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/4.9-clang-15.yml
+++ b/.github/workflows/4.9-clang-15.yml
@@ -13,7 +13,7 @@ name: 4.9 (clang-15)
     - tuxsuite/4.9-clang-15.tux.yml
     - .github/workflows/4.9-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.10-clang-11.yml
+++ b/.github/workflows/5.10-clang-11.yml
@@ -13,7 +13,7 @@ name: 5.10 (clang-11)
     - tuxsuite/5.10-clang-11.tux.yml
     - .github/workflows/5.10-clang-11.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.10-clang-12.yml
+++ b/.github/workflows/5.10-clang-12.yml
@@ -13,7 +13,7 @@ name: 5.10 (clang-12)
     - tuxsuite/5.10-clang-12.tux.yml
     - .github/workflows/5.10-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.10-clang-13.yml
+++ b/.github/workflows/5.10-clang-13.yml
@@ -13,7 +13,7 @@ name: 5.10 (clang-13)
     - tuxsuite/5.10-clang-13.tux.yml
     - .github/workflows/5.10-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.10-clang-14.yml
+++ b/.github/workflows/5.10-clang-14.yml
@@ -13,7 +13,7 @@ name: 5.10 (clang-14)
     - tuxsuite/5.10-clang-14.tux.yml
     - .github/workflows/5.10-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.10-clang-15.yml
+++ b/.github/workflows/5.10-clang-15.yml
@@ -13,7 +13,7 @@ name: 5.10 (clang-15)
     - tuxsuite/5.10-clang-15.tux.yml
     - .github/workflows/5.10-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -13,7 +13,7 @@ name: 5.15 (clang-11)
     - tuxsuite/5.15-clang-11.tux.yml
     - .github/workflows/5.15-clang-11.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -13,7 +13,7 @@ name: 5.15 (clang-12)
     - tuxsuite/5.15-clang-12.tux.yml
     - .github/workflows/5.15-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -13,7 +13,7 @@ name: 5.15 (clang-13)
     - tuxsuite/5.15-clang-13.tux.yml
     - .github/workflows/5.15-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -13,7 +13,7 @@ name: 5.15 (clang-14)
     - tuxsuite/5.15-clang-14.tux.yml
     - .github/workflows/5.15-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -13,7 +13,7 @@ name: 5.15 (clang-15)
     - tuxsuite/5.15-clang-15.tux.yml
     - .github/workflows/5.15-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.4-clang-13.yml
+++ b/.github/workflows/5.4-clang-13.yml
@@ -13,7 +13,7 @@ name: 5.4 (clang-13)
     - tuxsuite/5.4-clang-13.tux.yml
     - .github/workflows/5.4-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.4-clang-14.yml
+++ b/.github/workflows/5.4-clang-14.yml
@@ -13,7 +13,7 @@ name: 5.4 (clang-14)
     - tuxsuite/5.4-clang-14.tux.yml
     - .github/workflows/5.4-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.4-clang-15.yml
+++ b/.github/workflows/5.4-clang-15.yml
@@ -13,7 +13,7 @@ name: 5.4 (clang-15)
     - tuxsuite/5.4-clang-15.tux.yml
     - .github/workflows/5.4-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.14-clang-12.yml
+++ b/.github/workflows/android-4.14-clang-12.yml
@@ -13,7 +13,7 @@ name: android-4.14 (clang-12)
     - tuxsuite/android-4.14-clang-12.tux.yml
     - .github/workflows/android-4.14-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.14-clang-13.yml
+++ b/.github/workflows/android-4.14-clang-13.yml
@@ -13,7 +13,7 @@ name: android-4.14 (clang-13)
     - tuxsuite/android-4.14-clang-13.tux.yml
     - .github/workflows/android-4.14-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.14-clang-14.yml
+++ b/.github/workflows/android-4.14-clang-14.yml
@@ -13,7 +13,7 @@ name: android-4.14 (clang-14)
     - tuxsuite/android-4.14-clang-14.tux.yml
     - .github/workflows/android-4.14-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.14-clang-15.yml
+++ b/.github/workflows/android-4.14-clang-15.yml
@@ -13,7 +13,7 @@ name: android-4.14 (clang-15)
     - tuxsuite/android-4.14-clang-15.tux.yml
     - .github/workflows/android-4.14-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.14-clang-android.yml
+++ b/.github/workflows/android-4.14-clang-android.yml
@@ -13,7 +13,7 @@ name: android-4.14 (clang-android)
     - tuxsuite/android-4.14-clang-android.tux.yml
     - .github/workflows/android-4.14-clang-android.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.19-clang-12.yml
+++ b/.github/workflows/android-4.19-clang-12.yml
@@ -13,7 +13,7 @@ name: android-4.19 (clang-12)
     - tuxsuite/android-4.19-clang-12.tux.yml
     - .github/workflows/android-4.19-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.19-clang-13.yml
+++ b/.github/workflows/android-4.19-clang-13.yml
@@ -13,7 +13,7 @@ name: android-4.19 (clang-13)
     - tuxsuite/android-4.19-clang-13.tux.yml
     - .github/workflows/android-4.19-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.19-clang-14.yml
+++ b/.github/workflows/android-4.19-clang-14.yml
@@ -13,7 +13,7 @@ name: android-4.19 (clang-14)
     - tuxsuite/android-4.19-clang-14.tux.yml
     - .github/workflows/android-4.19-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.19-clang-15.yml
+++ b/.github/workflows/android-4.19-clang-15.yml
@@ -13,7 +13,7 @@ name: android-4.19 (clang-15)
     - tuxsuite/android-4.19-clang-15.tux.yml
     - .github/workflows/android-4.19-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.19-clang-android.yml
+++ b/.github/workflows/android-4.19-clang-android.yml
@@ -13,7 +13,7 @@ name: android-4.19 (clang-android)
     - tuxsuite/android-4.19-clang-android.tux.yml
     - .github/workflows/android-4.19-clang-android.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.9-clang-12.yml
+++ b/.github/workflows/android-4.9-clang-12.yml
@@ -13,7 +13,7 @@ name: android-4.9 (clang-12)
     - tuxsuite/android-4.9-clang-12.tux.yml
     - .github/workflows/android-4.9-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.9-clang-13.yml
+++ b/.github/workflows/android-4.9-clang-13.yml
@@ -13,7 +13,7 @@ name: android-4.9 (clang-13)
     - tuxsuite/android-4.9-clang-13.tux.yml
     - .github/workflows/android-4.9-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.9-clang-14.yml
+++ b/.github/workflows/android-4.9-clang-14.yml
@@ -13,7 +13,7 @@ name: android-4.9 (clang-14)
     - tuxsuite/android-4.9-clang-14.tux.yml
     - .github/workflows/android-4.9-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.9-clang-15.yml
+++ b/.github/workflows/android-4.9-clang-15.yml
@@ -13,7 +13,7 @@ name: android-4.9 (clang-15)
     - tuxsuite/android-4.9-clang-15.tux.yml
     - .github/workflows/android-4.9-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.9-clang-android.yml
+++ b/.github/workflows/android-4.9-clang-android.yml
@@ -13,7 +13,7 @@ name: android-4.9 (clang-android)
     - tuxsuite/android-4.9-clang-android.tux.yml
     - .github/workflows/android-4.9-clang-android.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-mainline-clang-12.yml
+++ b/.github/workflows/android-mainline-clang-12.yml
@@ -13,7 +13,7 @@ name: android-mainline (clang-12)
     - tuxsuite/android-mainline-clang-12.tux.yml
     - .github/workflows/android-mainline-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-mainline-clang-13.yml
+++ b/.github/workflows/android-mainline-clang-13.yml
@@ -13,7 +13,7 @@ name: android-mainline (clang-13)
     - tuxsuite/android-mainline-clang-13.tux.yml
     - .github/workflows/android-mainline-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-mainline-clang-14.yml
+++ b/.github/workflows/android-mainline-clang-14.yml
@@ -13,7 +13,7 @@ name: android-mainline (clang-14)
     - tuxsuite/android-mainline-clang-14.tux.yml
     - .github/workflows/android-mainline-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-mainline-clang-15.yml
+++ b/.github/workflows/android-mainline-clang-15.yml
@@ -13,7 +13,7 @@ name: android-mainline (clang-15)
     - tuxsuite/android-mainline-clang-15.tux.yml
     - .github/workflows/android-mainline-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-mainline-clang-android.yml
+++ b/.github/workflows/android-mainline-clang-android.yml
@@ -13,7 +13,7 @@ name: android-mainline (clang-android)
     - tuxsuite/android-mainline-clang-android.tux.yml
     - .github/workflows/android-mainline-clang-android.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.10-clang-12.yml
+++ b/.github/workflows/android12-5.10-clang-12.yml
@@ -13,7 +13,7 @@ name: android12-5.10 (clang-12)
     - tuxsuite/android12-5.10-clang-12.tux.yml
     - .github/workflows/android12-5.10-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.10-clang-13.yml
+++ b/.github/workflows/android12-5.10-clang-13.yml
@@ -13,7 +13,7 @@ name: android12-5.10 (clang-13)
     - tuxsuite/android12-5.10-clang-13.tux.yml
     - .github/workflows/android12-5.10-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.10-clang-14.yml
+++ b/.github/workflows/android12-5.10-clang-14.yml
@@ -13,7 +13,7 @@ name: android12-5.10 (clang-14)
     - tuxsuite/android12-5.10-clang-14.tux.yml
     - .github/workflows/android12-5.10-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.10-clang-15.yml
+++ b/.github/workflows/android12-5.10-clang-15.yml
@@ -13,7 +13,7 @@ name: android12-5.10 (clang-15)
     - tuxsuite/android12-5.10-clang-15.tux.yml
     - .github/workflows/android12-5.10-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.10-clang-android.yml
+++ b/.github/workflows/android12-5.10-clang-android.yml
@@ -13,7 +13,7 @@ name: android12-5.10 (clang-android)
     - tuxsuite/android12-5.10-clang-android.tux.yml
     - .github/workflows/android12-5.10-clang-android.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.4-clang-12.yml
+++ b/.github/workflows/android12-5.4-clang-12.yml
@@ -13,7 +13,7 @@ name: android12-5.4 (clang-12)
     - tuxsuite/android12-5.4-clang-12.tux.yml
     - .github/workflows/android12-5.4-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.4-clang-13.yml
+++ b/.github/workflows/android12-5.4-clang-13.yml
@@ -13,7 +13,7 @@ name: android12-5.4 (clang-13)
     - tuxsuite/android12-5.4-clang-13.tux.yml
     - .github/workflows/android12-5.4-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.4-clang-14.yml
+++ b/.github/workflows/android12-5.4-clang-14.yml
@@ -13,7 +13,7 @@ name: android12-5.4 (clang-14)
     - tuxsuite/android12-5.4-clang-14.tux.yml
     - .github/workflows/android12-5.4-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.4-clang-15.yml
+++ b/.github/workflows/android12-5.4-clang-15.yml
@@ -13,7 +13,7 @@ name: android12-5.4 (clang-15)
     - tuxsuite/android12-5.4-clang-15.tux.yml
     - .github/workflows/android12-5.4-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.4-clang-android.yml
+++ b/.github/workflows/android12-5.4-clang-android.yml
@@ -13,7 +13,7 @@ name: android12-5.4 (clang-android)
     - tuxsuite/android12-5.4-clang-android.tux.yml
     - .github/workflows/android12-5.4-clang-android.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.10-clang-12.yml
+++ b/.github/workflows/android13-5.10-clang-12.yml
@@ -13,7 +13,7 @@ name: android13-5.10 (clang-12)
     - tuxsuite/android13-5.10-clang-12.tux.yml
     - .github/workflows/android13-5.10-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.10-clang-13.yml
+++ b/.github/workflows/android13-5.10-clang-13.yml
@@ -13,7 +13,7 @@ name: android13-5.10 (clang-13)
     - tuxsuite/android13-5.10-clang-13.tux.yml
     - .github/workflows/android13-5.10-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.10-clang-14.yml
+++ b/.github/workflows/android13-5.10-clang-14.yml
@@ -13,7 +13,7 @@ name: android13-5.10 (clang-14)
     - tuxsuite/android13-5.10-clang-14.tux.yml
     - .github/workflows/android13-5.10-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.10-clang-15.yml
+++ b/.github/workflows/android13-5.10-clang-15.yml
@@ -13,7 +13,7 @@ name: android13-5.10 (clang-15)
     - tuxsuite/android13-5.10-clang-15.tux.yml
     - .github/workflows/android13-5.10-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.10-clang-android.yml
+++ b/.github/workflows/android13-5.10-clang-android.yml
@@ -13,7 +13,7 @@ name: android13-5.10 (clang-android)
     - tuxsuite/android13-5.10-clang-android.tux.yml
     - .github/workflows/android13-5.10-clang-android.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.15-clang-12.yml
+++ b/.github/workflows/android13-5.15-clang-12.yml
@@ -13,7 +13,7 @@ name: android13-5.15 (clang-12)
     - tuxsuite/android13-5.15-clang-12.tux.yml
     - .github/workflows/android13-5.15-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.15-clang-13.yml
+++ b/.github/workflows/android13-5.15-clang-13.yml
@@ -13,7 +13,7 @@ name: android13-5.15 (clang-13)
     - tuxsuite/android13-5.15-clang-13.tux.yml
     - .github/workflows/android13-5.15-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.15-clang-14.yml
+++ b/.github/workflows/android13-5.15-clang-14.yml
@@ -13,7 +13,7 @@ name: android13-5.15 (clang-14)
     - tuxsuite/android13-5.15-clang-14.tux.yml
     - .github/workflows/android13-5.15-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.15-clang-15.yml
+++ b/.github/workflows/android13-5.15-clang-15.yml
@@ -13,7 +13,7 @@ name: android13-5.15 (clang-15)
     - tuxsuite/android13-5.15-clang-15.tux.yml
     - .github/workflows/android13-5.15-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.15-clang-android.yml
+++ b/.github/workflows/android13-5.15-clang-android.yml
@@ -13,7 +13,7 @@ name: android13-5.15 (clang-android)
     - tuxsuite/android13-5.15-clang-android.tux.yml
     - .github/workflows/android13-5.15-clang-android.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/arm64-clang-11.yml
+++ b/.github/workflows/arm64-clang-11.yml
@@ -13,7 +13,7 @@ name: arm64 (clang-11)
     - tuxsuite/arm64-clang-11.tux.yml
     - .github/workflows/arm64-clang-11.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 18 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/arm64-clang-12.yml
+++ b/.github/workflows/arm64-clang-12.yml
@@ -13,7 +13,7 @@ name: arm64 (clang-12)
     - tuxsuite/arm64-clang-12.tux.yml
     - .github/workflows/arm64-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 18 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/arm64-clang-13.yml
+++ b/.github/workflows/arm64-clang-13.yml
@@ -13,7 +13,7 @@ name: arm64 (clang-13)
     - tuxsuite/arm64-clang-13.tux.yml
     - .github/workflows/arm64-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 18 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/arm64-fixes-clang-11.yml
+++ b/.github/workflows/arm64-fixes-clang-11.yml
@@ -13,7 +13,7 @@ name: arm64-fixes (clang-11)
     - tuxsuite/arm64-fixes-clang-11.tux.yml
     - .github/workflows/arm64-fixes-clang-11.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 18 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/arm64-fixes-clang-12.yml
+++ b/.github/workflows/arm64-fixes-clang-12.yml
@@ -13,7 +13,7 @@ name: arm64-fixes (clang-12)
     - tuxsuite/arm64-fixes-clang-12.tux.yml
     - .github/workflows/arm64-fixes-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 18 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/arm64-fixes-clang-13.yml
+++ b/.github/workflows/arm64-fixes-clang-13.yml
@@ -13,7 +13,7 @@ name: arm64-fixes (clang-13)
     - tuxsuite/arm64-fixes-clang-13.tux.yml
     - .github/workflows/arm64-fixes-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 18 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/tip-clang-11.yml
+++ b/.github/workflows/tip-clang-11.yml
@@ -13,7 +13,7 @@ name: tip (clang-11)
     - tuxsuite/tip-clang-11.tux.yml
     - .github/workflows/tip-clang-11.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 18 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/tip-clang-12.yml
+++ b/.github/workflows/tip-clang-12.yml
@@ -13,7 +13,7 @@ name: tip (clang-12)
     - tuxsuite/tip-clang-12.tux.yml
     - .github/workflows/tip-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 18 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/tip-clang-13.yml
+++ b/.github/workflows/tip-clang-13.yml
@@ -13,7 +13,7 @@ name: tip (clang-13)
     - tuxsuite/tip-clang-13.tux.yml
     - .github/workflows/tip-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 18 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/generate_workflow.py
+++ b/generate_workflow.py
@@ -159,7 +159,10 @@ def get_steps(build, build_set):
 
 def get_cron(tree_name, llvm_version):
     six_hours = "0 0,6,12,18 * * *"
-    daily = "0 0 * * *"
+    daily_midnight = "0 0 * * *"
+    daily_six = "0 6 * * *"
+    daily_noon = "0 12 * * *"
+    daily_eighteen = "0 18 * * *"
     weekdays = "0 12 * * 1,2,3,4,5"
     sundays = "0 0 * * 0"
     wednesdays = "0 0 * * 3"
@@ -182,9 +185,15 @@ def get_cron(tree_name, llvm_version):
         elif "android" in tree_name:
             return sundays
         else:
-            return daily
+            return daily_eighteen
     else:
-        return daily
+        # Spread out the other daily builds across three different times to
+        # help with build pressure on GitHub Actions
+        if tree_name in stable_linux_versions:
+            return daily_noon
+        elif "android" in tree_name:
+            return daily_six
+        return daily_midnight
 
 
 def print_builds(config, tree_name, llvm_version):

--- a/generate_workflow.py
+++ b/generate_workflow.py
@@ -157,6 +157,19 @@ def get_steps(build, build_set):
     } # yapf: disable
 
 
+def get_cron(tree_name):
+    six_hours = "0 0,6,12,18 * * *"
+    daily = "0 0 * * *"
+    weekdays = "0 12 * * 1,2,3,4,5"
+
+    if tree_name == "mainline":
+        return six_hours
+    elif tree_name == "next":
+        return weekdays
+    else:
+        return daily
+
+
 def print_builds(config, tree_name, llvm_version):
     repo, ref = get_repo_ref(config, tree_name)
     toolchain = "clang-{}".format(llvm_version)
@@ -170,7 +183,6 @@ def print_builds(config, tree_name, llvm_version):
         if build["git_repo"] == repo and \
            build["git_ref"] == ref and \
            build["llvm_version"] == llvm_version:
-            cron_schedule = build["schedule"]
             if "defconfig" in str(build["config"]):
                 check_logs_defconfigs.update(get_steps(build, "defconfigs"))
             elif "https://" in str(build["config"]):
@@ -180,6 +192,7 @@ def print_builds(config, tree_name, llvm_version):
                 check_logs_allconfigs.update(get_steps(build, "allconfigs"))
 
     workflow_name = "{} ({})".format(tree_name, toolchain)
+    cron_schedule = get_cron(tree_name)
     workflow = initial_workflow(workflow_name, cron_schedule, tuxsuite_yml,
                                 github_yml)
     workflow["jobs"].update(tuxsuite_setups("defconfigs", tuxsuite_yml))

--- a/generator.yml
+++ b/generator.yml
@@ -27,31 +27,26 @@ urls:
   - &x86_64-arch-config-url    https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
   - &x86_64-fedora-config-url  https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
   - &x86_64-suse-config-url    https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
-schedules:
-  - &six_hours {schedule: "0 0,6,12,18 * * *"}
-  - &daily     {schedule: "0 0 * * *"}
-  # -next updates M-F in the evening AEST, which is usually around 12:00PM UTC
-  - &weekdays  {schedule: "0 12 * * 1,2,3,4,5"}
 trees:
-  - &mainline         {git_repo: *mainline-url, git_ref: master,              name: mainline,         << : *six_hours}
-  - &next             {git_repo: *next-url,     git_ref: master,              name: next,             << : *weekdays}
-  - &stable-5_15      {git_repo: *stable-url,   git_ref: linux-5.15.y,        name: "5.15",           << : *daily}
-  - &stable-5_10      {git_repo: *stable-url,   git_ref: linux-5.10.y,        name: "5.10",           << : *daily}
-  - &stable-5_4       {git_repo: *stable-url,   git_ref: linux-5.4.y,         name: "5.4",            << : *daily}
-  - &stable-4_19      {git_repo: *stable-url,   git_ref: linux-4.19.y,        name: "4.19",           << : *daily}
-  - &stable-4_14      {git_repo: *stable-url,   git_ref: linux-4.14.y,        name: "4.14",           << : *daily}
-  - &stable-4_9       {git_repo: *stable-url,   git_ref: linux-4.9.y,         name: "4.9",            << : *daily}
-  - &android-mainline {git_repo: *android-url,  git_ref: android-mainline,    name: android-mainline, << : *daily}
-  - &android13-5_15   {git_repo: *android-url,  git_ref: android13-5.15,      name: android13-5.15,   << : *daily}
-  - &android13-5_10   {git_repo: *android-url,  git_ref: android13-5.10,      name: android13-5.10,   << : *daily}
-  - &android12-5_10   {git_repo: *android-url,  git_ref: android12-5.10,      name: android12-5.10,   << : *daily}
-  - &android12-5_4    {git_repo: *android-url,  git_ref: android12-5.4,       name: android12-5.4,    << : *daily}
-  - &android-4_19     {git_repo: *android-url,  git_ref: android-4.19-stable, name: android-4.19,     << : *daily}
-  - &android-4_14     {git_repo: *android-url,  git_ref: android-4.14-stable, name: android-4.14,     << : *daily}
-  - &android-4_9      {git_repo: *android-url,  git_ref: android-4.9-q,       name: android-4.9,      << : *daily}
-  - &tip              {git_repo: *tip-url,      git_ref: master,              name: tip,              << : *daily}
-  - &arm64-core       {git_repo: *arm64-url,    git_ref: for-next/core,       name: arm64,            << : *daily}
-  - &arm64-fixes      {git_repo: *arm64-url,    git_ref: for-next/fixes,      name: arm64-fixes,      << : *daily}
+  - &mainline         {git_repo: *mainline-url, git_ref: master,              name: mainline}
+  - &next             {git_repo: *next-url,     git_ref: master,              name: next}
+  - &stable-5_15      {git_repo: *stable-url,   git_ref: linux-5.15.y,        name: "5.15"}
+  - &stable-5_10      {git_repo: *stable-url,   git_ref: linux-5.10.y,        name: "5.10"}
+  - &stable-5_4       {git_repo: *stable-url,   git_ref: linux-5.4.y,         name: "5.4"}
+  - &stable-4_19      {git_repo: *stable-url,   git_ref: linux-4.19.y,        name: "4.19"}
+  - &stable-4_14      {git_repo: *stable-url,   git_ref: linux-4.14.y,        name: "4.14"}
+  - &stable-4_9       {git_repo: *stable-url,   git_ref: linux-4.9.y,         name: "4.9"}
+  - &android-mainline {git_repo: *android-url,  git_ref: android-mainline,    name: android-mainline}
+  - &android13-5_15   {git_repo: *android-url,  git_ref: android13-5.15,      name: android13-5.15}
+  - &android13-5_10   {git_repo: *android-url,  git_ref: android13-5.10,      name: android13-5.10}
+  - &android12-5_10   {git_repo: *android-url,  git_ref: android12-5.10,      name: android12-5.10}
+  - &android12-5_4    {git_repo: *android-url,  git_ref: android12-5.4,       name: android12-5.4}
+  - &android-4_19     {git_repo: *android-url,  git_ref: android-4.19-stable, name: android-4.19}
+  - &android-4_14     {git_repo: *android-url,  git_ref: android-4.14-stable, name: android-4.14}
+  - &android-4_9      {git_repo: *android-url,  git_ref: android-4.9-q,       name: android-4.9}
+  - &tip              {git_repo: *tip-url,      git_ref: master,              name: tip}
+  - &arm64-core       {git_repo: *arm64-url,    git_ref: for-next/core,       name: arm64}
+  - &arm64-fixes      {git_repo: *arm64-url,    git_ref: for-next/fixes,      name: arm64-fixes}
 architectures:
  - &arm-arch     arm
  - &arm64-arch   arm64


### PR DESCRIPTION
This PR moves the cron schedule logic into Python and updates it to do builds less frequently and at different intervals.
