### PR TITLE
Update cron schedule logic

### DIFF
--- a/.github/workflows/4.14-clang-13.yml
+++ b/.github/workflows/4.14-clang-13.yml
@@ -13,7 +13,7 @@ name: 4.14 (clang-13)
     - tuxsuite/4.14-clang-13.tux.yml
     - .github/workflows/4.14-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/4.14-clang-14.yml
+++ b/.github/workflows/4.14-clang-14.yml
@@ -13,7 +13,7 @@ name: 4.14 (clang-14)
     - tuxsuite/4.14-clang-14.tux.yml
     - .github/workflows/4.14-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/4.14-clang-15.yml
+++ b/.github/workflows/4.14-clang-15.yml
@@ -13,7 +13,7 @@ name: 4.14 (clang-15)
     - tuxsuite/4.14-clang-15.tux.yml
     - .github/workflows/4.14-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/4.19-clang-13.yml
+++ b/.github/workflows/4.19-clang-13.yml
@@ -13,7 +13,7 @@ name: 4.19 (clang-13)
     - tuxsuite/4.19-clang-13.tux.yml
     - .github/workflows/4.19-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/4.19-clang-14.yml
+++ b/.github/workflows/4.19-clang-14.yml
@@ -13,7 +13,7 @@ name: 4.19 (clang-14)
     - tuxsuite/4.19-clang-14.tux.yml
     - .github/workflows/4.19-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/4.19-clang-15.yml
+++ b/.github/workflows/4.19-clang-15.yml
@@ -13,7 +13,7 @@ name: 4.19 (clang-15)
     - tuxsuite/4.19-clang-15.tux.yml
     - .github/workflows/4.19-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/4.9-clang-13.yml
+++ b/.github/workflows/4.9-clang-13.yml
@@ -13,7 +13,7 @@ name: 4.9 (clang-13)
     - tuxsuite/4.9-clang-13.tux.yml
     - .github/workflows/4.9-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/4.9-clang-14.yml
+++ b/.github/workflows/4.9-clang-14.yml
@@ -13,7 +13,7 @@ name: 4.9 (clang-14)
     - tuxsuite/4.9-clang-14.tux.yml
     - .github/workflows/4.9-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/4.9-clang-15.yml
+++ b/.github/workflows/4.9-clang-15.yml
@@ -13,7 +13,7 @@ name: 4.9 (clang-15)
     - tuxsuite/4.9-clang-15.tux.yml
     - .github/workflows/4.9-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.10-clang-11.yml
+++ b/.github/workflows/5.10-clang-11.yml
@@ -13,7 +13,7 @@ name: 5.10 (clang-11)
     - tuxsuite/5.10-clang-11.tux.yml
     - .github/workflows/5.10-clang-11.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.10-clang-12.yml
+++ b/.github/workflows/5.10-clang-12.yml
@@ -13,7 +13,7 @@ name: 5.10 (clang-12)
     - tuxsuite/5.10-clang-12.tux.yml
     - .github/workflows/5.10-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.10-clang-13.yml
+++ b/.github/workflows/5.10-clang-13.yml
@@ -13,7 +13,7 @@ name: 5.10 (clang-13)
     - tuxsuite/5.10-clang-13.tux.yml
     - .github/workflows/5.10-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.10-clang-14.yml
+++ b/.github/workflows/5.10-clang-14.yml
@@ -13,7 +13,7 @@ name: 5.10 (clang-14)
     - tuxsuite/5.10-clang-14.tux.yml
     - .github/workflows/5.10-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.10-clang-15.yml
+++ b/.github/workflows/5.10-clang-15.yml
@@ -13,7 +13,7 @@ name: 5.10 (clang-15)
     - tuxsuite/5.10-clang-15.tux.yml
     - .github/workflows/5.10-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -13,7 +13,7 @@ name: 5.15 (clang-11)
     - tuxsuite/5.15-clang-11.tux.yml
     - .github/workflows/5.15-clang-11.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -13,7 +13,7 @@ name: 5.15 (clang-12)
     - tuxsuite/5.15-clang-12.tux.yml
     - .github/workflows/5.15-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -13,7 +13,7 @@ name: 5.15 (clang-13)
     - tuxsuite/5.15-clang-13.tux.yml
     - .github/workflows/5.15-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -13,7 +13,7 @@ name: 5.15 (clang-14)
     - tuxsuite/5.15-clang-14.tux.yml
     - .github/workflows/5.15-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -13,7 +13,7 @@ name: 5.15 (clang-15)
     - tuxsuite/5.15-clang-15.tux.yml
     - .github/workflows/5.15-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.4-clang-13.yml
+++ b/.github/workflows/5.4-clang-13.yml
@@ -13,7 +13,7 @@ name: 5.4 (clang-13)
     - tuxsuite/5.4-clang-13.tux.yml
     - .github/workflows/5.4-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 3
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.4-clang-14.yml
+++ b/.github/workflows/5.4-clang-14.yml
@@ -13,7 +13,7 @@ name: 5.4 (clang-14)
     - tuxsuite/5.4-clang-14.tux.yml
     - .github/workflows/5.4-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/5.4-clang-15.yml
+++ b/.github/workflows/5.4-clang-15.yml
@@ -13,7 +13,7 @@ name: 5.4 (clang-15)
     - tuxsuite/5.4-clang-15.tux.yml
     - .github/workflows/5.4-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 12 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.14-clang-12.yml
+++ b/.github/workflows/android-4.14-clang-12.yml
@@ -13,7 +13,7 @@ name: android-4.14 (clang-12)
     - tuxsuite/android-4.14-clang-12.tux.yml
     - .github/workflows/android-4.14-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.14-clang-13.yml
+++ b/.github/workflows/android-4.14-clang-13.yml
@@ -13,7 +13,7 @@ name: android-4.14 (clang-13)
     - tuxsuite/android-4.14-clang-13.tux.yml
     - .github/workflows/android-4.14-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.14-clang-14.yml
+++ b/.github/workflows/android-4.14-clang-14.yml
@@ -13,7 +13,7 @@ name: android-4.14 (clang-14)
     - tuxsuite/android-4.14-clang-14.tux.yml
     - .github/workflows/android-4.14-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.14-clang-15.yml
+++ b/.github/workflows/android-4.14-clang-15.yml
@@ -13,7 +13,7 @@ name: android-4.14 (clang-15)
     - tuxsuite/android-4.14-clang-15.tux.yml
     - .github/workflows/android-4.14-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.14-clang-android.yml
+++ b/.github/workflows/android-4.14-clang-android.yml
@@ -13,7 +13,7 @@ name: android-4.14 (clang-android)
     - tuxsuite/android-4.14-clang-android.tux.yml
     - .github/workflows/android-4.14-clang-android.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.19-clang-12.yml
+++ b/.github/workflows/android-4.19-clang-12.yml
@@ -13,7 +13,7 @@ name: android-4.19 (clang-12)
     - tuxsuite/android-4.19-clang-12.tux.yml
     - .github/workflows/android-4.19-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.19-clang-13.yml
+++ b/.github/workflows/android-4.19-clang-13.yml
@@ -13,7 +13,7 @@ name: android-4.19 (clang-13)
     - tuxsuite/android-4.19-clang-13.tux.yml
     - .github/workflows/android-4.19-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.19-clang-14.yml
+++ b/.github/workflows/android-4.19-clang-14.yml
@@ -13,7 +13,7 @@ name: android-4.19 (clang-14)
     - tuxsuite/android-4.19-clang-14.tux.yml
     - .github/workflows/android-4.19-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.19-clang-15.yml
+++ b/.github/workflows/android-4.19-clang-15.yml
@@ -13,7 +13,7 @@ name: android-4.19 (clang-15)
     - tuxsuite/android-4.19-clang-15.tux.yml
     - .github/workflows/android-4.19-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.19-clang-android.yml
+++ b/.github/workflows/android-4.19-clang-android.yml
@@ -13,7 +13,7 @@ name: android-4.19 (clang-android)
     - tuxsuite/android-4.19-clang-android.tux.yml
     - .github/workflows/android-4.19-clang-android.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.9-clang-12.yml
+++ b/.github/workflows/android-4.9-clang-12.yml
@@ -13,7 +13,7 @@ name: android-4.9 (clang-12)
     - tuxsuite/android-4.9-clang-12.tux.yml
     - .github/workflows/android-4.9-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.9-clang-13.yml
+++ b/.github/workflows/android-4.9-clang-13.yml
@@ -13,7 +13,7 @@ name: android-4.9 (clang-13)
     - tuxsuite/android-4.9-clang-13.tux.yml
     - .github/workflows/android-4.9-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.9-clang-14.yml
+++ b/.github/workflows/android-4.9-clang-14.yml
@@ -13,7 +13,7 @@ name: android-4.9 (clang-14)
     - tuxsuite/android-4.9-clang-14.tux.yml
     - .github/workflows/android-4.9-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.9-clang-15.yml
+++ b/.github/workflows/android-4.9-clang-15.yml
@@ -13,7 +13,7 @@ name: android-4.9 (clang-15)
     - tuxsuite/android-4.9-clang-15.tux.yml
     - .github/workflows/android-4.9-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-4.9-clang-android.yml
+++ b/.github/workflows/android-4.9-clang-android.yml
@@ -13,7 +13,7 @@ name: android-4.9 (clang-android)
     - tuxsuite/android-4.9-clang-android.tux.yml
     - .github/workflows/android-4.9-clang-android.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-mainline-clang-12.yml
+++ b/.github/workflows/android-mainline-clang-12.yml
@@ -13,7 +13,7 @@ name: android-mainline (clang-12)
     - tuxsuite/android-mainline-clang-12.tux.yml
     - .github/workflows/android-mainline-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-mainline-clang-13.yml
+++ b/.github/workflows/android-mainline-clang-13.yml
@@ -13,7 +13,7 @@ name: android-mainline (clang-13)
     - tuxsuite/android-mainline-clang-13.tux.yml
     - .github/workflows/android-mainline-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-mainline-clang-14.yml
+++ b/.github/workflows/android-mainline-clang-14.yml
@@ -13,7 +13,7 @@ name: android-mainline (clang-14)
     - tuxsuite/android-mainline-clang-14.tux.yml
     - .github/workflows/android-mainline-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-mainline-clang-15.yml
+++ b/.github/workflows/android-mainline-clang-15.yml
@@ -13,7 +13,7 @@ name: android-mainline (clang-15)
     - tuxsuite/android-mainline-clang-15.tux.yml
     - .github/workflows/android-mainline-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android-mainline-clang-android.yml
+++ b/.github/workflows/android-mainline-clang-android.yml
@@ -13,7 +13,7 @@ name: android-mainline (clang-android)
     - tuxsuite/android-mainline-clang-android.tux.yml
     - .github/workflows/android-mainline-clang-android.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.10-clang-12.yml
+++ b/.github/workflows/android12-5.10-clang-12.yml
@@ -13,7 +13,7 @@ name: android12-5.10 (clang-12)
     - tuxsuite/android12-5.10-clang-12.tux.yml
     - .github/workflows/android12-5.10-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.10-clang-13.yml
+++ b/.github/workflows/android12-5.10-clang-13.yml
@@ -13,7 +13,7 @@ name: android12-5.10 (clang-13)
     - tuxsuite/android12-5.10-clang-13.tux.yml
     - .github/workflows/android12-5.10-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.10-clang-14.yml
+++ b/.github/workflows/android12-5.10-clang-14.yml
@@ -13,7 +13,7 @@ name: android12-5.10 (clang-14)
     - tuxsuite/android12-5.10-clang-14.tux.yml
     - .github/workflows/android12-5.10-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.10-clang-15.yml
+++ b/.github/workflows/android12-5.10-clang-15.yml
@@ -13,7 +13,7 @@ name: android12-5.10 (clang-15)
     - tuxsuite/android12-5.10-clang-15.tux.yml
     - .github/workflows/android12-5.10-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.10-clang-android.yml
+++ b/.github/workflows/android12-5.10-clang-android.yml
@@ -13,7 +13,7 @@ name: android12-5.10 (clang-android)
     - tuxsuite/android12-5.10-clang-android.tux.yml
     - .github/workflows/android12-5.10-clang-android.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.4-clang-12.yml
+++ b/.github/workflows/android12-5.4-clang-12.yml
@@ -13,7 +13,7 @@ name: android12-5.4 (clang-12)
     - tuxsuite/android12-5.4-clang-12.tux.yml
     - .github/workflows/android12-5.4-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.4-clang-13.yml
+++ b/.github/workflows/android12-5.4-clang-13.yml
@@ -13,7 +13,7 @@ name: android12-5.4 (clang-13)
     - tuxsuite/android12-5.4-clang-13.tux.yml
     - .github/workflows/android12-5.4-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.4-clang-14.yml
+++ b/.github/workflows/android12-5.4-clang-14.yml
@@ -13,7 +13,7 @@ name: android12-5.4 (clang-14)
     - tuxsuite/android12-5.4-clang-14.tux.yml
     - .github/workflows/android12-5.4-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.4-clang-15.yml
+++ b/.github/workflows/android12-5.4-clang-15.yml
@@ -13,7 +13,7 @@ name: android12-5.4 (clang-15)
     - tuxsuite/android12-5.4-clang-15.tux.yml
     - .github/workflows/android12-5.4-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android12-5.4-clang-android.yml
+++ b/.github/workflows/android12-5.4-clang-android.yml
@@ -13,7 +13,7 @@ name: android12-5.4 (clang-android)
     - tuxsuite/android12-5.4-clang-android.tux.yml
     - .github/workflows/android12-5.4-clang-android.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.10-clang-12.yml
+++ b/.github/workflows/android13-5.10-clang-12.yml
@@ -13,7 +13,7 @@ name: android13-5.10 (clang-12)
     - tuxsuite/android13-5.10-clang-12.tux.yml
     - .github/workflows/android13-5.10-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.10-clang-13.yml
+++ b/.github/workflows/android13-5.10-clang-13.yml
@@ -13,7 +13,7 @@ name: android13-5.10 (clang-13)
     - tuxsuite/android13-5.10-clang-13.tux.yml
     - .github/workflows/android13-5.10-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.10-clang-14.yml
+++ b/.github/workflows/android13-5.10-clang-14.yml
@@ -13,7 +13,7 @@ name: android13-5.10 (clang-14)
     - tuxsuite/android13-5.10-clang-14.tux.yml
     - .github/workflows/android13-5.10-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.10-clang-15.yml
+++ b/.github/workflows/android13-5.10-clang-15.yml
@@ -13,7 +13,7 @@ name: android13-5.10 (clang-15)
     - tuxsuite/android13-5.10-clang-15.tux.yml
     - .github/workflows/android13-5.10-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.10-clang-android.yml
+++ b/.github/workflows/android13-5.10-clang-android.yml
@@ -13,7 +13,7 @@ name: android13-5.10 (clang-android)
     - tuxsuite/android13-5.10-clang-android.tux.yml
     - .github/workflows/android13-5.10-clang-android.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.15-clang-12.yml
+++ b/.github/workflows/android13-5.15-clang-12.yml
@@ -13,7 +13,7 @@ name: android13-5.15 (clang-12)
     - tuxsuite/android13-5.15-clang-12.tux.yml
     - .github/workflows/android13-5.15-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.15-clang-13.yml
+++ b/.github/workflows/android13-5.15-clang-13.yml
@@ -13,7 +13,7 @@ name: android13-5.15 (clang-13)
     - tuxsuite/android13-5.15-clang-13.tux.yml
     - .github/workflows/android13-5.15-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 0 * * 0
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.15-clang-14.yml
+++ b/.github/workflows/android13-5.15-clang-14.yml
@@ -13,7 +13,7 @@ name: android13-5.15 (clang-14)
     - tuxsuite/android13-5.15-clang-14.tux.yml
     - .github/workflows/android13-5.15-clang-14.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.15-clang-15.yml
+++ b/.github/workflows/android13-5.15-clang-15.yml
@@ -13,7 +13,7 @@ name: android13-5.15 (clang-15)
     - tuxsuite/android13-5.15-clang-15.tux.yml
     - .github/workflows/android13-5.15-clang-15.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/android13-5.15-clang-android.yml
+++ b/.github/workflows/android13-5.15-clang-android.yml
@@ -13,7 +13,7 @@ name: android13-5.15 (clang-android)
     - tuxsuite/android13-5.15-clang-android.tux.yml
     - .github/workflows/android13-5.15-clang-android.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 6 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/arm64-clang-11.yml
+++ b/.github/workflows/arm64-clang-11.yml
@@ -13,7 +13,7 @@ name: arm64 (clang-11)
     - tuxsuite/arm64-clang-11.tux.yml
     - .github/workflows/arm64-clang-11.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 18 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/arm64-clang-12.yml
+++ b/.github/workflows/arm64-clang-12.yml
@@ -13,7 +13,7 @@ name: arm64 (clang-12)
     - tuxsuite/arm64-clang-12.tux.yml
     - .github/workflows/arm64-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 18 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/arm64-clang-13.yml
+++ b/.github/workflows/arm64-clang-13.yml
@@ -13,7 +13,7 @@ name: arm64 (clang-13)
     - tuxsuite/arm64-clang-13.tux.yml
     - .github/workflows/arm64-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 18 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/arm64-fixes-clang-11.yml
+++ b/.github/workflows/arm64-fixes-clang-11.yml
@@ -13,7 +13,7 @@ name: arm64-fixes (clang-11)
     - tuxsuite/arm64-fixes-clang-11.tux.yml
     - .github/workflows/arm64-fixes-clang-11.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 18 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/arm64-fixes-clang-12.yml
+++ b/.github/workflows/arm64-fixes-clang-12.yml
@@ -13,7 +13,7 @@ name: arm64-fixes (clang-12)
     - tuxsuite/arm64-fixes-clang-12.tux.yml
     - .github/workflows/arm64-fixes-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 18 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/arm64-fixes-clang-13.yml
+++ b/.github/workflows/arm64-fixes-clang-13.yml
@@ -13,7 +13,7 @@ name: arm64-fixes (clang-13)
     - tuxsuite/arm64-fixes-clang-13.tux.yml
     - .github/workflows/arm64-fixes-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 18 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/tip-clang-11.yml
+++ b/.github/workflows/tip-clang-11.yml
@@ -13,7 +13,7 @@ name: tip (clang-11)
     - tuxsuite/tip-clang-11.tux.yml
     - .github/workflows/tip-clang-11.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 18 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/tip-clang-12.yml
+++ b/.github/workflows/tip-clang-12.yml
@@ -13,7 +13,7 @@ name: tip (clang-12)
     - tuxsuite/tip-clang-12.tux.yml
     - .github/workflows/tip-clang-12.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 18 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/.github/workflows/tip-clang-13.yml
+++ b/.github/workflows/tip-clang-13.yml
@@ -13,7 +13,7 @@ name: tip (clang-13)
     - tuxsuite/tip-clang-13.tux.yml
     - .github/workflows/tip-clang-13.yml
   schedule:
-  - cron: 0 0 * * *
+  - cron: 0 18 * * *
   workflow_dispatch: null
 jobs:
   kick_tuxsuite_defconfigs:

--- a/generator.yml
+++ b/generator.yml
@@ -28,10 +28,10 @@ urls:
   - &x86_64-fedora-config-url  https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
   - &x86_64-suse-config-url    https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
 schedules:
-  - &six_hours {schedule: "0 0,6,12,18 * * *"}
-  - &daily     {schedule: "0 0 * * *"}
+  - &six_hours      {schedule: "0 0,6,12,18 * * *"}
+  - &daily_midnight {schedule: "0 0 * * *"}
   # -next updates M-F in the evening AEST, which is usually around 12:00PM UTC
-  - &weekdays  {schedule: "0 12 * * 1,2,3,4,5"}
+  - &weekdays       {schedule: "0 12 * * 1,2,3,4,5"}
 trees:
   - &mainline         {git_repo: *mainline-url, git_ref: master,              name: mainline}
   - &next             {git_repo: *next-url,     git_ref: master,              name: next}
@@ -64,83 +64,83 @@ tree_schedules:
   - &next_llvm_12                  {<< : *llvm_12,      << : *next,             << : *weekdays}
   - &next_llvm_11                  {<< : *llvm_11,      << : *next,             << : *weekdays}
   - &next_llvm_android             {<< : *llvm_android, << : *next,             << : *weekdays}
-  - &stable-5_15_llvm_tot          {<< : *llvm_tot,     << : *stable-5_15,      << : *daily}
-  - &stable-5_15_llvm_latest       {<< : *llvm_latest,  << : *stable-5_15,      << : *daily}
-  - &stable-5_15_llvm_13           {<< : *llvm_13,      << : *stable-5_15,      << : *daily}
-  - &stable-5_15_llvm_12           {<< : *llvm_12,      << : *stable-5_15,      << : *daily}
-  - &stable-5_15_llvm_11           {<< : *llvm_11,      << : *stable-5_15,      << : *daily}
-  - &stable-5_10_llvm_tot          {<< : *llvm_tot,     << : *stable-5_10,      << : *daily}
-  - &stable-5_10_llvm_latest       {<< : *llvm_latest,  << : *stable-5_10,      << : *daily}
-  - &stable-5_10_llvm_13           {<< : *llvm_13,      << : *stable-5_10,      << : *daily}
-  - &stable-5_10_llvm_12           {<< : *llvm_12,      << : *stable-5_10,      << : *daily}
-  - &stable-5_10_llvm_11           {<< : *llvm_11,      << : *stable-5_10,      << : *daily}
-  - &stable-5_4_llvm_tot           {<< : *llvm_tot,     << : *stable-5_4,       << : *daily}
-  - &stable-5_4_llvm_latest        {<< : *llvm_latest,  << : *stable-5_4,       << : *daily}
-  - &stable-5_4_llvm_13            {<< : *llvm_13,      << : *stable-5_4,       << : *daily}
-  - &stable-4_19_llvm_tot          {<< : *llvm_tot,     << : *stable-4_19,      << : *daily}
-  - &stable-4_19_llvm_latest       {<< : *llvm_latest,  << : *stable-4_19,      << : *daily}
-  - &stable-4_19_llvm_13           {<< : *llvm_13,      << : *stable-4_19,      << : *daily}
-  - &stable-4_14_llvm_tot          {<< : *llvm_tot,     << : *stable-4_14,      << : *daily}
-  - &stable-4_14_llvm_latest       {<< : *llvm_latest,  << : *stable-4_14,      << : *daily}
-  - &stable-4_14_llvm_13           {<< : *llvm_13,      << : *stable-4_14,      << : *daily}
-  - &stable-4_9_llvm_tot           {<< : *llvm_tot,     << : *stable-4_9,       << : *daily}
-  - &stable-4_9_llvm_latest        {<< : *llvm_latest,  << : *stable-4_9,       << : *daily}
-  - &stable-4_9_llvm_13            {<< : *llvm_13,      << : *stable-4_9,       << : *daily}
-  - &android-mainline_llvm_tot     {<< : *llvm_tot,     << : *android-mainline, << : *daily}
-  - &android-mainline_llvm_latest  {<< : *llvm_latest,  << : *android-mainline, << : *daily}
-  - &android-mainline_llvm_13      {<< : *llvm_13,      << : *android-mainline, << : *daily}
-  - &android-mainline_llvm_12      {<< : *llvm_12,      << : *android-mainline, << : *daily}
-  - &android-mainline_llvm_android {<< : *llvm_android, << : *android-mainline, << : *daily}
-  - &android13-5_15_llvm_tot       {<< : *llvm_tot,     << : *android13-5_15,   << : *daily}
-  - &android13-5_15_llvm_latest    {<< : *llvm_latest,  << : *android13-5_15,   << : *daily}
-  - &android13-5_15_llvm_13        {<< : *llvm_13,      << : *android13-5_15,   << : *daily}
-  - &android13-5_15_llvm_12        {<< : *llvm_12,      << : *android13-5_15,   << : *daily}
-  - &android13-5_15_llvm_android   {<< : *llvm_android, << : *android13-5_15,   << : *daily}
-  - &android13-5_10_llvm_tot       {<< : *llvm_tot,     << : *android13-5_10,   << : *daily}
-  - &android13-5_10_llvm_latest    {<< : *llvm_latest,  << : *android13-5_10,   << : *daily}
-  - &android13-5_10_llvm_13        {<< : *llvm_13,      << : *android13-5_10,   << : *daily}
-  - &android13-5_10_llvm_12        {<< : *llvm_12,      << : *android13-5_10,   << : *daily}
-  - &android13-5_10_llvm_android   {<< : *llvm_android, << : *android13-5_10,   << : *daily}
-  - &android12-5_10_llvm_tot       {<< : *llvm_tot,     << : *android12-5_10,   << : *daily}
-  - &android12-5_10_llvm_latest    {<< : *llvm_latest,  << : *android12-5_10,   << : *daily}
-  - &android12-5_10_llvm_13        {<< : *llvm_13,      << : *android12-5_10,   << : *daily}
-  - &android12-5_10_llvm_12        {<< : *llvm_12,      << : *android12-5_10,   << : *daily}
-  - &android12-5_10_llvm_android   {<< : *llvm_android, << : *android12-5_10,   << : *daily}
-  - &android12-5_4_llvm_tot        {<< : *llvm_tot,     << : *android12-5_4,    << : *daily}
-  - &android12-5_4_llvm_latest     {<< : *llvm_latest,  << : *android12-5_4,    << : *daily}
-  - &android12-5_4_llvm_13         {<< : *llvm_13,      << : *android12-5_4,    << : *daily}
-  - &android12-5_4_llvm_12         {<< : *llvm_12,      << : *android12-5_4,    << : *daily}
-  - &android12-5_4_llvm_android    {<< : *llvm_android, << : *android12-5_4,    << : *daily}
-  - &android-4_19_llvm_tot         {<< : *llvm_tot,     << : *android-4_19,     << : *daily}
-  - &android-4_19_llvm_latest      {<< : *llvm_latest,  << : *android-4_19,     << : *daily}
-  - &android-4_19_llvm_13          {<< : *llvm_13,      << : *android-4_19,     << : *daily}
-  - &android-4_19_llvm_12          {<< : *llvm_12,      << : *android-4_19,     << : *daily}
-  - &android-4_19_llvm_android     {<< : *llvm_android, << : *android-4_19,     << : *daily}
-  - &android-4_14_llvm_tot         {<< : *llvm_tot,     << : *android-4_14,     << : *daily}
-  - &android-4_14_llvm_latest      {<< : *llvm_latest,  << : *android-4_14,     << : *daily}
-  - &android-4_14_llvm_13          {<< : *llvm_13,      << : *android-4_14,     << : *daily}
-  - &android-4_14_llvm_12          {<< : *llvm_12,      << : *android-4_14,     << : *daily}
-  - &android-4_14_llvm_android     {<< : *llvm_android, << : *android-4_14,     << : *daily}
-  - &android-4_9_llvm_tot          {<< : *llvm_tot,     << : *android-4_9,      << : *daily}
-  - &android-4_9_llvm_latest       {<< : *llvm_latest,  << : *android-4_9,      << : *daily}
-  - &android-4_9_llvm_13           {<< : *llvm_13,      << : *android-4_9,      << : *daily}
-  - &android-4_9_llvm_12           {<< : *llvm_12,      << : *android-4_9,      << : *daily}
-  - &android-4_9_llvm_android      {<< : *llvm_android, << : *android-4_9,      << : *daily}
-  - &tip_llvm_tot                  {<< : *llvm_tot,     << : *tip,              << : *daily}
-  - &tip_llvm_latest               {<< : *llvm_latest,  << : *tip,              << : *daily}
-  - &tip_llvm_13                   {<< : *llvm_13,      << : *tip,              << : *daily}
-  - &tip_llvm_12                   {<< : *llvm_12,      << : *tip,              << : *daily}
-  - &tip_llvm_11                   {<< : *llvm_11,      << : *tip,              << : *daily}
-  - &arm64-core_llvm_tot           {<< : *llvm_tot,     << : *arm64-core,       << : *daily}
-  - &arm64-core_llvm_latest        {<< : *llvm_latest,  << : *arm64-core,       << : *daily}
-  - &arm64-core_llvm_13            {<< : *llvm_13,      << : *arm64-core,       << : *daily}
-  - &arm64-core_llvm_12            {<< : *llvm_12,      << : *arm64-core,       << : *daily}
-  - &arm64-core_llvm_11            {<< : *llvm_11,      << : *arm64-core,       << : *daily}
-  - &arm64-fixes_llvm_tot          {<< : *llvm_tot,     << : *arm64-fixes,      << : *daily}
-  - &arm64-fixes_llvm_latest       {<< : *llvm_latest,  << : *arm64-fixes,      << : *daily}
-  - &arm64-fixes_llvm_13           {<< : *llvm_13,      << : *arm64-fixes,      << : *daily}
-  - &arm64-fixes_llvm_12           {<< : *llvm_12,      << : *arm64-fixes,      << : *daily}
-  - &arm64-fixes_llvm_11           {<< : *llvm_11,      << : *arm64-fixes,      << : *daily}
+  - &stable-5_15_llvm_tot          {<< : *llvm_tot,     << : *stable-5_15,      << : *daily_midnight}
+  - &stable-5_15_llvm_latest       {<< : *llvm_latest,  << : *stable-5_15,      << : *daily_midnight}
+  - &stable-5_15_llvm_13           {<< : *llvm_13,      << : *stable-5_15,      << : *daily_midnight}
+  - &stable-5_15_llvm_12           {<< : *llvm_12,      << : *stable-5_15,      << : *daily_midnight}
+  - &stable-5_15_llvm_11           {<< : *llvm_11,      << : *stable-5_15,      << : *daily_midnight}
+  - &stable-5_10_llvm_tot          {<< : *llvm_tot,     << : *stable-5_10,      << : *daily_midnight}
+  - &stable-5_10_llvm_latest       {<< : *llvm_latest,  << : *stable-5_10,      << : *daily_midnight}
+  - &stable-5_10_llvm_13           {<< : *llvm_13,      << : *stable-5_10,      << : *daily_midnight}
+  - &stable-5_10_llvm_12           {<< : *llvm_12,      << : *stable-5_10,      << : *daily_midnight}
+  - &stable-5_10_llvm_11           {<< : *llvm_11,      << : *stable-5_10,      << : *daily_midnight}
+  - &stable-5_4_llvm_tot           {<< : *llvm_tot,     << : *stable-5_4,       << : *daily_midnight}
+  - &stable-5_4_llvm_latest        {<< : *llvm_latest,  << : *stable-5_4,       << : *daily_midnight}
+  - &stable-5_4_llvm_13            {<< : *llvm_13,      << : *stable-5_4,       << : *daily_midnight}
+  - &stable-4_19_llvm_tot          {<< : *llvm_tot,     << : *stable-4_19,      << : *daily_midnight}
+  - &stable-4_19_llvm_latest       {<< : *llvm_latest,  << : *stable-4_19,      << : *daily_midnight}
+  - &stable-4_19_llvm_13           {<< : *llvm_13,      << : *stable-4_19,      << : *daily_midnight}
+  - &stable-4_14_llvm_tot          {<< : *llvm_tot,     << : *stable-4_14,      << : *daily_midnight}
+  - &stable-4_14_llvm_latest       {<< : *llvm_latest,  << : *stable-4_14,      << : *daily_midnight}
+  - &stable-4_14_llvm_13           {<< : *llvm_13,      << : *stable-4_14,      << : *daily_midnight}
+  - &stable-4_9_llvm_tot           {<< : *llvm_tot,     << : *stable-4_9,       << : *daily_midnight}
+  - &stable-4_9_llvm_latest        {<< : *llvm_latest,  << : *stable-4_9,       << : *daily_midnight}
+  - &stable-4_9_llvm_13            {<< : *llvm_13,      << : *stable-4_9,       << : *daily_midnight}
+  - &android-mainline_llvm_tot     {<< : *llvm_tot,     << : *android-mainline, << : *daily_midnight}
+  - &android-mainline_llvm_latest  {<< : *llvm_latest,  << : *android-mainline, << : *daily_midnight}
+  - &android-mainline_llvm_13      {<< : *llvm_13,      << : *android-mainline, << : *daily_midnight}
+  - &android-mainline_llvm_12      {<< : *llvm_12,      << : *android-mainline, << : *daily_midnight}
+  - &android-mainline_llvm_android {<< : *llvm_android, << : *android-mainline, << : *daily_midnight}
+  - &android13-5_15_llvm_tot       {<< : *llvm_tot,     << : *android13-5_15,   << : *daily_midnight}
+  - &android13-5_15_llvm_latest    {<< : *llvm_latest,  << : *android13-5_15,   << : *daily_midnight}
+  - &android13-5_15_llvm_13        {<< : *llvm_13,      << : *android13-5_15,   << : *daily_midnight}
+  - &android13-5_15_llvm_12        {<< : *llvm_12,      << : *android13-5_15,   << : *daily_midnight}
+  - &android13-5_15_llvm_android   {<< : *llvm_android, << : *android13-5_15,   << : *daily_midnight}
+  - &android13-5_10_llvm_tot       {<< : *llvm_tot,     << : *android13-5_10,   << : *daily_midnight}
+  - &android13-5_10_llvm_latest    {<< : *llvm_latest,  << : *android13-5_10,   << : *daily_midnight}
+  - &android13-5_10_llvm_13        {<< : *llvm_13,      << : *android13-5_10,   << : *daily_midnight}
+  - &android13-5_10_llvm_12        {<< : *llvm_12,      << : *android13-5_10,   << : *daily_midnight}
+  - &android13-5_10_llvm_android   {<< : *llvm_android, << : *android13-5_10,   << : *daily_midnight}
+  - &android12-5_10_llvm_tot       {<< : *llvm_tot,     << : *android12-5_10,   << : *daily_midnight}
+  - &android12-5_10_llvm_latest    {<< : *llvm_latest,  << : *android12-5_10,   << : *daily_midnight}
+  - &android12-5_10_llvm_13        {<< : *llvm_13,      << : *android12-5_10,   << : *daily_midnight}
+  - &android12-5_10_llvm_12        {<< : *llvm_12,      << : *android12-5_10,   << : *daily_midnight}
+  - &android12-5_10_llvm_android   {<< : *llvm_android, << : *android12-5_10,   << : *daily_midnight}
+  - &android12-5_4_llvm_tot        {<< : *llvm_tot,     << : *android12-5_4,    << : *daily_midnight}
+  - &android12-5_4_llvm_latest     {<< : *llvm_latest,  << : *android12-5_4,    << : *daily_midnight}
+  - &android12-5_4_llvm_13         {<< : *llvm_13,      << : *android12-5_4,    << : *daily_midnight}
+  - &android12-5_4_llvm_12         {<< : *llvm_12,      << : *android12-5_4,    << : *daily_midnight}
+  - &android12-5_4_llvm_android    {<< : *llvm_android, << : *android12-5_4,    << : *daily_midnight}
+  - &android-4_19_llvm_tot         {<< : *llvm_tot,     << : *android-4_19,     << : *daily_midnight}
+  - &android-4_19_llvm_latest      {<< : *llvm_latest,  << : *android-4_19,     << : *daily_midnight}
+  - &android-4_19_llvm_13          {<< : *llvm_13,      << : *android-4_19,     << : *daily_midnight}
+  - &android-4_19_llvm_12          {<< : *llvm_12,      << : *android-4_19,     << : *daily_midnight}
+  - &android-4_19_llvm_android     {<< : *llvm_android, << : *android-4_19,     << : *daily_midnight}
+  - &android-4_14_llvm_tot         {<< : *llvm_tot,     << : *android-4_14,     << : *daily_midnight}
+  - &android-4_14_llvm_latest      {<< : *llvm_latest,  << : *android-4_14,     << : *daily_midnight}
+  - &android-4_14_llvm_13          {<< : *llvm_13,      << : *android-4_14,     << : *daily_midnight}
+  - &android-4_14_llvm_12          {<< : *llvm_12,      << : *android-4_14,     << : *daily_midnight}
+  - &android-4_14_llvm_android     {<< : *llvm_android, << : *android-4_14,     << : *daily_midnight}
+  - &android-4_9_llvm_tot          {<< : *llvm_tot,     << : *android-4_9,      << : *daily_midnight}
+  - &android-4_9_llvm_latest       {<< : *llvm_latest,  << : *android-4_9,      << : *daily_midnight}
+  - &android-4_9_llvm_13           {<< : *llvm_13,      << : *android-4_9,      << : *daily_midnight}
+  - &android-4_9_llvm_12           {<< : *llvm_12,      << : *android-4_9,      << : *daily_midnight}
+  - &android-4_9_llvm_android      {<< : *llvm_android, << : *android-4_9,      << : *daily_midnight}
+  - &tip_llvm_tot                  {<< : *llvm_tot,     << : *tip,              << : *daily_midnight}
+  - &tip_llvm_latest               {<< : *llvm_latest,  << : *tip,              << : *daily_midnight}
+  - &tip_llvm_13                   {<< : *llvm_13,      << : *tip,              << : *daily_midnight}
+  - &tip_llvm_12                   {<< : *llvm_12,      << : *tip,              << : *daily_midnight}
+  - &tip_llvm_11                   {<< : *llvm_11,      << : *tip,              << : *daily_midnight}
+  - &arm64-core_llvm_tot           {<< : *llvm_tot,     << : *arm64-core,       << : *daily_midnight}
+  - &arm64-core_llvm_latest        {<< : *llvm_latest,  << : *arm64-core,       << : *daily_midnight}
+  - &arm64-core_llvm_13            {<< : *llvm_13,      << : *arm64-core,       << : *daily_midnight}
+  - &arm64-core_llvm_12            {<< : *llvm_12,      << : *arm64-core,       << : *daily_midnight}
+  - &arm64-core_llvm_11            {<< : *llvm_11,      << : *arm64-core,       << : *daily_midnight}
+  - &arm64-fixes_llvm_tot          {<< : *llvm_tot,     << : *arm64-fixes,      << : *daily_midnight}
+  - &arm64-fixes_llvm_latest       {<< : *llvm_latest,  << : *arm64-fixes,      << : *daily_midnight}
+  - &arm64-fixes_llvm_13           {<< : *llvm_13,      << : *arm64-fixes,      << : *daily_midnight}
+  - &arm64-fixes_llvm_12           {<< : *llvm_12,      << : *arm64-fixes,      << : *daily_midnight}
+  - &arm64-fixes_llvm_11           {<< : *llvm_11,      << : *arm64-fixes,      << : *daily_midnight}
 architectures:
  - &arm-arch     arm
  - &arm64-arch   arm64

--- a/generator.yml
+++ b/generator.yml
@@ -33,25 +33,114 @@ schedules:
   # -next updates M-F in the evening AEST, which is usually around 12:00PM UTC
   - &weekdays  {schedule: "0 12 * * 1,2,3,4,5"}
 trees:
-  - &mainline         {git_repo: *mainline-url, git_ref: master,              name: mainline,         << : *six_hours}
-  - &next             {git_repo: *next-url,     git_ref: master,              name: next,             << : *weekdays}
-  - &stable-5_15      {git_repo: *stable-url,   git_ref: linux-5.15.y,        name: "5.15",           << : *daily}
-  - &stable-5_10      {git_repo: *stable-url,   git_ref: linux-5.10.y,        name: "5.10",           << : *daily}
-  - &stable-5_4       {git_repo: *stable-url,   git_ref: linux-5.4.y,         name: "5.4",            << : *daily}
-  - &stable-4_19      {git_repo: *stable-url,   git_ref: linux-4.19.y,        name: "4.19",           << : *daily}
-  - &stable-4_14      {git_repo: *stable-url,   git_ref: linux-4.14.y,        name: "4.14",           << : *daily}
-  - &stable-4_9       {git_repo: *stable-url,   git_ref: linux-4.9.y,         name: "4.9",            << : *daily}
-  - &android-mainline {git_repo: *android-url,  git_ref: android-mainline,    name: android-mainline, << : *daily}
-  - &android13-5_15   {git_repo: *android-url,  git_ref: android13-5.15,      name: android13-5.15,   << : *daily}
-  - &android13-5_10   {git_repo: *android-url,  git_ref: android13-5.10,      name: android13-5.10,   << : *daily}
-  - &android12-5_10   {git_repo: *android-url,  git_ref: android12-5.10,      name: android12-5.10,   << : *daily}
-  - &android12-5_4    {git_repo: *android-url,  git_ref: android12-5.4,       name: android12-5.4,    << : *daily}
-  - &android-4_19     {git_repo: *android-url,  git_ref: android-4.19-stable, name: android-4.19,     << : *daily}
-  - &android-4_14     {git_repo: *android-url,  git_ref: android-4.14-stable, name: android-4.14,     << : *daily}
-  - &android-4_9      {git_repo: *android-url,  git_ref: android-4.9-q,       name: android-4.9,      << : *daily}
-  - &tip              {git_repo: *tip-url,      git_ref: master,              name: tip,              << : *daily}
-  - &arm64-core       {git_repo: *arm64-url,    git_ref: for-next/core,       name: arm64,            << : *daily}
-  - &arm64-fixes      {git_repo: *arm64-url,    git_ref: for-next/fixes,      name: arm64-fixes,      << : *daily}
+  - &mainline         {git_repo: *mainline-url, git_ref: master,              name: mainline}
+  - &next             {git_repo: *next-url,     git_ref: master,              name: next}
+  - &stable-5_15      {git_repo: *stable-url,   git_ref: linux-5.15.y,        name: "5.15"}
+  - &stable-5_10      {git_repo: *stable-url,   git_ref: linux-5.10.y,        name: "5.10"}
+  - &stable-5_4       {git_repo: *stable-url,   git_ref: linux-5.4.y,         name: "5.4"}
+  - &stable-4_19      {git_repo: *stable-url,   git_ref: linux-4.19.y,        name: "4.19"}
+  - &stable-4_14      {git_repo: *stable-url,   git_ref: linux-4.14.y,        name: "4.14"}
+  - &stable-4_9       {git_repo: *stable-url,   git_ref: linux-4.9.y,         name: "4.9"}
+  - &android-mainline {git_repo: *android-url,  git_ref: android-mainline,    name: android-mainline}
+  - &android13-5_15   {git_repo: *android-url,  git_ref: android13-5.15,      name: android13-5.15}
+  - &android13-5_10   {git_repo: *android-url,  git_ref: android13-5.10,      name: android13-5.10}
+  - &android12-5_10   {git_repo: *android-url,  git_ref: android12-5.10,      name: android12-5.10}
+  - &android12-5_4    {git_repo: *android-url,  git_ref: android12-5.4,       name: android12-5.4}
+  - &android-4_19     {git_repo: *android-url,  git_ref: android-4.19-stable, name: android-4.19}
+  - &android-4_14     {git_repo: *android-url,  git_ref: android-4.14-stable, name: android-4.14}
+  - &android-4_9      {git_repo: *android-url,  git_ref: android-4.9-q,       name: android-4.9}
+  - &tip              {git_repo: *tip-url,      git_ref: master,              name: tip}
+  - &arm64-core       {git_repo: *arm64-url,    git_ref: for-next/core,       name: arm64}
+  - &arm64-fixes      {git_repo: *arm64-url,    git_ref: for-next/fixes,      name: arm64-fixes}
+tree_schedules:
+  - &mainline_llvm_tot             {<< : *llvm_tot,     << : *mainline,         << : *six_hours}
+  - &mainline_llvm_latest          {<< : *llvm_latest,  << : *mainline,         << : *six_hours}
+  - &mainline_llvm_13              {<< : *llvm_13,      << : *mainline,         << : *six_hours}
+  - &mainline_llvm_12              {<< : *llvm_12,      << : *mainline,         << : *six_hours}
+  - &mainline_llvm_11              {<< : *llvm_11,      << : *mainline,         << : *six_hours}
+  - &next_llvm_tot                 {<< : *llvm_tot,     << : *next,             << : *weekdays}
+  - &next_llvm_latest              {<< : *llvm_latest,  << : *next,             << : *weekdays}
+  - &next_llvm_13                  {<< : *llvm_13,      << : *next,             << : *weekdays}
+  - &next_llvm_12                  {<< : *llvm_12,      << : *next,             << : *weekdays}
+  - &next_llvm_11                  {<< : *llvm_11,      << : *next,             << : *weekdays}
+  - &next_llvm_android             {<< : *llvm_android, << : *next,             << : *weekdays}
+  - &stable-5_15_llvm_tot          {<< : *llvm_tot,     << : *stable-5_15,      << : *daily}
+  - &stable-5_15_llvm_latest       {<< : *llvm_latest,  << : *stable-5_15,      << : *daily}
+  - &stable-5_15_llvm_13           {<< : *llvm_13,      << : *stable-5_15,      << : *daily}
+  - &stable-5_15_llvm_12           {<< : *llvm_12,      << : *stable-5_15,      << : *daily}
+  - &stable-5_15_llvm_11           {<< : *llvm_11,      << : *stable-5_15,      << : *daily}
+  - &stable-5_10_llvm_tot          {<< : *llvm_tot,     << : *stable-5_10,      << : *daily}
+  - &stable-5_10_llvm_latest       {<< : *llvm_latest,  << : *stable-5_10,      << : *daily}
+  - &stable-5_10_llvm_13           {<< : *llvm_13,      << : *stable-5_10,      << : *daily}
+  - &stable-5_10_llvm_12           {<< : *llvm_12,      << : *stable-5_10,      << : *daily}
+  - &stable-5_10_llvm_11           {<< : *llvm_11,      << : *stable-5_10,      << : *daily}
+  - &stable-5_4_llvm_tot           {<< : *llvm_tot,     << : *stable-5_4,       << : *daily}
+  - &stable-5_4_llvm_latest        {<< : *llvm_latest,  << : *stable-5_4,       << : *daily}
+  - &stable-5_4_llvm_13            {<< : *llvm_13,      << : *stable-5_4,       << : *daily}
+  - &stable-4_19_llvm_tot          {<< : *llvm_tot,     << : *stable-4_19,      << : *daily}
+  - &stable-4_19_llvm_latest       {<< : *llvm_latest,  << : *stable-4_19,      << : *daily}
+  - &stable-4_19_llvm_13           {<< : *llvm_13,      << : *stable-4_19,      << : *daily}
+  - &stable-4_14_llvm_tot          {<< : *llvm_tot,     << : *stable-4_14,      << : *daily}
+  - &stable-4_14_llvm_latest       {<< : *llvm_latest,  << : *stable-4_14,      << : *daily}
+  - &stable-4_14_llvm_13           {<< : *llvm_13,      << : *stable-4_14,      << : *daily}
+  - &stable-4_9_llvm_tot           {<< : *llvm_tot,     << : *stable-4_9,       << : *daily}
+  - &stable-4_9_llvm_latest        {<< : *llvm_latest,  << : *stable-4_9,       << : *daily}
+  - &stable-4_9_llvm_13            {<< : *llvm_13,      << : *stable-4_9,       << : *daily}
+  - &android-mainline_llvm_tot     {<< : *llvm_tot,     << : *android-mainline, << : *daily}
+  - &android-mainline_llvm_latest  {<< : *llvm_latest,  << : *android-mainline, << : *daily}
+  - &android-mainline_llvm_13      {<< : *llvm_13,      << : *android-mainline, << : *daily}
+  - &android-mainline_llvm_12      {<< : *llvm_12,      << : *android-mainline, << : *daily}
+  - &android-mainline_llvm_android {<< : *llvm_android, << : *android-mainline, << : *daily}
+  - &android13-5_15_llvm_tot       {<< : *llvm_tot,     << : *android13-5_15,   << : *daily}
+  - &android13-5_15_llvm_latest    {<< : *llvm_latest,  << : *android13-5_15,   << : *daily}
+  - &android13-5_15_llvm_13        {<< : *llvm_13,      << : *android13-5_15,   << : *daily}
+  - &android13-5_15_llvm_12        {<< : *llvm_12,      << : *android13-5_15,   << : *daily}
+  - &android13-5_15_llvm_android   {<< : *llvm_android, << : *android13-5_15,   << : *daily}
+  - &android13-5_10_llvm_tot       {<< : *llvm_tot,     << : *android13-5_10,   << : *daily}
+  - &android13-5_10_llvm_latest    {<< : *llvm_latest,  << : *android13-5_10,   << : *daily}
+  - &android13-5_10_llvm_13        {<< : *llvm_13,      << : *android13-5_10,   << : *daily}
+  - &android13-5_10_llvm_12        {<< : *llvm_12,      << : *android13-5_10,   << : *daily}
+  - &android13-5_10_llvm_android   {<< : *llvm_android, << : *android13-5_10,   << : *daily}
+  - &android12-5_10_llvm_tot       {<< : *llvm_tot,     << : *android12-5_10,   << : *daily}
+  - &android12-5_10_llvm_latest    {<< : *llvm_latest,  << : *android12-5_10,   << : *daily}
+  - &android12-5_10_llvm_13        {<< : *llvm_13,      << : *android12-5_10,   << : *daily}
+  - &android12-5_10_llvm_12        {<< : *llvm_12,      << : *android12-5_10,   << : *daily}
+  - &android12-5_10_llvm_android   {<< : *llvm_android, << : *android12-5_10,   << : *daily}
+  - &android12-5_4_llvm_tot        {<< : *llvm_tot,     << : *android12-5_4,    << : *daily}
+  - &android12-5_4_llvm_latest     {<< : *llvm_latest,  << : *android12-5_4,    << : *daily}
+  - &android12-5_4_llvm_13         {<< : *llvm_13,      << : *android12-5_4,    << : *daily}
+  - &android12-5_4_llvm_12         {<< : *llvm_12,      << : *android12-5_4,    << : *daily}
+  - &android12-5_4_llvm_android    {<< : *llvm_android, << : *android12-5_4,    << : *daily}
+  - &android-4_19_llvm_tot         {<< : *llvm_tot,     << : *android-4_19,     << : *daily}
+  - &android-4_19_llvm_latest      {<< : *llvm_latest,  << : *android-4_19,     << : *daily}
+  - &android-4_19_llvm_13          {<< : *llvm_13,      << : *android-4_19,     << : *daily}
+  - &android-4_19_llvm_12          {<< : *llvm_12,      << : *android-4_19,     << : *daily}
+  - &android-4_19_llvm_android     {<< : *llvm_android, << : *android-4_19,     << : *daily}
+  - &android-4_14_llvm_tot         {<< : *llvm_tot,     << : *android-4_14,     << : *daily}
+  - &android-4_14_llvm_latest      {<< : *llvm_latest,  << : *android-4_14,     << : *daily}
+  - &android-4_14_llvm_13          {<< : *llvm_13,      << : *android-4_14,     << : *daily}
+  - &android-4_14_llvm_12          {<< : *llvm_12,      << : *android-4_14,     << : *daily}
+  - &android-4_14_llvm_android     {<< : *llvm_android, << : *android-4_14,     << : *daily}
+  - &android-4_9_llvm_tot          {<< : *llvm_tot,     << : *android-4_9,      << : *daily}
+  - &android-4_9_llvm_latest       {<< : *llvm_latest,  << : *android-4_9,      << : *daily}
+  - &android-4_9_llvm_13           {<< : *llvm_13,      << : *android-4_9,      << : *daily}
+  - &android-4_9_llvm_12           {<< : *llvm_12,      << : *android-4_9,      << : *daily}
+  - &android-4_9_llvm_android      {<< : *llvm_android, << : *android-4_9,      << : *daily}
+  - &tip_llvm_tot                  {<< : *llvm_tot,     << : *tip,              << : *daily}
+  - &tip_llvm_latest               {<< : *llvm_latest,  << : *tip,              << : *daily}
+  - &tip_llvm_13                   {<< : *llvm_13,      << : *tip,              << : *daily}
+  - &tip_llvm_12                   {<< : *llvm_12,      << : *tip,              << : *daily}
+  - &tip_llvm_11                   {<< : *llvm_11,      << : *tip,              << : *daily}
+  - &arm64-core_llvm_tot           {<< : *llvm_tot,     << : *arm64-core,       << : *daily}
+  - &arm64-core_llvm_latest        {<< : *llvm_latest,  << : *arm64-core,       << : *daily}
+  - &arm64-core_llvm_13            {<< : *llvm_13,      << : *arm64-core,       << : *daily}
+  - &arm64-core_llvm_12            {<< : *llvm_12,      << : *arm64-core,       << : *daily}
+  - &arm64-core_llvm_11            {<< : *llvm_11,      << : *arm64-core,       << : *daily}
+  - &arm64-fixes_llvm_tot          {<< : *llvm_tot,     << : *arm64-fixes,      << : *daily}
+  - &arm64-fixes_llvm_latest       {<< : *llvm_latest,  << : *arm64-fixes,      << : *daily}
+  - &arm64-fixes_llvm_13           {<< : *llvm_13,      << : *arm64-fixes,      << : *daily}
+  - &arm64-fixes_llvm_12           {<< : *llvm_12,      << : *arm64-fixes,      << : *daily}
+  - &arm64-fixes_llvm_11           {<< : *llvm_11,      << : *arm64-fixes,      << : *daily}
 architectures:
  - &arm-arch     arm
  - &arm64-arch   arm64

--- a/generator.yml
+++ b/generator.yml
@@ -32,6 +32,8 @@ schedules:
   - &daily_midnight {schedule: "0 0 * * *"}
   # -next updates M-F in the evening AEST, which is usually around 12:00PM UTC
   - &weekdays       {schedule: "0 12 * * 1,2,3,4,5"}
+  - &sundays        {schedule: "0 0 * * 0"}
+  - &wednesdays     {schedule: "0 0 * * 3"}
 trees:
   - &mainline         {git_repo: *mainline-url, git_ref: master,              name: mainline}
   - &next             {git_repo: *next-url,     git_ref: master,              name: next}
@@ -66,65 +68,65 @@ tree_schedules:
   - &next_llvm_android             {<< : *llvm_android, << : *next,             << : *weekdays}
   - &stable-5_15_llvm_tot          {<< : *llvm_tot,     << : *stable-5_15,      << : *daily_midnight}
   - &stable-5_15_llvm_latest       {<< : *llvm_latest,  << : *stable-5_15,      << : *daily_midnight}
-  - &stable-5_15_llvm_13           {<< : *llvm_13,      << : *stable-5_15,      << : *daily_midnight}
-  - &stable-5_15_llvm_12           {<< : *llvm_12,      << : *stable-5_15,      << : *daily_midnight}
-  - &stable-5_15_llvm_11           {<< : *llvm_11,      << : *stable-5_15,      << : *daily_midnight}
+  - &stable-5_15_llvm_13           {<< : *llvm_13,      << : *stable-5_15,      << : *wednesdays}
+  - &stable-5_15_llvm_12           {<< : *llvm_12,      << : *stable-5_15,      << : *wednesdays}
+  - &stable-5_15_llvm_11           {<< : *llvm_11,      << : *stable-5_15,      << : *wednesdays}
   - &stable-5_10_llvm_tot          {<< : *llvm_tot,     << : *stable-5_10,      << : *daily_midnight}
   - &stable-5_10_llvm_latest       {<< : *llvm_latest,  << : *stable-5_10,      << : *daily_midnight}
-  - &stable-5_10_llvm_13           {<< : *llvm_13,      << : *stable-5_10,      << : *daily_midnight}
-  - &stable-5_10_llvm_12           {<< : *llvm_12,      << : *stable-5_10,      << : *daily_midnight}
-  - &stable-5_10_llvm_11           {<< : *llvm_11,      << : *stable-5_10,      << : *daily_midnight}
+  - &stable-5_10_llvm_13           {<< : *llvm_13,      << : *stable-5_10,      << : *wednesdays}
+  - &stable-5_10_llvm_12           {<< : *llvm_12,      << : *stable-5_10,      << : *wednesdays}
+  - &stable-5_10_llvm_11           {<< : *llvm_11,      << : *stable-5_10,      << : *wednesdays}
   - &stable-5_4_llvm_tot           {<< : *llvm_tot,     << : *stable-5_4,       << : *daily_midnight}
   - &stable-5_4_llvm_latest        {<< : *llvm_latest,  << : *stable-5_4,       << : *daily_midnight}
-  - &stable-5_4_llvm_13            {<< : *llvm_13,      << : *stable-5_4,       << : *daily_midnight}
+  - &stable-5_4_llvm_13            {<< : *llvm_13,      << : *stable-5_4,       << : *wednesdays}
   - &stable-4_19_llvm_tot          {<< : *llvm_tot,     << : *stable-4_19,      << : *daily_midnight}
   - &stable-4_19_llvm_latest       {<< : *llvm_latest,  << : *stable-4_19,      << : *daily_midnight}
-  - &stable-4_19_llvm_13           {<< : *llvm_13,      << : *stable-4_19,      << : *daily_midnight}
+  - &stable-4_19_llvm_13           {<< : *llvm_13,      << : *stable-4_19,      << : *wednesdays}
   - &stable-4_14_llvm_tot          {<< : *llvm_tot,     << : *stable-4_14,      << : *daily_midnight}
   - &stable-4_14_llvm_latest       {<< : *llvm_latest,  << : *stable-4_14,      << : *daily_midnight}
-  - &stable-4_14_llvm_13           {<< : *llvm_13,      << : *stable-4_14,      << : *daily_midnight}
+  - &stable-4_14_llvm_13           {<< : *llvm_13,      << : *stable-4_14,      << : *wednesdays}
   - &stable-4_9_llvm_tot           {<< : *llvm_tot,     << : *stable-4_9,       << : *daily_midnight}
   - &stable-4_9_llvm_latest        {<< : *llvm_latest,  << : *stable-4_9,       << : *daily_midnight}
-  - &stable-4_9_llvm_13            {<< : *llvm_13,      << : *stable-4_9,       << : *daily_midnight}
+  - &stable-4_9_llvm_13            {<< : *llvm_13,      << : *stable-4_9,       << : *wednesdays}
   - &android-mainline_llvm_tot     {<< : *llvm_tot,     << : *android-mainline, << : *daily_midnight}
   - &android-mainline_llvm_latest  {<< : *llvm_latest,  << : *android-mainline, << : *daily_midnight}
-  - &android-mainline_llvm_13      {<< : *llvm_13,      << : *android-mainline, << : *daily_midnight}
-  - &android-mainline_llvm_12      {<< : *llvm_12,      << : *android-mainline, << : *daily_midnight}
+  - &android-mainline_llvm_13      {<< : *llvm_13,      << : *android-mainline, << : *sundays}
+  - &android-mainline_llvm_12      {<< : *llvm_12,      << : *android-mainline, << : *sundays}
   - &android-mainline_llvm_android {<< : *llvm_android, << : *android-mainline, << : *daily_midnight}
   - &android13-5_15_llvm_tot       {<< : *llvm_tot,     << : *android13-5_15,   << : *daily_midnight}
   - &android13-5_15_llvm_latest    {<< : *llvm_latest,  << : *android13-5_15,   << : *daily_midnight}
-  - &android13-5_15_llvm_13        {<< : *llvm_13,      << : *android13-5_15,   << : *daily_midnight}
-  - &android13-5_15_llvm_12        {<< : *llvm_12,      << : *android13-5_15,   << : *daily_midnight}
+  - &android13-5_15_llvm_13        {<< : *llvm_13,      << : *android13-5_15,   << : *sundays}
+  - &android13-5_15_llvm_12        {<< : *llvm_12,      << : *android13-5_15,   << : *sundays}
   - &android13-5_15_llvm_android   {<< : *llvm_android, << : *android13-5_15,   << : *daily_midnight}
   - &android13-5_10_llvm_tot       {<< : *llvm_tot,     << : *android13-5_10,   << : *daily_midnight}
   - &android13-5_10_llvm_latest    {<< : *llvm_latest,  << : *android13-5_10,   << : *daily_midnight}
-  - &android13-5_10_llvm_13        {<< : *llvm_13,      << : *android13-5_10,   << : *daily_midnight}
-  - &android13-5_10_llvm_12        {<< : *llvm_12,      << : *android13-5_10,   << : *daily_midnight}
+  - &android13-5_10_llvm_13        {<< : *llvm_13,      << : *android13-5_10,   << : *sundays}
+  - &android13-5_10_llvm_12        {<< : *llvm_12,      << : *android13-5_10,   << : *sundays}
   - &android13-5_10_llvm_android   {<< : *llvm_android, << : *android13-5_10,   << : *daily_midnight}
   - &android12-5_10_llvm_tot       {<< : *llvm_tot,     << : *android12-5_10,   << : *daily_midnight}
   - &android12-5_10_llvm_latest    {<< : *llvm_latest,  << : *android12-5_10,   << : *daily_midnight}
-  - &android12-5_10_llvm_13        {<< : *llvm_13,      << : *android12-5_10,   << : *daily_midnight}
-  - &android12-5_10_llvm_12        {<< : *llvm_12,      << : *android12-5_10,   << : *daily_midnight}
+  - &android12-5_10_llvm_13        {<< : *llvm_13,      << : *android12-5_10,   << : *sundays}
+  - &android12-5_10_llvm_12        {<< : *llvm_12,      << : *android12-5_10,   << : *sundays}
   - &android12-5_10_llvm_android   {<< : *llvm_android, << : *android12-5_10,   << : *daily_midnight}
   - &android12-5_4_llvm_tot        {<< : *llvm_tot,     << : *android12-5_4,    << : *daily_midnight}
   - &android12-5_4_llvm_latest     {<< : *llvm_latest,  << : *android12-5_4,    << : *daily_midnight}
-  - &android12-5_4_llvm_13         {<< : *llvm_13,      << : *android12-5_4,    << : *daily_midnight}
-  - &android12-5_4_llvm_12         {<< : *llvm_12,      << : *android12-5_4,    << : *daily_midnight}
+  - &android12-5_4_llvm_13         {<< : *llvm_13,      << : *android12-5_4,    << : *sundays}
+  - &android12-5_4_llvm_12         {<< : *llvm_12,      << : *android12-5_4,    << : *sundays}
   - &android12-5_4_llvm_android    {<< : *llvm_android, << : *android12-5_4,    << : *daily_midnight}
   - &android-4_19_llvm_tot         {<< : *llvm_tot,     << : *android-4_19,     << : *daily_midnight}
   - &android-4_19_llvm_latest      {<< : *llvm_latest,  << : *android-4_19,     << : *daily_midnight}
-  - &android-4_19_llvm_13          {<< : *llvm_13,      << : *android-4_19,     << : *daily_midnight}
-  - &android-4_19_llvm_12          {<< : *llvm_12,      << : *android-4_19,     << : *daily_midnight}
+  - &android-4_19_llvm_13          {<< : *llvm_13,      << : *android-4_19,     << : *sundays}
+  - &android-4_19_llvm_12          {<< : *llvm_12,      << : *android-4_19,     << : *sundays}
   - &android-4_19_llvm_android     {<< : *llvm_android, << : *android-4_19,     << : *daily_midnight}
   - &android-4_14_llvm_tot         {<< : *llvm_tot,     << : *android-4_14,     << : *daily_midnight}
   - &android-4_14_llvm_latest      {<< : *llvm_latest,  << : *android-4_14,     << : *daily_midnight}
-  - &android-4_14_llvm_13          {<< : *llvm_13,      << : *android-4_14,     << : *daily_midnight}
-  - &android-4_14_llvm_12          {<< : *llvm_12,      << : *android-4_14,     << : *daily_midnight}
+  - &android-4_14_llvm_13          {<< : *llvm_13,      << : *android-4_14,     << : *sundays}
+  - &android-4_14_llvm_12          {<< : *llvm_12,      << : *android-4_14,     << : *sundays}
   - &android-4_14_llvm_android     {<< : *llvm_android, << : *android-4_14,     << : *daily_midnight}
   - &android-4_9_llvm_tot          {<< : *llvm_tot,     << : *android-4_9,      << : *daily_midnight}
   - &android-4_9_llvm_latest       {<< : *llvm_latest,  << : *android-4_9,      << : *daily_midnight}
-  - &android-4_9_llvm_13           {<< : *llvm_13,      << : *android-4_9,      << : *daily_midnight}
-  - &android-4_9_llvm_12           {<< : *llvm_12,      << : *android-4_9,      << : *daily_midnight}
+  - &android-4_9_llvm_13           {<< : *llvm_13,      << : *android-4_9,      << : *sundays}
+  - &android-4_9_llvm_12           {<< : *llvm_12,      << : *android-4_9,      << : *sundays}
   - &android-4_9_llvm_android      {<< : *llvm_android, << : *android-4_9,      << : *daily_midnight}
   - &tip_llvm_tot                  {<< : *llvm_tot,     << : *tip,              << : *daily_midnight}
   - &tip_llvm_latest               {<< : *llvm_latest,  << : *tip,              << : *daily_midnight}

--- a/generator.yml
+++ b/generator.yml
@@ -30,6 +30,7 @@ urls:
 schedules:
   - &six_hours      {schedule: "0 0,6,12,18 * * *"}
   - &daily_midnight {schedule: "0 0 * * *"}
+  - &daily_six      {schedule: "0 6 * * *"}
   - &daily_noon     {schedule: "0 12 * * *"}
   # -next updates M-F in the evening AEST, which is usually around 12:00PM UTC
   - &weekdays       {schedule: "0 12 * * 1,2,3,4,5"}
@@ -89,46 +90,46 @@ tree_schedules:
   - &stable-4_9_llvm_tot           {<< : *llvm_tot,     << : *stable-4_9,       << : *daily_noon}
   - &stable-4_9_llvm_latest        {<< : *llvm_latest,  << : *stable-4_9,       << : *daily_noon}
   - &stable-4_9_llvm_13            {<< : *llvm_13,      << : *stable-4_9,       << : *wednesdays}
-  - &android-mainline_llvm_tot     {<< : *llvm_tot,     << : *android-mainline, << : *daily_midnight}
-  - &android-mainline_llvm_latest  {<< : *llvm_latest,  << : *android-mainline, << : *daily_midnight}
+  - &android-mainline_llvm_tot     {<< : *llvm_tot,     << : *android-mainline, << : *daily_six}
+  - &android-mainline_llvm_latest  {<< : *llvm_latest,  << : *android-mainline, << : *daily_six}
   - &android-mainline_llvm_13      {<< : *llvm_13,      << : *android-mainline, << : *sundays}
   - &android-mainline_llvm_12      {<< : *llvm_12,      << : *android-mainline, << : *sundays}
-  - &android-mainline_llvm_android {<< : *llvm_android, << : *android-mainline, << : *daily_midnight}
-  - &android13-5_15_llvm_tot       {<< : *llvm_tot,     << : *android13-5_15,   << : *daily_midnight}
-  - &android13-5_15_llvm_latest    {<< : *llvm_latest,  << : *android13-5_15,   << : *daily_midnight}
+  - &android-mainline_llvm_android {<< : *llvm_android, << : *android-mainline, << : *daily_six}
+  - &android13-5_15_llvm_tot       {<< : *llvm_tot,     << : *android13-5_15,   << : *daily_six}
+  - &android13-5_15_llvm_latest    {<< : *llvm_latest,  << : *android13-5_15,   << : *daily_six}
   - &android13-5_15_llvm_13        {<< : *llvm_13,      << : *android13-5_15,   << : *sundays}
   - &android13-5_15_llvm_12        {<< : *llvm_12,      << : *android13-5_15,   << : *sundays}
-  - &android13-5_15_llvm_android   {<< : *llvm_android, << : *android13-5_15,   << : *daily_midnight}
-  - &android13-5_10_llvm_tot       {<< : *llvm_tot,     << : *android13-5_10,   << : *daily_midnight}
-  - &android13-5_10_llvm_latest    {<< : *llvm_latest,  << : *android13-5_10,   << : *daily_midnight}
+  - &android13-5_15_llvm_android   {<< : *llvm_android, << : *android13-5_15,   << : *daily_six}
+  - &android13-5_10_llvm_tot       {<< : *llvm_tot,     << : *android13-5_10,   << : *daily_six}
+  - &android13-5_10_llvm_latest    {<< : *llvm_latest,  << : *android13-5_10,   << : *daily_six}
   - &android13-5_10_llvm_13        {<< : *llvm_13,      << : *android13-5_10,   << : *sundays}
   - &android13-5_10_llvm_12        {<< : *llvm_12,      << : *android13-5_10,   << : *sundays}
-  - &android13-5_10_llvm_android   {<< : *llvm_android, << : *android13-5_10,   << : *daily_midnight}
-  - &android12-5_10_llvm_tot       {<< : *llvm_tot,     << : *android12-5_10,   << : *daily_midnight}
-  - &android12-5_10_llvm_latest    {<< : *llvm_latest,  << : *android12-5_10,   << : *daily_midnight}
+  - &android13-5_10_llvm_android   {<< : *llvm_android, << : *android13-5_10,   << : *daily_six}
+  - &android12-5_10_llvm_tot       {<< : *llvm_tot,     << : *android12-5_10,   << : *daily_six}
+  - &android12-5_10_llvm_latest    {<< : *llvm_latest,  << : *android12-5_10,   << : *daily_six}
   - &android12-5_10_llvm_13        {<< : *llvm_13,      << : *android12-5_10,   << : *sundays}
   - &android12-5_10_llvm_12        {<< : *llvm_12,      << : *android12-5_10,   << : *sundays}
-  - &android12-5_10_llvm_android   {<< : *llvm_android, << : *android12-5_10,   << : *daily_midnight}
-  - &android12-5_4_llvm_tot        {<< : *llvm_tot,     << : *android12-5_4,    << : *daily_midnight}
-  - &android12-5_4_llvm_latest     {<< : *llvm_latest,  << : *android12-5_4,    << : *daily_midnight}
+  - &android12-5_10_llvm_android   {<< : *llvm_android, << : *android12-5_10,   << : *daily_six}
+  - &android12-5_4_llvm_tot        {<< : *llvm_tot,     << : *android12-5_4,    << : *daily_six}
+  - &android12-5_4_llvm_latest     {<< : *llvm_latest,  << : *android12-5_4,    << : *daily_six}
   - &android12-5_4_llvm_13         {<< : *llvm_13,      << : *android12-5_4,    << : *sundays}
   - &android12-5_4_llvm_12         {<< : *llvm_12,      << : *android12-5_4,    << : *sundays}
-  - &android12-5_4_llvm_android    {<< : *llvm_android, << : *android12-5_4,    << : *daily_midnight}
-  - &android-4_19_llvm_tot         {<< : *llvm_tot,     << : *android-4_19,     << : *daily_midnight}
-  - &android-4_19_llvm_latest      {<< : *llvm_latest,  << : *android-4_19,     << : *daily_midnight}
+  - &android12-5_4_llvm_android    {<< : *llvm_android, << : *android12-5_4,    << : *daily_six}
+  - &android-4_19_llvm_tot         {<< : *llvm_tot,     << : *android-4_19,     << : *daily_six}
+  - &android-4_19_llvm_latest      {<< : *llvm_latest,  << : *android-4_19,     << : *daily_six}
   - &android-4_19_llvm_13          {<< : *llvm_13,      << : *android-4_19,     << : *sundays}
   - &android-4_19_llvm_12          {<< : *llvm_12,      << : *android-4_19,     << : *sundays}
-  - &android-4_19_llvm_android     {<< : *llvm_android, << : *android-4_19,     << : *daily_midnight}
-  - &android-4_14_llvm_tot         {<< : *llvm_tot,     << : *android-4_14,     << : *daily_midnight}
-  - &android-4_14_llvm_latest      {<< : *llvm_latest,  << : *android-4_14,     << : *daily_midnight}
+  - &android-4_19_llvm_android     {<< : *llvm_android, << : *android-4_19,     << : *daily_six}
+  - &android-4_14_llvm_tot         {<< : *llvm_tot,     << : *android-4_14,     << : *daily_six}
+  - &android-4_14_llvm_latest      {<< : *llvm_latest,  << : *android-4_14,     << : *daily_six}
   - &android-4_14_llvm_13          {<< : *llvm_13,      << : *android-4_14,     << : *sundays}
   - &android-4_14_llvm_12          {<< : *llvm_12,      << : *android-4_14,     << : *sundays}
-  - &android-4_14_llvm_android     {<< : *llvm_android, << : *android-4_14,     << : *daily_midnight}
-  - &android-4_9_llvm_tot          {<< : *llvm_tot,     << : *android-4_9,      << : *daily_midnight}
-  - &android-4_9_llvm_latest       {<< : *llvm_latest,  << : *android-4_9,      << : *daily_midnight}
+  - &android-4_14_llvm_android     {<< : *llvm_android, << : *android-4_14,     << : *daily_six}
+  - &android-4_9_llvm_tot          {<< : *llvm_tot,     << : *android-4_9,      << : *daily_six}
+  - &android-4_9_llvm_latest       {<< : *llvm_latest,  << : *android-4_9,      << : *daily_six}
   - &android-4_9_llvm_13           {<< : *llvm_13,      << : *android-4_9,      << : *sundays}
   - &android-4_9_llvm_12           {<< : *llvm_12,      << : *android-4_9,      << : *sundays}
-  - &android-4_9_llvm_android      {<< : *llvm_android, << : *android-4_9,      << : *daily_midnight}
+  - &android-4_9_llvm_android      {<< : *llvm_android, << : *android-4_9,      << : *daily_six}
   - &tip_llvm_tot                  {<< : *llvm_tot,     << : *tip,              << : *daily_midnight}
   - &tip_llvm_latest               {<< : *llvm_latest,  << : *tip,              << : *daily_midnight}
   - &tip_llvm_13                   {<< : *llvm_13,      << : *tip,              << : *daily_midnight}

--- a/generator.yml
+++ b/generator.yml
@@ -30,6 +30,7 @@ urls:
 schedules:
   - &six_hours      {schedule: "0 0,6,12,18 * * *"}
   - &daily_midnight {schedule: "0 0 * * *"}
+  - &daily_noon     {schedule: "0 12 * * *"}
   # -next updates M-F in the evening AEST, which is usually around 12:00PM UTC
   - &weekdays       {schedule: "0 12 * * 1,2,3,4,5"}
   - &sundays        {schedule: "0 0 * * 0"}
@@ -66,27 +67,27 @@ tree_schedules:
   - &next_llvm_12                  {<< : *llvm_12,      << : *next,             << : *weekdays}
   - &next_llvm_11                  {<< : *llvm_11,      << : *next,             << : *weekdays}
   - &next_llvm_android             {<< : *llvm_android, << : *next,             << : *weekdays}
-  - &stable-5_15_llvm_tot          {<< : *llvm_tot,     << : *stable-5_15,      << : *daily_midnight}
-  - &stable-5_15_llvm_latest       {<< : *llvm_latest,  << : *stable-5_15,      << : *daily_midnight}
+  - &stable-5_15_llvm_tot          {<< : *llvm_tot,     << : *stable-5_15,      << : *daily_noon}
+  - &stable-5_15_llvm_latest       {<< : *llvm_latest,  << : *stable-5_15,      << : *daily_noon}
   - &stable-5_15_llvm_13           {<< : *llvm_13,      << : *stable-5_15,      << : *wednesdays}
   - &stable-5_15_llvm_12           {<< : *llvm_12,      << : *stable-5_15,      << : *wednesdays}
   - &stable-5_15_llvm_11           {<< : *llvm_11,      << : *stable-5_15,      << : *wednesdays}
-  - &stable-5_10_llvm_tot          {<< : *llvm_tot,     << : *stable-5_10,      << : *daily_midnight}
-  - &stable-5_10_llvm_latest       {<< : *llvm_latest,  << : *stable-5_10,      << : *daily_midnight}
+  - &stable-5_10_llvm_tot          {<< : *llvm_tot,     << : *stable-5_10,      << : *daily_noon}
+  - &stable-5_10_llvm_latest       {<< : *llvm_latest,  << : *stable-5_10,      << : *daily_noon}
   - &stable-5_10_llvm_13           {<< : *llvm_13,      << : *stable-5_10,      << : *wednesdays}
   - &stable-5_10_llvm_12           {<< : *llvm_12,      << : *stable-5_10,      << : *wednesdays}
   - &stable-5_10_llvm_11           {<< : *llvm_11,      << : *stable-5_10,      << : *wednesdays}
-  - &stable-5_4_llvm_tot           {<< : *llvm_tot,     << : *stable-5_4,       << : *daily_midnight}
-  - &stable-5_4_llvm_latest        {<< : *llvm_latest,  << : *stable-5_4,       << : *daily_midnight}
+  - &stable-5_4_llvm_tot           {<< : *llvm_tot,     << : *stable-5_4,       << : *daily_noon}
+  - &stable-5_4_llvm_latest        {<< : *llvm_latest,  << : *stable-5_4,       << : *daily_noon}
   - &stable-5_4_llvm_13            {<< : *llvm_13,      << : *stable-5_4,       << : *wednesdays}
-  - &stable-4_19_llvm_tot          {<< : *llvm_tot,     << : *stable-4_19,      << : *daily_midnight}
-  - &stable-4_19_llvm_latest       {<< : *llvm_latest,  << : *stable-4_19,      << : *daily_midnight}
+  - &stable-4_19_llvm_tot          {<< : *llvm_tot,     << : *stable-4_19,      << : *daily_noon}
+  - &stable-4_19_llvm_latest       {<< : *llvm_latest,  << : *stable-4_19,      << : *daily_noon}
   - &stable-4_19_llvm_13           {<< : *llvm_13,      << : *stable-4_19,      << : *wednesdays}
-  - &stable-4_14_llvm_tot          {<< : *llvm_tot,     << : *stable-4_14,      << : *daily_midnight}
-  - &stable-4_14_llvm_latest       {<< : *llvm_latest,  << : *stable-4_14,      << : *daily_midnight}
+  - &stable-4_14_llvm_tot          {<< : *llvm_tot,     << : *stable-4_14,      << : *daily_noon}
+  - &stable-4_14_llvm_latest       {<< : *llvm_latest,  << : *stable-4_14,      << : *daily_noon}
   - &stable-4_14_llvm_13           {<< : *llvm_13,      << : *stable-4_14,      << : *wednesdays}
-  - &stable-4_9_llvm_tot           {<< : *llvm_tot,     << : *stable-4_9,       << : *daily_midnight}
-  - &stable-4_9_llvm_latest        {<< : *llvm_latest,  << : *stable-4_9,       << : *daily_midnight}
+  - &stable-4_9_llvm_tot           {<< : *llvm_tot,     << : *stable-4_9,       << : *daily_noon}
+  - &stable-4_9_llvm_latest        {<< : *llvm_latest,  << : *stable-4_9,       << : *daily_noon}
   - &stable-4_9_llvm_13            {<< : *llvm_13,      << : *stable-4_9,       << : *wednesdays}
   - &android-mainline_llvm_tot     {<< : *llvm_tot,     << : *android-mainline, << : *daily_midnight}
   - &android-mainline_llvm_latest  {<< : *llvm_latest,  << : *android-mainline, << : *daily_midnight}

--- a/generator.yml
+++ b/generator.yml
@@ -1,10 +1,10 @@
 llvm_versions:
-  - &llvm_tot 15
-  - &llvm_latest 14
-  - &llvm_13 13
-  - &llvm_12 12
-  - &llvm_11 11
-  - &llvm_android android
+  - &llvm_tot     {llvm_version: 15}
+  - &llvm_latest  {llvm_version: 14}
+  - &llvm_13      {llvm_version: 13}
+  - &llvm_12      {llvm_version: 12}
+  - &llvm_11      {llvm_version: 11}
+  - &llvm_android {llvm_version: android}
 urls:
   # git repo URLs
   - &mainline-url https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
@@ -178,301 +178,301 @@ builds:
   #  Mainline  #
   ##############
   #  configs:                 trees:                  make_variables:        BOOT=1       llvm_versions:
-  - {<< : *arm32_v5,          << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_v6,          << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_v7,          << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_v7_t,        << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_imx,         << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_omap,        << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_lpae_fp,     << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_allno,       << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_allyes,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_kasan,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_ubsan,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allno,       << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_suse,        << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *hexagon,           << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *hexagon_allmod,    << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm32_v5,          << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_v6,          << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_v7,          << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_v7_t,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_imx,         << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_omap,        << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_lpae_fp,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_allno,       << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_kasan,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_ubsan,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64_allno,       << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *hexagon,           << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *hexagon_allmod,    << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
-  # - {<< : *i686_fedora,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *i386_suse,         << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *mips,              << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *mipsel,            << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc64le,           << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc64le_fedora,    << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc64le_suse,      << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *riscv,             << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *s390_kasan,        << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *s390_fedora,       << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *s390_suse,         << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_lto_thin,   << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_kasan,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_kcsan,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_ubsan,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_allmod,     << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *x86_64_allmod_lto, << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *x86_64_allno,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *x86_64_arch,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_fedora,     << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_suse,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  # - {<< : *i686_fedora,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *i386_suse,         << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *mips,              << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *mipsel,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le,           << : *mainline,         << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le_fedora,    << : *mainline,         << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le_suse,      << : *mainline,         << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *riscv,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *s390_kasan,        << : *mainline,         << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *s390_fedora,       << : *mainline,         << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *s390_suse,         << : *mainline,         << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_lto_thin,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_kasan,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_kcsan,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_ubsan,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_allmod,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_allmod_lto, << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_allno,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_arch,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_fedora,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_suse,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   ##########
   #  Next  #
   ##########
-  - {<< : *arm32_v5,          << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_v6,          << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_v7,          << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_v7_t,        << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_imx,         << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_omap,        << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_lpae_fp,     << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_allyes,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_fedora,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_kasan_sw,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_ubsan,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_fedora,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_suse,        << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *hexagon_allmod,    << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm32_v5,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_v6,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_v7,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_v7_t,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_imx,         << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_omap,        << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_lpae_fp,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_fedora,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_kasan_sw,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_ubsan,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64_fedora,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *hexagon_allmod,    << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
-  # - {<< : *i686_fedora,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *i386_suse,         << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *mips,              << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *mipsel,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc32,             << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc64le_fedora,    << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc64le_suse,      << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *riscv_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *s390_kasan,        << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *s390_fedora,       << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *s390_suse,         << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_lto_thin,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_kasan,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_kcsan,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_ubsan,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *x86_64_gcov,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_arch,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_fedora,     << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_suse,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  # - {<< : *i686_fedora,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *i386_suse,         << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *mips,              << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *mipsel,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *ppc32,             << : *next,             << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le_fedora,    << : *next,             << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le_suse,      << : *next,             << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *riscv_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *s390,              << : *next,             << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *s390_kasan,        << : *next,             << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *s390_fedora,       << : *next,             << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *s390_suse,         << : *next,             << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_lto_thin,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_kasan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_kcsan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_ubsan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_gcov,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_arch,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_fedora,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_suse,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   ############
   #  5.15.y  #
   ############
-  - {<< : *arm32_v5,          << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_v6,          << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_v7,          << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_v7_t,        << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_imx,         << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_omap,        << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_lpae_fp,     << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_cfi,         << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allmod_lto,  << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm32_v5,          << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_v6,          << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_v7,          << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_v7_t,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_imx,         << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_omap,        << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_lpae_fp,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_cfi,         << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64_allmod_lto,  << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
-  # - {<< : *i686_fedora,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *i386_suse,         << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *mips,              << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *mipsel,            << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc32,             << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc64le,           << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc64le_fedora,    << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *riscv,             << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *s390,              << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *s390_kasan,        << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *s390_fedora,       << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *s390_suse,         << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64,            << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_lto_full,   << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_lto_thin,   << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_kasan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_kcsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_ubsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_allmod,     << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *x86_64_allmod_lto, << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *x86_64_allno,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *x86_64_allyes,     << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *x86_64_arch,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_fedora,     << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_suse,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  # - {<< : *i686_fedora,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *i386_suse,         << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *mips,              << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *mipsel,            << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *ppc32,             << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le,           << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le_fedora,    << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *riscv,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *s390,              << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *s390_kasan,        << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *s390_fedora,       << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *s390_suse,         << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *x86_64,            << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_lto_full,   << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_lto_thin,   << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_kasan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_kcsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_ubsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_allmod,     << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_allmod_lto, << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_allno,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_allyes,     << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_arch,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_fedora,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_suse,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   ############
   #  5.10.y  #
   ############
-  - {<< : *arm32_v5,          << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_v6,          << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_v7,          << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_v7_t,        << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_allmod,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_allyes,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64,             << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64be,           << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *mips,              << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc64le,           << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *riscv,             << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_tot}
-  - {<< : *s390,              << : *stable-5_10,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64,            << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_allmod,     << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *x86_64_allno,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *x86_64_allyes,     << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm32_v5,          << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *arm32_v6,          << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *arm32_v7,          << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *arm32_v7_t,        << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *arm32_allmod,      << : *stable-5_10,      << : *llvm,            boot: false, << : *llvm_tot}
+  - {<< : *arm32_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_allyes,      << : *stable-5_10,      << : *llvm,            boot: false, << : *llvm_tot}
+  - {<< : *arm64,             << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64be,           << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *mips,              << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le,           << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *riscv,             << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  << : *llvm_tot}
+  - {<< : *s390,              << : *stable-5_10,      << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *x86_64,            << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_allmod,     << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_allno,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_allyes,     << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_tot}
   ###########
   #  5.4.y  #
   ###########
-  - {<< : *arm32_v7,          << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_v7_t,        << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_no_vdso32,   << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64be,           << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *mips,              << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *mipsel,            << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc32,             << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc64,             << : *stable-5_4,       << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc64le,           << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64,            << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm32_v7,          << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *arm32_v7_t,        << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *arm64_no_vdso32,   << : *stable-5_4,       << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64be,           << : *stable-5_4,       << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *mips,              << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *mipsel,            << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *ppc32,             << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *ppc64,             << : *stable-5_4,       << : *ppc64_llvm,      boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le,           << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *x86_64,            << : *stable-5_4,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   ############
   #  4.19.y  #
   ############
-  - {<< : *arm32_v7,          << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_v7_t,        << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64,             << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64be,           << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc64le,           << : *stable-4_19,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64,            << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm32_v7,          << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *arm32_v7_t,        << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *arm64,             << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *arm64be,           << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le,           << : *stable-4_19,      << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *x86_64,            << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_tot}
   ############
   #  4.14.y  #
   ############
-  - {<< : *arm32_v7,          << : *stable-4_14,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_v7_t,        << : *stable-4_14,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64,             << : *stable-4_14,      << : *lld,             boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64be,           << : *stable-4_14,      << : *lld,             boot: true,  llvm_version: *llvm_tot}
-  - {<< : *ppc64le,           << : *stable-4_14,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64,            << : *stable-4_14,      << : *lld,             boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm32_v7,          << : *stable-4_14,      << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *arm32_v7_t,        << : *stable-4_14,      << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *arm64,             << : *stable-4_14,      << : *lld,             boot: true,  << : *llvm_tot}
+  - {<< : *arm64be,           << : *stable-4_14,      << : *lld,             boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le,           << : *stable-4_14,      << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *x86_64,            << : *stable-4_14,      << : *lld,             boot: true,  << : *llvm_tot}
   ###########
   #  4.9.y  #
   ###########
-  - {<< : *arm32_v7,          << : *stable-4_9,       << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64,             << : *stable-4_9,       << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64be,           << : *stable-4_9,       << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64,            << : *stable-4_9,       << : *lld,             boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm32_v7,          << : *stable-4_9,       << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *arm64,             << : *stable-4_9,       << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *arm64be,           << : *stable-4_9,       << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *x86_64,            << : *stable-4_9,       << : *lld,             boot: true,  << : *llvm_tot}
   #############
   #  Android  #
   #############
-  - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_allmod,      << : *android13-5_15,   << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_v7_t,        << : *android13-5_15,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_gki,         << : *android13-5_15,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_gki,        << : *android13-5_15,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_allmod,      << : *android13-5_10,   << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_v7_t,        << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_gki,         << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_gki,        << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_allmod,      << : *android12-5_10,   << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_v7_t,        << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_gki,         << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_gki,        << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm32_allmod,      << : *android12-5_4,    << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm32_v7_t,        << : *android12-5_4,    << : *llvm,            boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_gki,         << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_gki,        << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_gki,         << : *android-4_19,     << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_gki,        << : *android-4_19,     << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_cut,         << : *android-4_14,     << : *lld,             boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_cut,        << : *android-4_14,     << : *lld,             boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_cut,         << : *android-4_9,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_cut,        << : *android-4_9,      << : *clang,           boot: true,  llvm_version: *llvm_tot}
+  - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_allmod,      << : *android13-5_15,   << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_v7_t,        << : *android13-5_15,   << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_gki,         << : *android13-5_15,   << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_gki,        << : *android13-5_15,   << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_allmod,      << : *android13-5_10,   << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_v7_t,        << : *android13-5_10,   << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_gki,         << : *android13-5_10,   << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_gki,        << : *android13-5_10,   << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_allmod,      << : *android12-5_10,   << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_v7_t,        << : *android12-5_10,   << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_gki,         << : *android12-5_10,   << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_gki,        << : *android12-5_10,   << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_allmod,      << : *android12-5_4,    << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm32_v7_t,        << : *android12-5_4,    << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *arm64_gki,         << : *android12-5_4,    << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_gki,        << : *android12-5_4,    << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_gki,         << : *android-4_19,     << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_gki,        << : *android-4_19,     << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_cut,         << : *android-4_14,     << : *lld,             boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_cut,        << : *android-4_14,     << : *lld,             boot: true,  << : *llvm_tot}
+  - {<< : *arm64_cut,         << : *android-4_9,      << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_cut,        << : *android-4_9,      << : *clang,           boot: true,  << : *llvm_tot}
   #########
   #  TIP  #
   #########
-  - {<< : *i386,              << : *tip,              << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64,            << : *tip,              << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *x86_64_allmod,     << : *tip,              << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *x86_64_allno,      << : *tip,              << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
+  - {<< : *i386,              << : *tip,              << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64,            << : *tip,              << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_allmod,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_allno,      << : *tip,              << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_tot}
   ###########
   #  ARM64  #
   ###########
-  - {<< : *arm64,             << : *arm64-core,       << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64be,           << : *arm64-core,       << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_allmod,      << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allno,       << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allyes,      << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64,             << : *arm64-fixes,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64be,           << : *arm64-fixes,      << : *llvm_full,       boot: true,  llvm_version: *llvm_tot}
-  - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allno,       << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
-  - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_tot}
+  - {<< : *arm64,             << : *arm64-core,       << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64be,           << : *arm64-core,       << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_allmod,      << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64_allno,       << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64_allyes,      << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64,             << : *arm64-fixes,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64be,           << : *arm64-fixes,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64_allno,       << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_tot}
   #########################
   #  Latest LLVM release  #
   #########################
@@ -480,1132 +480,1132 @@ builds:
   #  Mainline  #
   ##############
   #  configs:                 trees:                  make_variables:        BOOT=1       llvm_versions:
-  - {<< : *arm32_v5,          << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_v6,          << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_v7,          << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_v7_t,        << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_imx,         << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_omap,        << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_lpae_fp,     << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_allno,       << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_allyes,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_kasan,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_ubsan,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allno,       << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_suse,        << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *hexagon,           << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *hexagon_allmod,    << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm32_v5,          << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_v6,          << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_v7,          << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_v7_t,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_imx,         << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_omap,        << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_lpae_fp,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_allno,       << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_kasan,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_ubsan,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64_allno,       << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *hexagon,           << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *hexagon_allmod,    << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
-  # - {<< : *i686_fedora,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *i386_suse,         << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *mips,              << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *mipsel,            << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc64le,           << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc64le_fedora,    << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc64le_suse,      << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *riscv,             << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *s390_kasan,        << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *s390_fedora,       << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *s390_suse,         << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_lto_thin,   << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_kasan,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_kcsan,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_ubsan,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_allmod,     << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *x86_64_allmod_lto, << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *x86_64_allno,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *x86_64_arch,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_fedora,     << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_suse,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  # - {<< : *i686_fedora,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *i386_suse,         << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *mips,              << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *mipsel,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le,           << : *mainline,         << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le_fedora,    << : *mainline,         << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le_suse,      << : *mainline,         << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *riscv,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *s390_kasan,        << : *mainline,         << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *s390_fedora,       << : *mainline,         << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *s390_suse,         << : *mainline,         << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_lto_thin,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_kasan,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_kcsan,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_ubsan,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_allmod,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_allmod_lto, << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_allno,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_arch,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_fedora,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_suse,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   ##########
   #  Next  #
   ##########
-  - {<< : *arm32_v5,          << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_v6,          << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_v7,          << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_v7_t,        << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_imx,         << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_omap,        << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_lpae_fp,     << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_allyes,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_fedora,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_kasan_sw,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_ubsan,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_fedora,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_suse,        << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *hexagon_allmod,    << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm32_v5,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_v6,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_v7,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_v7_t,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_imx,         << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_omap,        << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_lpae_fp,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_fedora,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_kasan_sw,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_ubsan,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64_fedora,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *hexagon_allmod,    << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
-  # - {<< : *i686_fedora,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *i386_suse,         << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *mips,              << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *mipsel,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc32,             << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc64le_fedora,    << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc64le_suse,      << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *riscv_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *s390_kasan,        << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *s390_fedora,       << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *s390_suse,         << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_lto_thin,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_kasan,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_kcsan,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_ubsan,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *x86_64_gcov,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_arch,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_fedora,     << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_suse,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  # - {<< : *i686_fedora,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *i386_suse,         << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *mips,              << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *mipsel,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *ppc32,             << : *next,             << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le_fedora,    << : *next,             << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le_suse,      << : *next,             << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *riscv_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *s390,              << : *next,             << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *s390_kasan,        << : *next,             << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *s390_fedora,       << : *next,             << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *s390_suse,         << : *next,             << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_lto_thin,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_kasan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_kcsan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_ubsan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_gcov,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_arch,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_fedora,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_suse,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   ############
   #  5.15.y  #
   ############
-  - {<< : *arm32_v5,          << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_v6,          << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_v7,          << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_v7_t,        << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_imx,         << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_omap,        << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_lpae_fp,     << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_cfi,         << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allmod_lto,  << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm32_v5,          << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_v6,          << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_v7,          << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_v7_t,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_imx,         << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_omap,        << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_lpae_fp,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_cfi,         << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64_allmod_lto,  << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
-  # - {<< : *i686_fedora,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *i386_suse,         << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *mips,              << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *mipsel,            << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc32,             << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc64le,           << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc64le_fedora,    << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *riscv,             << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *s390,              << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *s390_kasan,        << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *s390_fedora,       << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *s390_suse,         << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64,            << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_lto_full,   << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_lto_thin,   << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_kasan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_kcsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_ubsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_allmod,     << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *x86_64_allmod_lto, << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *x86_64_allno,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *x86_64_allyes,     << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *x86_64_arch,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_fedora,     << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_suse,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  # - {<< : *i686_fedora,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *i386_suse,         << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *mips,              << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *mipsel,            << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *ppc32,             << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le,           << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le_fedora,    << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *riscv,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *s390,              << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *s390_kasan,        << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *s390_fedora,       << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *s390_suse,         << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *x86_64,            << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_lto_full,   << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_lto_thin,   << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_kasan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_kcsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_ubsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_allmod,     << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_allmod_lto, << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_allno,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_allyes,     << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_arch,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_fedora,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_suse,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   ############
   #  5.10.y  #
   ############
-  - {<< : *arm32_v5,          << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_v6,          << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_v7,          << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_v7_t,        << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_allmod,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_allyes,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64,             << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64be,           << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *mips,              << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc64le,           << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *riscv,             << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_latest}
-  - {<< : *s390,              << : *stable-5_10,      << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64,            << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_allmod,     << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *x86_64_allno,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *x86_64_allyes,     << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm32_v5,          << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *arm32_v6,          << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *arm32_v7,          << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *arm32_v7_t,        << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *arm32_allmod,      << : *stable-5_10,      << : *llvm,            boot: false, << : *llvm_latest}
+  - {<< : *arm32_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_allyes,      << : *stable-5_10,      << : *llvm,            boot: false, << : *llvm_latest}
+  - {<< : *arm64,             << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64be,           << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *mips,              << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le,           << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *riscv,             << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  << : *llvm_latest}
+  - {<< : *s390,              << : *stable-5_10,      << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *x86_64,            << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_allmod,     << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_allno,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_allyes,     << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_latest}
   ###########
   #  5.4.y  #
   ###########
-  - {<< : *arm32_v7,          << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_v7_t,        << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_no_vdso32,   << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64be,           << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *mips,              << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *mipsel,            << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc32,             << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc64,             << : *stable-5_4,       << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc64le,           << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64,            << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm32_v7,          << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *arm32_v7_t,        << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *arm64_no_vdso32,   << : *stable-5_4,       << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64be,           << : *stable-5_4,       << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *mips,              << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *mipsel,            << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *ppc32,             << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *ppc64,             << : *stable-5_4,       << : *ppc64_llvm,      boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le,           << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *x86_64,            << : *stable-5_4,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   ############
   #  4.19.y  #
   ############
-  - {<< : *arm32_v7,          << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_v7_t,        << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64,             << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64be,           << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc64le,           << : *stable-4_19,      << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64,            << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm32_v7,          << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *arm32_v7_t,        << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *arm64,             << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *arm64be,           << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le,           << : *stable-4_19,      << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *x86_64,            << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_latest}
   ############
   #  4.14.y  #
   ############
-  - {<< : *arm32_v7,          << : *stable-4_14,      << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_v7_t,        << : *stable-4_14,      << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64,             << : *stable-4_14,      << : *lld,             boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64be,           << : *stable-4_14,      << : *lld,             boot: true,  llvm_version: *llvm_latest}
-  - {<< : *ppc64le,           << : *stable-4_14,      << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64,            << : *stable-4_14,      << : *lld,             boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm32_v7,          << : *stable-4_14,      << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *arm32_v7_t,        << : *stable-4_14,      << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *arm64,             << : *stable-4_14,      << : *lld,             boot: true,  << : *llvm_latest}
+  - {<< : *arm64be,           << : *stable-4_14,      << : *lld,             boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le,           << : *stable-4_14,      << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *x86_64,            << : *stable-4_14,      << : *lld,             boot: true,  << : *llvm_latest}
   ###########
   #  4.9.y  #
   ###########
-  - {<< : *arm32_v7,          << : *stable-4_9,       << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64,             << : *stable-4_9,       << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64be,           << : *stable-4_9,       << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64,            << : *stable-4_9,       << : *lld,             boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm32_v7,          << : *stable-4_9,       << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *arm64,             << : *stable-4_9,       << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *arm64be,           << : *stable-4_9,       << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *x86_64,            << : *stable-4_9,       << : *lld,             boot: true,  << : *llvm_latest}
   #############
   #  Android  #
   #############
-  - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_allmod,      << : *android13-5_15,   << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_v7_t,        << : *android13-5_15,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_gki,         << : *android13-5_15,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_gki,        << : *android13-5_15,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_allmod,      << : *android13-5_10,   << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_v7_t,        << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_gki,         << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_gki,        << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_allmod,      << : *android12-5_10,   << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_v7_t,        << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_gki,         << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_gki,        << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm32_allmod,      << : *android12-5_4,    << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm32_v7_t,        << : *android12-5_4,    << : *llvm,            boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_gki,         << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_gki,        << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_gki,         << : *android-4_19,     << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_gki,        << : *android-4_19,     << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_cut,         << : *android-4_14,     << : *lld,             boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_cut,        << : *android-4_14,     << : *lld,             boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_cut,         << : *android-4_9,      << : *clang,           boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_cut,        << : *android-4_9,      << : *clang,           boot: true,  llvm_version: *llvm_latest}
+  - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_allmod,      << : *android13-5_15,   << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_v7_t,        << : *android13-5_15,   << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_gki,         << : *android13-5_15,   << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_gki,        << : *android13-5_15,   << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_allmod,      << : *android13-5_10,   << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_v7_t,        << : *android13-5_10,   << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_gki,         << : *android13-5_10,   << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_gki,        << : *android13-5_10,   << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_allmod,      << : *android12-5_10,   << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_v7_t,        << : *android12-5_10,   << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_gki,         << : *android12-5_10,   << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_gki,        << : *android12-5_10,   << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_allmod,      << : *android12-5_4,    << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm32_v7_t,        << : *android12-5_4,    << : *llvm,            boot: true,  << : *llvm_latest}
+  - {<< : *arm64_gki,         << : *android12-5_4,    << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_gki,        << : *android12-5_4,    << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_gki,         << : *android-4_19,     << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_gki,        << : *android-4_19,     << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_cut,         << : *android-4_14,     << : *lld,             boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_cut,        << : *android-4_14,     << : *lld,             boot: true,  << : *llvm_latest}
+  - {<< : *arm64_cut,         << : *android-4_9,      << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_cut,        << : *android-4_9,      << : *clang,           boot: true,  << : *llvm_latest}
   #########
   #  TIP  #
   #########
-  - {<< : *i386,              << : *tip,              << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64,            << : *tip,              << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *x86_64_allmod,     << : *tip,              << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *x86_64_allno,      << : *tip,              << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
+  - {<< : *i386,              << : *tip,              << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64,            << : *tip,              << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_allmod,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_allno,      << : *tip,              << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_latest}
   ###########
   #  ARM64  #
   ###########
-  - {<< : *arm64,             << : *arm64-core,       << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64be,           << : *arm64-core,       << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_allmod,      << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allno,       << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allyes,      << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64,             << : *arm64-fixes,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64be,           << : *arm64-fixes,      << : *llvm_full,       boot: true,  llvm_version: *llvm_latest}
-  - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allno,       << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
-  - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_latest}
+  - {<< : *arm64,             << : *arm64-core,       << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64be,           << : *arm64-core,       << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_allmod,      << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64_allno,       << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64_allyes,      << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64,             << : *arm64-fixes,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64be,           << : *arm64-fixes,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64_allno,       << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_latest}
   #############
   #  LLVM 13  #
   #############
   ##############
   #  Mainline  #
   ##############
-  - {<< : *arm32_v5,          << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_v6,          << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_v7,          << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_v7_t,        << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_imx,         << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_omap,        << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_lpae_fp,     << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_allno,       << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_allyes,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_kasan,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_ubsan,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64_allno,       << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_suse,        << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *hexagon,           << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *hexagon_allmod,    << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
+  - {<< : *arm32_v5,          << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_v6,          << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_v7,          << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_v7_t,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_imx,         << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_omap,        << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_lpae_fp,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_allno,       << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_kasan,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_ubsan,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64_allno,       << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *hexagon,           << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *hexagon_allmod,    << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
-  # - {<< : *i686_fedora,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *i386_suse,         << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *mips,              << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *mipsel,            << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc64le,           << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc64le_fedora,    << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc64le_suse,      << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *riscv,             << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *s390_kasan,        << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *s390_fedora,       << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *s390_suse,         << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_lto_thin,   << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_kasan,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_kcsan,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_ubsan,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_allmod,     << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *x86_64_allmod_lto, << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *x86_64_allno,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *x86_64_arch,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_fedora,     << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_suse,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
+  # - {<< : *i686_fedora,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *i386_suse,         << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *mips,              << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *mipsel,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  << : *llvm_13}
+  - {<< : *ppc64le,           << : *mainline,         << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *ppc64le_fedora,    << : *mainline,         << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *ppc64le_suse,      << : *mainline,         << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *riscv,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *s390_kasan,        << : *mainline,         << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *s390_fedora,       << : *mainline,         << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *s390_suse,         << : *mainline,         << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_lto_thin,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_kasan,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_kcsan,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_ubsan,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_allmod,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *x86_64_allmod_lto, << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *x86_64_allno,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *x86_64_arch,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_fedora,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_suse,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
   ##########
   #  Next  #
   ##########
-  - {<< : *arm32_v5,          << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_v6,          << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_v7,          << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_v7_t,        << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_imx,         << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_omap,        << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_lpae_fp,     << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_allyes,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_fedora,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_kasan_sw,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_ubsan,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64_fedora,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_suse,        << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *hexagon_allmod,    << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
+  - {<< : *arm32_v5,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_v6,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_v7,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_v7_t,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_imx,         << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_omap,        << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_lpae_fp,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_fedora,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_kasan_sw,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_ubsan,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64_fedora,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *hexagon_allmod,    << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
-  # - {<< : *i686_fedora,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *i386_suse,         << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *mips,              << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *mipsel,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc32,             << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc64le_fedora,    << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc64le_suse,      << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *riscv_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *s390_kasan,        << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *s390_fedora,       << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *s390_suse,         << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_lto_thin,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_kasan,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_kcsan,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_ubsan,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *x86_64_gcov,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_arch,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_fedora,     << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_suse,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
+  # - {<< : *i686_fedora,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *i386_suse,         << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *mips,              << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *mipsel,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *ppc32,             << : *next,             << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  << : *llvm_13}
+  - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *ppc64le_fedora,    << : *next,             << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *ppc64le_suse,      << : *next,             << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *riscv_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *s390,              << : *next,             << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *s390_kasan,        << : *next,             << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *s390_fedora,       << : *next,             << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *s390_suse,         << : *next,             << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_lto_thin,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_kasan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_kcsan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_ubsan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *x86_64_gcov,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_arch,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_fedora,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_suse,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   ############
   #  5.15.y  #
   ############
-  - {<< : *arm32_v5,          << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_v6,          << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_v7,          << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_v7_t,        << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_imx,         << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_omap,        << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_lpae_fp,     << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_cfi,         << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64_allmod_lto,  << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
+  - {<< : *arm32_v5,          << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_v6,          << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_v7,          << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_v7_t,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_imx,         << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_omap,        << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_lpae_fp,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_cfi,         << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64_allmod_lto,  << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
-  # - {<< : *i686_fedora,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *i386_suse,         << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *mips,              << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *mipsel,            << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc32,             << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc64le,           << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc64le_fedora,    << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *riscv,             << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *s390,              << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *s390_kasan,        << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *s390_fedora,       << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *s390_suse,         << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64,            << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_lto_full,   << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_lto_thin,   << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_kasan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_kcsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_ubsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_allmod,     << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *x86_64_allmod_lto, << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *x86_64_allno,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *x86_64_allyes,     << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *x86_64_arch,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_fedora,     << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_suse,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
+  # - {<< : *i686_fedora,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *i386_suse,         << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *mips,              << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *mipsel,            << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *ppc32,             << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  << : *llvm_13}
+  - {<< : *ppc64le,           << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *ppc64le_fedora,    << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *riscv,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *s390,              << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *s390_kasan,        << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *s390_fedora,       << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *s390_suse,         << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *x86_64,            << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_lto_full,   << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_lto_thin,   << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_kasan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_kcsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_ubsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_allmod,     << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *x86_64_allmod_lto, << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *x86_64_allno,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *x86_64_allyes,     << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *x86_64_arch,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_fedora,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_suse,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   ############
   #  5.10.y  #
   ############
-  - {<< : *arm32_v5,          << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_v6,          << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_v7,          << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_v7_t,        << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_allmod,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_allyes,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64,             << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64be,           << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *mips,              << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc64le,           << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *riscv,             << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_13}
-  - {<< : *s390,              << : *stable-5_10,      << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64,            << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_allmod,     << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *x86_64_allno,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *x86_64_allyes,     << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
+  - {<< : *arm32_v5,          << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *arm32_v6,          << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *arm32_v7,          << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *arm32_v7_t,        << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *arm32_allmod,      << : *stable-5_10,      << : *llvm,            boot: false, << : *llvm_13}
+  - {<< : *arm32_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_allyes,      << : *stable-5_10,      << : *llvm,            boot: false, << : *llvm_13}
+  - {<< : *arm64,             << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64be,           << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *mips,              << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  << : *llvm_13}
+  - {<< : *ppc64le,           << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *riscv,             << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  << : *llvm_13}
+  - {<< : *s390,              << : *stable-5_10,      << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *x86_64,            << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_allmod,     << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *x86_64_allno,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *x86_64_allyes,     << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_13}
   ###########
   #  5.4.y  #
   ###########
-  - {<< : *arm32_v7,          << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_v7_t,        << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_no_vdso32,   << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64be,           << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *mips,              << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *mipsel,            << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc32,             << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc64,             << : *stable-5_4,       << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc64le,           << : *stable-5_4,       << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64,            << : *stable-5_4,       << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
+  - {<< : *arm32_v7,          << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *arm32_v7_t,        << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *arm64_no_vdso32,   << : *stable-5_4,       << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64be,           << : *stable-5_4,       << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *mips,              << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *mipsel,            << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *ppc32,             << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *ppc64,             << : *stable-5_4,       << : *ppc64_llvm,      boot: true,  << : *llvm_13}
+  - {<< : *ppc64le,           << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *x86_64,            << : *stable-5_4,       << : *llvm_full,       boot: true,  << : *llvm_13}
   ############
   #  4.19.y  #
   ############
-  - {<< : *arm32_v7,          << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_v7_t,        << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64,             << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64be,           << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc64le,           << : *stable-4_19,      << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64,            << : *stable-4_19,      << : *llvm,            boot: true,  llvm_version: *llvm_13}
+  - {<< : *arm32_v7,          << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *arm32_v7_t,        << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *arm64,             << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *arm64be,           << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *ppc64le,           << : *stable-4_19,      << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *x86_64,            << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_13}
   ############
   #  4.14.y  #
   ############
-  - {<< : *arm32_v7,          << : *stable-4_14,      << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_v7_t,        << : *stable-4_14,      << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64,             << : *stable-4_14,      << : *lld,             boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64be,           << : *stable-4_14,      << : *lld,             boot: true,  llvm_version: *llvm_13}
-  - {<< : *ppc64le,           << : *stable-4_14,      << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64,            << : *stable-4_14,      << : *lld,             boot: true,  llvm_version: *llvm_13}
+  - {<< : *arm32_v7,          << : *stable-4_14,      << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *arm32_v7_t,        << : *stable-4_14,      << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *arm64,             << : *stable-4_14,      << : *lld,             boot: true,  << : *llvm_13}
+  - {<< : *arm64be,           << : *stable-4_14,      << : *lld,             boot: true,  << : *llvm_13}
+  - {<< : *ppc64le,           << : *stable-4_14,      << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *x86_64,            << : *stable-4_14,      << : *lld,             boot: true,  << : *llvm_13}
   ###########
   #  4.9.y  #
   ###########
-  - {<< : *arm32_v7,          << : *stable-4_9,       << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64,             << : *stable-4_9,       << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64be,           << : *stable-4_9,       << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64,            << : *stable-4_9,       << : *lld,             boot: true,  llvm_version: *llvm_13}
+  - {<< : *arm32_v7,          << : *stable-4_9,       << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *arm64,             << : *stable-4_9,       << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *arm64be,           << : *stable-4_9,       << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *x86_64,            << : *stable-4_9,       << : *lld,             boot: true,  << : *llvm_13}
   #############
   #  Android  #
   #############
-  - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_allmod,      << : *android13-5_15,   << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_v7_t,        << : *android13-5_15,   << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_gki,         << : *android13-5_15,   << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_gki,        << : *android13-5_15,   << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_allmod,      << : *android13-5_10,   << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_v7_t,        << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_gki,         << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_gki,        << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_allmod,      << : *android12-5_10,   << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_v7_t,        << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_gki,         << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_gki,        << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm32_allmod,      << : *android12-5_4,    << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm32_v7_t,        << : *android12-5_4,    << : *llvm,            boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_gki,         << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_gki,        << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_gki,         << : *android-4_19,     << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_gki,        << : *android-4_19,     << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_cut,         << : *android-4_14,     << : *lld,             boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_cut,        << : *android-4_14,     << : *lld,             boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_cut,         << : *android-4_9,      << : *clang,           boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_cut,        << : *android-4_9,      << : *clang,           boot: true,  llvm_version: *llvm_13}
+  - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_allmod,      << : *android13-5_15,   << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_v7_t,        << : *android13-5_15,   << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_gki,         << : *android13-5_15,   << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_gki,        << : *android13-5_15,   << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_allmod,      << : *android13-5_10,   << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_v7_t,        << : *android13-5_10,   << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_gki,         << : *android13-5_10,   << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_gki,        << : *android13-5_10,   << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_allmod,      << : *android12-5_10,   << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_v7_t,        << : *android12-5_10,   << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_gki,         << : *android12-5_10,   << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_gki,        << : *android12-5_10,   << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm32_allmod,      << : *android12-5_4,    << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm32_v7_t,        << : *android12-5_4,    << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *arm64_gki,         << : *android12-5_4,    << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_gki,        << : *android12-5_4,    << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_gki,         << : *android-4_19,     << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_gki,        << : *android-4_19,     << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_cut,         << : *android-4_14,     << : *lld,             boot: true,  << : *llvm_13}
+  - {<< : *x86_64_cut,        << : *android-4_14,     << : *lld,             boot: true,  << : *llvm_13}
+  - {<< : *arm64_cut,         << : *android-4_9,      << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *x86_64_cut,        << : *android-4_9,      << : *clang,           boot: true,  << : *llvm_13}
   #########
   #  TIP  #
   #########
-  - {<< : *i386,              << : *tip,              << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64,            << : *tip,              << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *x86_64_allmod,     << : *tip,              << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *x86_64_allno,      << : *tip,              << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, llvm_version: *llvm_13}
+  - {<< : *i386,              << : *tip,              << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64,            << : *tip,              << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *x86_64_allmod,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *x86_64_allno,      << : *tip,              << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_13}
   ###########
   #  ARM64  #
   ###########
-  - {<< : *arm64,             << : *arm64-core,       << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64be,           << : *arm64-core,       << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_allmod,      << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64_allno,       << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64_allyes,      << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64,             << : *arm64-fixes,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64be,           << : *arm64-fixes,      << : *llvm_full,       boot: true,  llvm_version: *llvm_13}
-  - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64_allno,       << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
-  - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_13}
+  - {<< : *arm64,             << : *arm64-core,       << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64be,           << : *arm64-core,       << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_allmod,      << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64_allno,       << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64_allyes,      << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64,             << : *arm64-fixes,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64be,           << : *arm64-fixes,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64_allno,       << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_13}
   #############
   #  LLVM 12  #
   #############
   ##############
   #  Mainline  #
   ##############
-  - {<< : *arm32_v5,          << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_v6,          << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_v7,          << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_v7_t,        << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_imx,         << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_omap,        << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_lpae_fp,     << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_allmod,      << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_allno,       << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_allyes,      << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_fedora,      << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_suse,        << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_kasan,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_ubsan,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allno,       << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_suse,        << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *hexagon,           << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm32_v5,          << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_v6,          << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_v7,          << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_v7_t,        << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_imx,         << : *mainline,         << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_omap,        << : *mainline,         << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_lpae_fp,     << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_allmod,      << : *mainline,         << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_allno,       << : *mainline,         << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_allyes,      << : *mainline,         << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_fedora,      << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_suse,        << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_kasan,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_ubsan,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_allno,       << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *hexagon,           << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
-  # - {<< : *i686_fedora,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *i386_suse,         << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *mips,              << : *mainline,         << : *mips_llvm_full,  boot: true,  llvm_version: *llvm_12}
-  - {<< : *mipsel,            << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  # - {<< : *i686_fedora,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *i386_suse,         << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *mips,              << : *mainline,         << : *mips_llvm_full,  boot: true,  << : *llvm_12}
+  - {<< : *mipsel,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
   # ppc32: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1345)
-  - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_12}
-  - {<< : *ppc64le,           << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *ppc64le_fedora,    << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_12}
-  - {<< : *ppc64le_suse,      << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_12}
-  - {<< : *riscv,             << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *riscv_allmod,      << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_12}
+  - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  << : *llvm_12}
+  - {<< : *ppc64le,           << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *ppc64le_fedora,    << : *mainline,         << : *clang,           boot: true,  << : *llvm_12}
+  - {<< : *ppc64le_suse,      << : *mainline,         << : *clang,           boot: true,  << : *llvm_12}
+  - {<< : *riscv,             << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *riscv_allmod,      << : *mainline,         << : *llvm,            boot: false, << : *llvm_12}
   # s390: Build disabled (https://lore.kernel.org/r/YMtib5hKVyNknZt3@osiris/)
-  # - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_lto_thin,   << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_kasan,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_kcsan,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_ubsan,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_allmod,     << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *x86_64_allmod_lto, << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *x86_64_allno,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *x86_64_arch,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_fedora,     << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_suse,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  # - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  << : *llvm_12}
+  - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_lto_thin,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_kasan,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_kcsan,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_ubsan,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_allmod,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *x86_64_allmod_lto, << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *x86_64_allno,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *x86_64_arch,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_fedora,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_suse,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
   ##########
   #  Next  #
   ##########
-  - {<< : *arm32_v5,          << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_v6,          << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_v7,          << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_v7_t,        << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_imx,         << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_omap,        << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_lpae_fp,     << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_allmod,      << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_allno,       << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_allyes,      << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_fedora,      << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_suse,        << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_kasan_sw,    << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_ubsan,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_fedora,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_suse,        << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm32_v5,          << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_v6,          << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_v7,          << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_v7_t,        << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_imx,         << : *next,             << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_omap,        << : *next,             << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_lpae_fp,     << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_allmod,      << : *next,             << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_allno,       << : *next,             << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_allyes,      << : *next,             << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_fedora,      << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_suse,        << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_kasan_sw,    << : *next,             << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_ubsan,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_fedora,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
-  # - {<< : *i686_fedora,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *i386_suse,         << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *mips,              << : *next,             << : *mips_llvm_full,  boot: true,  llvm_version: *llvm_12}
-  - {<< : *mipsel,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  # - {<< : *i686_fedora,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *i386_suse,         << : *next,             << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *mips,              << : *next,             << : *mips_llvm_full,  boot: true,  << : *llvm_12}
+  - {<< : *mipsel,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
   # ppc32: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1345)
-  - {<< : *ppc32,             << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_12}
-  - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *ppc64le_fedora,    << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_12}
-  - {<< : *ppc64le_suse,      << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_12}
-  - {<< : *riscv,             << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *riscv_allmod,      << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_12}
+  - {<< : *ppc32,             << : *next,             << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  << : *llvm_12}
+  - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *ppc64le_fedora,    << : *next,             << : *clang,           boot: true,  << : *llvm_12}
+  - {<< : *ppc64le_suse,      << : *next,             << : *clang,           boot: true,  << : *llvm_12}
+  - {<< : *riscv,             << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *riscv_allmod,      << : *next,             << : *llvm,            boot: false, << : *llvm_12}
   # s390: Build disabled (https://lore.kernel.org/r/YMtib5hKVyNknZt3@osiris/)
-  # - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_lto_thin,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_kasan,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_kcsan,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_ubsan,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *x86_64_arch,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_fedora,     << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_suse,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  # - {<< : *s390,              << : *next,             << : *clang,           boot: true,  << : *llvm_12}
+  - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_lto_thin,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_kasan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_kcsan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_ubsan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *x86_64_arch,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_fedora,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_suse,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
   ############
   #  5.15.y  #
   ############
-  - {<< : *arm32_v5,          << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_v6,          << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_v7,          << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_v7_t,        << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_imx,         << : *stable-5_15,      << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_omap,        << : *stable-5_15,      << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_lpae_fp,     << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_allmod,      << : *stable-5_15,      << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_cfi,         << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allmod_lto,  << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm32_v5,          << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_v6,          << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_v7,          << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_v7_t,        << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_imx,         << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_omap,        << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_lpae_fp,     << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_allmod,      << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_cfi,         << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_allmod_lto,  << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
   # Fedora i686 build disabled: https://github.com/ClangBuiltLinux/linux/issues/1442
-  # - {<< : *i686_fedora,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *i386_suse,         << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *mips,              << : *stable-5_15,      << : *mips_llvm_full,  boot: true,  llvm_version: *llvm_12}
-  - {<< : *mipsel,            << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  # - {<< : *i686_fedora,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *i386_suse,         << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *mips,              << : *stable-5_15,      << : *mips_llvm_full,  boot: true,  << : *llvm_12}
+  - {<< : *mipsel,            << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
   # ppc32: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1345)
-  - {<< : *ppc32,             << : *stable-5_15,      << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_12}
-  - {<< : *ppc64le,           << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *ppc64le_fedora,    << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_12}
-  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_12}
-  - {<< : *riscv,             << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm,            boot: false, llvm_version: *llvm_12}
+  - {<< : *ppc32,             << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  << : *llvm_12}
+  - {<< : *ppc64le,           << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *ppc64le_fedora,    << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_12}
+  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_12}
+  - {<< : *riscv,             << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_12}
   # s390: Build disabled (https://lore.kernel.org/r/YMtib5hKVyNknZt3@osiris/)
-  # - {<< : *s390,              << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64,            << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_lto_full,   << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_lto_thin,   << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_kasan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_kcsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_ubsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_allmod,     << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *x86_64_allmod_lto, << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *x86_64_allno,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *x86_64_allyes,     << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *x86_64_arch,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_fedora,     << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_suse,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
+  # - {<< : *s390,              << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_12}
+  - {<< : *x86_64,            << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_lto_full,   << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_lto_thin,   << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_kasan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_kcsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_ubsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_allmod,     << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *x86_64_allmod_lto, << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *x86_64_allno,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *x86_64_allyes,     << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *x86_64_arch,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_fedora,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_suse,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
   ############
   #  5.10.y  #
   ############
-  - {<< : *arm32_v5,          << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_v6,          << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_v7,          << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_v7_t,        << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_allmod,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_allno,       << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_allyes,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64,             << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *mips,              << : *stable-5_10,      << : *mips_llvm,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_12}
-  - {<< : *ppc64le,           << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm32_v5,          << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_v6,          << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_v7,          << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_v7_t,        << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm32_allmod,      << : *stable-5_10,      << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_allno,       << : *stable-5_10,      << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_allyes,      << : *stable-5_10,      << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm64,             << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *mips,              << : *stable-5_10,      << : *mips_llvm,       boot: true,  << : *llvm_12}
+  - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  << : *llvm_12}
+  - {<< : *ppc64le,           << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_12}
   # https://github.com/ClangBuiltLinux/linux/issues/1023
   # https://github.com/ClangBuiltLinux/linux/issues/1143
-  - {<< : *riscv_no_efi,      << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_12}
-  - {<< : *s390,              << : *stable-5_10,      << : *clang,           boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64,            << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_allmod,     << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *x86_64_allno,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *x86_64_allyes,     << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
+  - {<< : *riscv_no_efi,      << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  << : *llvm_12}
+  - {<< : *s390,              << : *stable-5_10,      << : *clang,           boot: true,  << : *llvm_12}
+  - {<< : *x86_64,            << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_allmod,     << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *x86_64_allno,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *x86_64_allyes,     << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_12}
   #############
   #  Android  #
   #############
-  - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_allmod,      << : *android13-5_15,   << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_v7_t,        << : *android13-5_15,   << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_gki,         << : *android13-5_15,   << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_gki,        << : *android13-5_15,   << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_allmod,      << : *android13-5_10,   << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_v7_t,        << : *android13-5_10,   << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_gki,         << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_gki,        << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_allmod,      << : *android12-5_10,   << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_v7_t,        << : *android12-5_10,   << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_gki,         << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_gki,        << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm32_allmod,      << : *android12-5_4,    << : *llvm,            boot: false, llvm_version: *llvm_12}
-  - {<< : *arm32_v7_t,        << : *android12-5_4,    << : *llvm,            boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_gki,         << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_gki,        << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_gki,         << : *android-4_19,     << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_gki,        << : *android-4_19,     << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_cut,         << : *android-4_14,     << : *lld,             boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_cut,        << : *android-4_14,     << : *lld,             boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_cut,         << : *android-4_9,      << : *clang,           boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_cut,        << : *android-4_9,      << : *clang,           boot: true,  llvm_version: *llvm_12}
+  - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm32_allmod,      << : *android13-5_15,   << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_v7_t,        << : *android13-5_15,   << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm64_gki,         << : *android13-5_15,   << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_gki,        << : *android13-5_15,   << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm32_allmod,      << : *android13-5_10,   << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_v7_t,        << : *android13-5_10,   << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm64_gki,         << : *android13-5_10,   << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_gki,        << : *android13-5_10,   << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm32_allmod,      << : *android12-5_10,   << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_v7_t,        << : *android12-5_10,   << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm64_gki,         << : *android12-5_10,   << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_gki,        << : *android12-5_10,   << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm32_allmod,      << : *android12-5_4,    << : *llvm,            boot: false, << : *llvm_12}
+  - {<< : *arm32_v7_t,        << : *android12-5_4,    << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *arm64_gki,         << : *android12-5_4,    << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_gki,        << : *android12-5_4,    << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_gki,         << : *android-4_19,     << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_gki,        << : *android-4_19,     << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_cut,         << : *android-4_14,     << : *lld,             boot: true,  << : *llvm_12}
+  - {<< : *x86_64_cut,        << : *android-4_14,     << : *lld,             boot: true,  << : *llvm_12}
+  - {<< : *arm64_cut,         << : *android-4_9,      << : *clang,           boot: true,  << : *llvm_12}
+  - {<< : *x86_64_cut,        << : *android-4_9,      << : *clang,           boot: true,  << : *llvm_12}
   #########
   #  TIP  #
   #########
-  - {<< : *i386,              << : *tip,              << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64,            << : *tip,              << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *x86_64_allmod,     << : *tip,              << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *x86_64_allno,      << : *tip,              << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, llvm_version: *llvm_12}
+  - {<< : *i386,              << : *tip,              << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64,            << : *tip,              << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *x86_64_allmod,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *x86_64_allno,      << : *tip,              << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_12}
   ###########
   #  ARM64  #
   ###########
-  - {<< : *arm64,             << : *arm64-core,       << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_allmod,      << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allno,       << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allyes,      << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64,             << : *arm64-fixes,      << : *llvm_full,       boot: true,  llvm_version: *llvm_12}
-  - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allno,       << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
-  - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_12}
+  - {<< : *arm64,             << : *arm64-core,       << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_allmod,      << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_allno,       << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_allyes,      << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64,             << : *arm64-fixes,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_allno,       << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_12}
   #############
   #  LLVM 11  #
   #############
   ##############
   #  Mainline  #
   ##############
-  - {<< : *arm32_v5,          << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_v6,          << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_v7,          << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_v7_t,        << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_imx,         << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm32_omap,        << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm32_lpae_fp,     << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_allmod,      << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm32_allno,       << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm32_allyes,      << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm32_fedora,      << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_suse,        << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_kasan,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_ubsan,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allno,       << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_suse,        << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *hexagon,           << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *i686_fedora,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *i386_suse,         << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *mips,              << : *mainline,         << : *mips_llvm,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *mipsel,            << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm32_v5,          << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_v6,          << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_v7,          << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_v7_t,        << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_imx,         << : *mainline,         << : *llvm,            boot: false, << : *llvm_11}
+  - {<< : *arm32_omap,        << : *mainline,         << : *llvm,            boot: false, << : *llvm_11}
+  - {<< : *arm32_lpae_fp,     << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_allmod,      << : *mainline,         << : *llvm,            boot: false, << : *llvm_11}
+  - {<< : *arm32_allno,       << : *mainline,         << : *llvm,            boot: false, << : *llvm_11}
+  - {<< : *arm32_allyes,      << : *mainline,         << : *llvm,            boot: false, << : *llvm_11}
+  - {<< : *arm32_fedora,      << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_suse,        << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_kasan,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_kasan_sw,    << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_ubsan,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_allno,       << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *hexagon,           << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *i686_fedora,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *i386_suse,         << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *mips,              << : *mainline,         << : *mips_llvm,       boot: true,  << : *llvm_11}
+  - {<< : *mipsel,            << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
   # ppc32 and ppc64: Build disabled (https://gitlab.com/Linaro/tuxmake/-/issues/108)
-  # - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  # - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_11}
-  - {<< : *ppc64le,           << : *mainline,         << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_11}
-  - {<< : *ppc64le_fedora,    << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_11}
-  - {<< : *ppc64le_suse,      << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_11}
-  - {<< : *riscv,             << : *mainline,         << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *riscv_allmod,      << : *mainline,         << : *llvm,            boot: false, llvm_version: *llvm_11}
+  # - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
+  # - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  << : *llvm_11}
+  - {<< : *ppc64le,           << : *mainline,         << : *ppc64_llvm,      boot: true,  << : *llvm_11}
+  - {<< : *ppc64le_fedora,    << : *mainline,         << : *clang,           boot: true,  << : *llvm_11}
+  - {<< : *ppc64le_suse,      << : *mainline,         << : *clang,           boot: true,  << : *llvm_11}
+  - {<< : *riscv,             << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *riscv_allmod,      << : *mainline,         << : *llvm,            boot: false, << : *llvm_11}
   # s390: Build disabled (https://lore.kernel.org/r/YMtib5hKVyNknZt3@osiris/)
-  # - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_lto_thin,   << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_kasan,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_kcsan,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_ubsan,      << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_allmod,     << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *x86_64_allmod_lto, << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *x86_64_allno,      << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *x86_64_arch,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_fedora,     << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_suse,       << : *mainline,         << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  # - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  << : *llvm_11}
+  - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_lto_thin,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_kasan,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_kcsan,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_ubsan,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_allmod,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *x86_64_allmod_lto, << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *x86_64_allno,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *x86_64_arch,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_fedora,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_suse,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
   ##########
   #  Next  #
   ##########
-  - {<< : *arm32_v5,          << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_v6,          << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_v7,          << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_v7_t,        << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_imx,         << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm32_omap,        << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm32_lpae_fp,     << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_allmod,      << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm32_allno,       << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm32_allyes,      << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm32_fedora,      << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_suse,        << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_kasan_sw,    << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_ubsan,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_fedora,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_suse,        << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *i686_fedora,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *i386_suse,         << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *mips,              << : *next,             << : *mips_llvm,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *mipsel,            << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm32_v5,          << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_v6,          << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_v7,          << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_v7_t,        << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_imx,         << : *next,             << : *llvm,            boot: false, << : *llvm_11}
+  - {<< : *arm32_omap,        << : *next,             << : *llvm,            boot: false, << : *llvm_11}
+  - {<< : *arm32_lpae_fp,     << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_allmod,      << : *next,             << : *llvm,            boot: false, << : *llvm_11}
+  - {<< : *arm32_allno,       << : *next,             << : *llvm,            boot: false, << : *llvm_11}
+  - {<< : *arm32_allyes,      << : *next,             << : *llvm,            boot: false, << : *llvm_11}
+  - {<< : *arm32_fedora,      << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_suse,        << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_kasan_sw,    << : *next,             << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_ubsan,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_fedora,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *i686_fedora,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *i386_suse,         << : *next,             << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *mips,              << : *next,             << : *mips_llvm,       boot: true,  << : *llvm_11}
+  - {<< : *mipsel,            << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
   # ppc32 and ppc64: Build disabled (https://gitlab.com/Linaro/tuxmake/-/issues/108)
-  # - {<< : *ppc32,             << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  # - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_11}
-  - {<< : *ppc64le,           << : *next,             << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_11}
-  - {<< : *ppc64le_fedora,    << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_11}
-  - {<< : *ppc64le_suse,      << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_11}
-  - {<< : *riscv,             << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *riscv_allmod,      << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_11}
+  # - {<< : *ppc32,             << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
+  # - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  << : *llvm_11}
+  - {<< : *ppc64le,           << : *next,             << : *ppc64_llvm,      boot: true,  << : *llvm_11}
+  - {<< : *ppc64le_fedora,    << : *next,             << : *clang,           boot: true,  << : *llvm_11}
+  - {<< : *ppc64le_suse,      << : *next,             << : *clang,           boot: true,  << : *llvm_11}
+  - {<< : *riscv,             << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *riscv_allmod,      << : *next,             << : *llvm,            boot: false, << : *llvm_11}
   # s390: Build disabled (https://lore.kernel.org/r/YMtib5hKVyNknZt3@osiris/)
-  # - {<< : *s390,              << : *next,             << : *clang,           boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_lto_thin,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_kasan,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_kcsan,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_ubsan,      << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *x86_64_arch,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_fedora,     << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_suse,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  # - {<< : *s390,              << : *next,             << : *clang,           boot: true,  << : *llvm_11}
+  - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_lto_thin,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_kasan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_kcsan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_ubsan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *x86_64_arch,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_fedora,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_suse,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
   ############
   #  5.15.y  #
   ############
-  - {<< : *arm32_v5,          << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_v6,          << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_v7,          << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_v7_t,        << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_imx,         << : *stable-5_15,      << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm32_omap,        << : *stable-5_15,      << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm32_lpae_fp,     << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_allmod,      << : *stable-5_15,      << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allmod_lto,  << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *i686_fedora,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *i386_suse,         << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *mips,              << : *stable-5_15,      << : *mips_llvm,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *mipsel,            << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm32_v5,          << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_v6,          << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_v7,          << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_v7_t,        << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_imx,         << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_11}
+  - {<< : *arm32_omap,        << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_11}
+  - {<< : *arm32_lpae_fp,     << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_allmod,      << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_11}
+  - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_11}
+  - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_11}
+  - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_allmod_lto,  << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *i686_fedora,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *i386_suse,         << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *mips,              << : *stable-5_15,      << : *mips_llvm,       boot: true,  << : *llvm_11}
+  - {<< : *mipsel,            << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
   # ppc32 and ppc64: Build disabled (https://gitlab.com/Linaro/tuxmake/-/issues/108)
-  # - {<< : *ppc32,             << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  # - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_11}
-  - {<< : *ppc64le,           << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_11}
-  - {<< : *ppc64le_fedora,    << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_11}
-  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_11}
-  - {<< : *riscv,             << : *stable-5_15,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm,            boot: false, llvm_version: *llvm_11}
+  # - {<< : *ppc32,             << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
+  # - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  << : *llvm_11}
+  - {<< : *ppc64le,           << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  << : *llvm_11}
+  - {<< : *ppc64le_fedora,    << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_11}
+  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_11}
+  - {<< : *riscv,             << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_11}
   # s390: Build disabled (https://lore.kernel.org/r/YMtib5hKVyNknZt3@osiris/)
-  # - {<< : *s390,              << : *stable-5_15,      << : *clang,           boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64,            << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_lto_full,   << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_lto_thin,   << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_kasan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_kcsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_ubsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_allmod,     << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *x86_64_allmod_lto, << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *x86_64_allno,      << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *x86_64_allyes,     << : *stable-5_15,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *x86_64_arch,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_fedora,     << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_suse,       << : *stable-5_15,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
+  # - {<< : *s390,              << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_11}
+  - {<< : *x86_64,            << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_lto_full,   << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_lto_thin,   << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_kasan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_kcsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_ubsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_allmod,     << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *x86_64_allmod_lto, << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *x86_64_allno,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *x86_64_allyes,     << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *x86_64_arch,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_fedora,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_suse,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
   ############
   #  5.10.y  #
   ############
-  - {<< : *arm32_v5,          << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_v6,          << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_v7,          << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_v7_t,        << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm32_allmod,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm32_allno,       << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm32_allyes,      << : *stable-5_10,      << : *llvm,            boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64,             << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *mips,              << : *stable-5_10,      << : *mips_llvm,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
+  - {<< : *arm32_v5,          << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_v6,          << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_v7,          << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_v7_t,        << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *arm32_allmod,      << : *stable-5_10,      << : *llvm,            boot: false, << : *llvm_11}
+  - {<< : *arm32_allno,       << : *stable-5_10,      << : *llvm,            boot: false, << : *llvm_11}
+  - {<< : *arm32_allyes,      << : *stable-5_10,      << : *llvm,            boot: false, << : *llvm_11}
+  - {<< : *arm64,             << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *mips,              << : *stable-5_10,      << : *mips_llvm,       boot: true,  << : *llvm_11}
+  - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_11}
   # ppc32 and ppc64: Build disabled (https://gitlab.com/Linaro/tuxmake/-/issues/108)
-  # - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
-  # - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  llvm_version: *llvm_11}
-  - {<< : *ppc64le,           << : *stable-5_10,      << : *llvm,            boot: true,  llvm_version: *llvm_11}
+  # - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_11}
+  # - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  << : *llvm_11}
+  - {<< : *ppc64le,           << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_11}
   # https://github.com/ClangBuiltLinux/linux/issues/1023
   # https://github.com/ClangBuiltLinux/linux/issues/1143
-  - {<< : *riscv_no_efi,      << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  llvm_version: *llvm_11}
-  - {<< : *s390,              << : *stable-5_10,      << : *clang,           boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64,            << : *stable-5_10,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_allmod,     << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *x86_64_allno,      << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *x86_64_allyes,     << : *stable-5_10,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
+  - {<< : *riscv_no_efi,      << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  << : *llvm_11}
+  - {<< : *s390,              << : *stable-5_10,      << : *clang,           boot: true,  << : *llvm_11}
+  - {<< : *x86_64,            << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_allmod,     << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *x86_64_allno,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *x86_64_allyes,     << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_11}
   #########
   #  TIP  #
   #########
-  - {<< : *i386,              << : *tip,              << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64,            << : *tip,              << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *x86_64_allmod,     << : *tip,              << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *x86_64_allno,      << : *tip,              << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, llvm_version: *llvm_11}
+  - {<< : *i386,              << : *tip,              << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64,            << : *tip,              << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *x86_64_allmod,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *x86_64_allno,      << : *tip,              << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_11}
   ###########
   #  ARM64  #
   ###########
-  - {<< : *arm64,             << : *arm64-core,       << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_allmod,      << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allno,       << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allyes,      << : *arm64-core,       << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64,             << : *arm64-fixes,      << : *llvm_full,       boot: true,  llvm_version: *llvm_11}
-  - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allno,       << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
-  - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *llvm_full,       boot: false, llvm_version: *llvm_11}
+  - {<< : *arm64,             << : *arm64-core,       << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_allmod,      << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_allno,       << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_allyes,      << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64,             << : *arm64-fixes,      << : *llvm_full,       boot: true,  << : *llvm_11}
+  - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_allno,       << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_11}
   ##################
   #  Android LLVM  #
   ##################
   ##########
   #  Next  #
   ##########
-  - {<< : *arm32_v5,          << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
+  - {<< : *arm32_v5,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
   # Certain ARM builds disabled until next Android LLVM release: https://android-review.googlesource.com/c/toolchain/llvm_android/+/1983048
-  # - {<< : *arm32_v6,          << : *next,             << : *llvm,            boot: true,  llvm_version: *llvm_android}
-  # - {<< : *arm32_v7,          << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  # - {<< : *arm32_v7_t,        << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *arm32_allmod,      << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_android}
-  - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_android}
-  - {<< : *arm32_allyes,      << : *next,             << : *llvm,            boot: false, llvm_version: *llvm_android}
-  - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_android}
-  - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_android}
-  - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_android}
-  - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_android}
-  - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *x86_64_lto_thin,   << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_android}
-  - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_android}
-  - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_android}
-  - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, llvm_version: *llvm_android}
-  - {<< : *x86_64_gcov,       << : *next,             << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
+  # - {<< : *arm32_v6,          << : *next,             << : *llvm,            boot: true,  << : *llvm_android}
+  # - {<< : *arm32_v7,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
+  # - {<< : *arm32_v7_t,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *arm32_allmod,      << : *next,             << : *llvm,            boot: false, << : *llvm_android}
+  - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
+  - {<< : *arm32_allyes,      << : *next,             << : *llvm,            boot: false, << : *llvm_android}
+  - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
+  - {<< : *arm64_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
+  - {<< : *arm64_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
+  - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
+  - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *x86_64_lto_thin,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
+  - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
+  - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
+  - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
+  - {<< : *x86_64_gcov,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
   #############
   #  Android  #
   #############
-  - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, llvm_version: *llvm_android}
+  - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, << : *llvm_android}
   # Certain ARM builds disabled until next Android LLVM release: https://android-review.googlesource.com/c/toolchain/llvm_android/+/1983048
-  # - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *arm32_allmod,      << : *android13-5_15,   << : *llvm_full,       boot: false, llvm_version: *llvm_android}
-  - {<< : *arm32_v7_t,        << : *android13-5_15,   << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *arm64_gki,         << : *android13-5_15,   << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *x86_64_gki,        << : *android13-5_15,   << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *arm32_allmod,      << : *android13-5_10,   << : *llvm_full,       boot: false, llvm_version: *llvm_android}
-  - {<< : *arm32_v7_t,        << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *arm64_gki,         << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *x86_64_gki,        << : *android13-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *arm32_allmod,      << : *android12-5_10,   << : *llvm_full,       boot: false, llvm_version: *llvm_android}
-  - {<< : *arm32_v7_t,        << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *arm64_gki,         << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *x86_64_gki,        << : *android12-5_10,   << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *arm32_allmod,      << : *android12-5_4,    << : *llvm_full,       boot: false, llvm_version: *llvm_android}
-  - {<< : *arm32_v7_t,        << : *android12-5_4,    << : *llvm,            boot: true,  llvm_version: *llvm_android}
-  - {<< : *arm64_gki,         << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *x86_64_gki,        << : *android12-5_4,    << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *arm64_gki,         << : *android-4_19,     << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *x86_64_gki,        << : *android-4_19,     << : *llvm_full,       boot: true,  llvm_version: *llvm_android}
-  - {<< : *arm64_cut,         << : *android-4_14,     << : *lld,             boot: true,  llvm_version: *llvm_android}
-  - {<< : *x86_64_cut,        << : *android-4_14,     << : *lld,             boot: true,  llvm_version: *llvm_android}
-  - {<< : *arm64_cut,         << : *android-4_9,      << : *clang,           boot: true,  llvm_version: *llvm_android}
-  - {<< : *x86_64_cut,        << : *android-4_9,      << : *clang,           boot: true,  llvm_version: *llvm_android}
+  # - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *arm32_allmod,      << : *android13-5_15,   << : *llvm_full,       boot: false, << : *llvm_android}
+  - {<< : *arm32_v7_t,        << : *android13-5_15,   << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *arm64_gki,         << : *android13-5_15,   << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *x86_64_gki,        << : *android13-5_15,   << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *arm32_allmod,      << : *android13-5_10,   << : *llvm_full,       boot: false, << : *llvm_android}
+  - {<< : *arm32_v7_t,        << : *android13-5_10,   << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *arm64_gki,         << : *android13-5_10,   << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *x86_64_gki,        << : *android13-5_10,   << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *arm32_allmod,      << : *android12-5_10,   << : *llvm_full,       boot: false, << : *llvm_android}
+  - {<< : *arm32_v7_t,        << : *android12-5_10,   << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *arm64_gki,         << : *android12-5_10,   << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *x86_64_gki,        << : *android12-5_10,   << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *arm32_allmod,      << : *android12-5_4,    << : *llvm_full,       boot: false, << : *llvm_android}
+  - {<< : *arm32_v7_t,        << : *android12-5_4,    << : *llvm,            boot: true,  << : *llvm_android}
+  - {<< : *arm64_gki,         << : *android12-5_4,    << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *x86_64_gki,        << : *android12-5_4,    << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *arm64_gki,         << : *android-4_19,     << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *x86_64_gki,        << : *android-4_19,     << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *arm64_cut,         << : *android-4_14,     << : *lld,             boot: true,  << : *llvm_android}
+  - {<< : *x86_64_cut,        << : *android-4_14,     << : *lld,             boot: true,  << : *llvm_android}
+  - {<< : *arm64_cut,         << : *android-4_9,      << : *clang,           boot: true,  << : *llvm_android}
+  - {<< : *x86_64_cut,        << : *android-4_9,      << : *clang,           boot: true,  << : *llvm_android}

--- a/generator.yml
+++ b/generator.yml
@@ -32,6 +32,7 @@ schedules:
   - &daily_midnight {schedule: "0 0 * * *"}
   - &daily_six      {schedule: "0 6 * * *"}
   - &daily_noon     {schedule: "0 12 * * *"}
+  - &daily_eighteen {schedule: "0 18 * * *"}
   # -next updates M-F in the evening AEST, which is usually around 12:00PM UTC
   - &weekdays       {schedule: "0 12 * * 1,2,3,4,5"}
   - &sundays        {schedule: "0 0 * * 0"}
@@ -132,19 +133,19 @@ tree_schedules:
   - &android-4_9_llvm_android      {<< : *llvm_android, << : *android-4_9,      << : *daily_six}
   - &tip_llvm_tot                  {<< : *llvm_tot,     << : *tip,              << : *daily_midnight}
   - &tip_llvm_latest               {<< : *llvm_latest,  << : *tip,              << : *daily_midnight}
-  - &tip_llvm_13                   {<< : *llvm_13,      << : *tip,              << : *daily_midnight}
-  - &tip_llvm_12                   {<< : *llvm_12,      << : *tip,              << : *daily_midnight}
-  - &tip_llvm_11                   {<< : *llvm_11,      << : *tip,              << : *daily_midnight}
+  - &tip_llvm_13                   {<< : *llvm_13,      << : *tip,              << : *daily_eighteen}
+  - &tip_llvm_12                   {<< : *llvm_12,      << : *tip,              << : *daily_eighteen}
+  - &tip_llvm_11                   {<< : *llvm_11,      << : *tip,              << : *daily_eighteen}
   - &arm64-core_llvm_tot           {<< : *llvm_tot,     << : *arm64-core,       << : *daily_midnight}
   - &arm64-core_llvm_latest        {<< : *llvm_latest,  << : *arm64-core,       << : *daily_midnight}
-  - &arm64-core_llvm_13            {<< : *llvm_13,      << : *arm64-core,       << : *daily_midnight}
-  - &arm64-core_llvm_12            {<< : *llvm_12,      << : *arm64-core,       << : *daily_midnight}
-  - &arm64-core_llvm_11            {<< : *llvm_11,      << : *arm64-core,       << : *daily_midnight}
+  - &arm64-core_llvm_13            {<< : *llvm_13,      << : *arm64-core,       << : *daily_eighteen}
+  - &arm64-core_llvm_12            {<< : *llvm_12,      << : *arm64-core,       << : *daily_eighteen}
+  - &arm64-core_llvm_11            {<< : *llvm_11,      << : *arm64-core,       << : *daily_eighteen}
   - &arm64-fixes_llvm_tot          {<< : *llvm_tot,     << : *arm64-fixes,      << : *daily_midnight}
   - &arm64-fixes_llvm_latest       {<< : *llvm_latest,  << : *arm64-fixes,      << : *daily_midnight}
-  - &arm64-fixes_llvm_13           {<< : *llvm_13,      << : *arm64-fixes,      << : *daily_midnight}
-  - &arm64-fixes_llvm_12           {<< : *llvm_12,      << : *arm64-fixes,      << : *daily_midnight}
-  - &arm64-fixes_llvm_11           {<< : *llvm_11,      << : *arm64-fixes,      << : *daily_midnight}
+  - &arm64-fixes_llvm_13           {<< : *llvm_13,      << : *arm64-fixes,      << : *daily_eighteen}
+  - &arm64-fixes_llvm_12           {<< : *llvm_12,      << : *arm64-fixes,      << : *daily_eighteen}
+  - &arm64-fixes_llvm_11           {<< : *llvm_11,      << : *arm64-fixes,      << : *daily_eighteen}
 architectures:
  - &arm-arch     arm
  - &arm64-arch   arm64


### PR DESCRIPTION
This is an alternative to #309.

Instead of moving the cron schedule logic into `generate_workflow.py`, it stays in `generator.yml`, which is more verbose and declarative, but gives us more accurate control over the schedule.
