### PR TITLE
Build most powerpc64le configs with LLVM=1 LLVM_IAS=1

### DIFF
--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -431,10 +431,10 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b83e803d7dd6c3201bea198a418a70ce:
+  _184d8d4f81b0cb5c1f31ff3bfa495255:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
@@ -732,10 +732,10 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _08fb5d721ebe5360162eab624a731362:
+  _3604dd182915d18674b48e45803faa77:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
@@ -751,10 +751,10 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _cf214bc1ac3d0d1e5d672c288d3a49e6:
+  _03b8db92013edc5ad35714594a030940:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     env:
       ARCH: powerpc
       LLVM_VERSION: 15

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -431,10 +431,10 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b83e803d7dd6c3201bea198a418a70ce:
+  _184d8d4f81b0cb5c1f31ff3bfa495255:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
@@ -751,10 +751,10 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _08fb5d721ebe5360162eab624a731362:
+  _3604dd182915d18674b48e45803faa77:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
@@ -770,10 +770,10 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _cf214bc1ac3d0d1e5d672c288d3a49e6:
+  _3f59e2fc30565fc140588eaca2035b8c:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     env:
       ARCH: powerpc
       LLVM_VERSION: 15

--- a/generator.yml
+++ b/generator.yml
@@ -308,9 +308,10 @@ builds:
   - {<< : *mipsel,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: true,  << : *llvm_tot}
   - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  << : *llvm_tot}
-  - {<< : *ppc64le,           << : *mainline,         << : *llvm,            boot: true,  << : *llvm_tot}
-  - {<< : *ppc64le_fedora,    << : *mainline,         << : *clang,           boot: true,  << : *llvm_tot}
-  - {<< : *ppc64le_suse,      << : *mainline,         << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le_fedora,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  # SUSE ppc64le build with LLVM_IAS=0: https://github.com/ClangBuiltLinux/linux/issues/1418
+  - {<< : *ppc64le_suse,      << : *mainline,         << : *llvm,            boot: true,  << : *llvm_tot}
   - {<< : *riscv,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  << : *llvm_tot}
@@ -369,9 +370,9 @@ builds:
   - {<< : *mipsel,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *ppc32,             << : *next,             << : *llvm,            boot: true,  << : *llvm_tot}
   - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  << : *llvm_tot}
-  - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  << : *llvm_tot}
-  - {<< : *ppc64le_fedora,    << : *next,             << : *clang,           boot: true,  << : *llvm_tot}
-  - {<< : *ppc64le_suse,      << : *next,             << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le_fedora,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le_suse,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *riscv_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *s390,              << : *next,             << : *clang,           boot: true,  << : *llvm_tot}

--- a/tuxsuite/mainline-clang-15.tux.yml
+++ b/tuxsuite/mainline-clang-15.tux.yml
@@ -266,7 +266,7 @@ sets:
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
-      LLVM_IAS: 0
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: riscv
@@ -445,7 +445,8 @@ sets:
     - kernel
     kernel_image: zImage.epapr
     make_variables:
-      LLVM_IAS: 0
+      LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: powerpc
@@ -455,6 +456,7 @@ sets:
     - kernel
     kernel_image: zImage.epapr
     make_variables:
+      LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master

--- a/tuxsuite/next-clang-15.tux.yml
+++ b/tuxsuite/next-clang-15.tux.yml
@@ -266,7 +266,7 @@ sets:
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
-      LLVM_IAS: 0
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: riscv
@@ -458,7 +458,8 @@ sets:
     - kernel
     kernel_image: zImage.epapr
     make_variables:
-      LLVM_IAS: 0
+      LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: powerpc
@@ -468,7 +469,8 @@ sets:
     - kernel
     kernel_image: zImage.epapr
     make_variables:
-      LLVM_IAS: 0
+      LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: s390


### PR DESCRIPTION
On mainline, SUSE's configuration needs to build with `LLVM_IAS=0` because
of https://github.com/ClangBuiltLinux/linux/issues/1418.

Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/265
