### PR TITLE
Revert 4eec5c448d09646659806afdd42b080a7002620f for stable

### DIFF
--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -431,10 +431,10 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _184d8d4f81b0cb5c1f31ff3bfa495255:
+  _b83e803d7dd6c3201bea198a418a70ce:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
@@ -732,10 +732,10 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3604dd182915d18674b48e45803faa77:
+  _08fb5d721ebe5360162eab624a731362:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
@@ -751,10 +751,10 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3f59e2fc30565fc140588eaca2035b8c:
+  _cf214bc1ac3d0d1e5d672c288d3a49e6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     env:
       ARCH: powerpc
       LLVM_VERSION: 15

--- a/generator.yml
+++ b/generator.yml
@@ -437,9 +437,9 @@ builds:
   - {<< : *mipsel,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *ppc32,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_tot}
   - {<< : *ppc64,             << : *stable,           << : *ppc64_llvm,      boot: true,  << : *llvm_tot}
-  - {<< : *ppc64le,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *ppc64le_fedora,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *ppc64le_suse,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le,           << : *stable,           << : *llvm,            boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le_fedora,    << : *stable,           << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le_suse,      << : *stable,           << : *clang,           boot: true,  << : *llvm_tot}
   - {<< : *riscv,             << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *riscv_allmod,      << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *s390,              << : *stable,           << : *clang,           boot: true,  << : *llvm_tot}

--- a/tuxsuite/stable-clang-15.tux.yml
+++ b/tuxsuite/stable-clang-15.tux.yml
@@ -266,7 +266,7 @@ sets:
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
-      LLVM_IAS: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.17.y
     target_arch: riscv
@@ -445,8 +445,7 @@ sets:
     - kernel
     kernel_image: zImage.epapr
     make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.17.y
     target_arch: powerpc
@@ -456,8 +455,7 @@ sets:
     - kernel
     kernel_image: zImage.epapr
     make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
+      LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.17.y
     target_arch: s390


### PR DESCRIPTION
We are applying patches to make 4eec5c448d09646659806afdd42b080a7002620f work in mainline. Given that the patches are unlikely to be stable material when merged, just revert 4eec5c448d09646659806afdd42b080a7002620f for stable.

Link: https://github.com/ClangBuiltLinux/continuous-integration2/actions/runs/2028368723
