### PR TITLE
Fix up check_logs.py and messages/documentation after scripts move

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ to it. Ex.
 
 ```
 # Generate just next and mainline TuxSuite and GitHub Action workflows
-$ ./generate.sh next mainline
+$ scripts/generate.sh next mainline
 
 # Regenerate all of the current TuxSuite and GitHub Action workflows
-$ ./generate.sh all
+$ scripts/generate.sh all
 ```
 
 The CI the child workflows run can be rerun locally via:

--- a/check_logs.py
+++ b/check_logs.py
@@ -193,7 +193,7 @@ def print_clang_info(build):
     metadata_json = json.loads(open(metadata_file).read())
     print_yellow("Printing clang-nightly checkout date and hash")
     subprocess.run([
-        "./parse-debian-clang.sh", "--print-info", "--version-string",
+        "./scripts/parse-debian-clang.sh", "--print-info", "--version-string",
         metadata_json["compiler"]["version_full"]
     ])
 

--- a/scripts/check-patches.sh
+++ b/scripts/check-patches.sh
@@ -61,7 +61,7 @@ for workflow in "${repo}"/.github/workflows/*.yml; do
         echo
         echo "Regenerate the TuxSuite and workflow files:"
         echo
-        echo "$ ./generate.sh ${tree}"
+        echo "$ scripts/generate.sh ${tree}"
         exit 1
     fi
 
@@ -72,7 +72,7 @@ for workflow in "${repo}"/.github/workflows/*.yml; do
         echo
         echo "Regenerate the TuxSuite and workflow files:"
         echo
-        echo "$ ./generate.sh ${tree}"
+        echo "$ scripts/generate.sh ${tree}"
         echo
         echo "or remove the patches if they are no longer being used."
         exit 1

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -42,11 +42,11 @@ if ${CHECK:=false}; then
     if [[ -n "$(git --no-optional-locks status -uno --porcelain 2>/dev/null)" ]]; then
         set +x
         echo
-        echo "Running 'generate.sh all' generated the following diff:"
+        echo "Running 'scripts/generate.sh all' generated the following diff:"
         echo
         git diff HEAD
         echo
-        echo "Please run 'generate.sh all' locally and commit then push the changes it creates!"
+        echo "Please run 'scripts/generate.sh all' locally and commit then push the changes it creates!"
         exit 1
     fi
 fi


### PR DESCRIPTION
This fixes a few places where `.sh` scripts are being referenced by the old location, namely `check_logs.py`, which is causing the CI to fail currently.

NOTE: I intend to merge this without explicit approval once the checks pass to attempt to prevent the CI from going completely red.
