### PR TITLE
check_logs.py: Use proper syntax for removing problem matcher

### DIFF
--- a/check_logs.py
+++ b/check_logs.py
@@ -223,7 +223,7 @@ def run_boot(build):
            "CONFIG_KCSAN_KUNIT_TEST=y" in build["kconfig"]:
             print_yellow(
                 "Disabling Oops problem matcher under Sanitizer KUnit build")
-            print("::remove-matcher owner=linux-kernel-oopses")
+            print("::remove-matcher owner=linux-kernel-oopses::")
 
     # Before spawning a process with potentially different IO buffering,
     # flush the existing buffers so output is ordered correctly.


### PR DESCRIPTION
The oopses problem matcher is not getting removed for KUnit runs as it
should:

https://github.com/ClangBuiltLinux/continuous-integration2/actions/runs/1964728851

According to GitHub's official documentation, there should be two colons
at the end of the remove-matcher command but they are not present in the
check_logs.py print out. Add them to hopefully fix the problem matcher
getting disabled.

Link: https://github.com/actions/toolkit/blob/main/docs/commands.md#problem-matchers
