### PR TITLE
Update AOSP LLVM builds

### DIFF
--- a/.github/workflows/android-mainline-clang-android.yml
+++ b/.github/workflows/android-mainline-clang-android.yml
@@ -32,6 +32,25 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
+  _351114799740fe3119a3b2ce6956a6bb:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=android multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    env:
+      ARCH: arm
+      LLVM_VERSION: android
+      BOOT: 1
+      CONFIG: multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    container: ghcr.io/clangbuiltlinux/qemu
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _092d18d4defe742a9f23a18a7d2eebc6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/next-clang-android.yml
+++ b/.github/workflows/next-clang-android.yml
@@ -51,6 +51,63 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _a82d5da76edb25de07265b1189803b21:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=android aspeed_g5_defconfig
+    env:
+      ARCH: arm
+      LLVM_VERSION: android
+      BOOT: 1
+      CONFIG: aspeed_g5_defconfig
+    container: ghcr.io/clangbuiltlinux/qemu
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
+  _87ceb80e8738ca51446e7e1857d39b9c:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=android multi_v7_defconfig
+    env:
+      ARCH: arm
+      LLVM_VERSION: android
+      BOOT: 1
+      CONFIG: multi_v7_defconfig
+    container: ghcr.io/clangbuiltlinux/qemu
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
+  _351114799740fe3119a3b2ce6956a6bb:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=android multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    env:
+      ARCH: arm
+      LLVM_VERSION: android
+      BOOT: 1
+      CONFIG: multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
+    container: ghcr.io/clangbuiltlinux/qemu
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _300e2471179b5487f89662afe7517d23:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
@@ -371,44 +428,6 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _191bb4a446201921f3ea6bfa0e9b122f:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n
-    env:
-      ARCH: x86_64
-      LLVM_VERSION: android
-      BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
-    container: ghcr.io/clangbuiltlinux/qemu
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
-  _bf13eb4d6ca658a087deadacb13963ec:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
-    env:
-      ARCH: x86_64
-      LLVM_VERSION: android
-      BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
-    container: ghcr.io/clangbuiltlinux/qemu
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _00318ac7d697c430359de1e4e903d7eb:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
@@ -418,25 +437,6 @@ jobs:
       LLVM_VERSION: android
       BOOT: 0
       CONFIG: allnoconfig
-    container: ghcr.io/clangbuiltlinux/qemu
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
-  _40dc138ef3ff6bc3203c6d3c9a524e48:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allyesconfig+CONFIG_WERROR=n
-    env:
-      ARCH: x86_64
-      LLVM_VERSION: android
-      BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
     container: ghcr.io/clangbuiltlinux/qemu
     steps:
     - uses: actions/checkout@v2

--- a/generator.yml
+++ b/generator.yml
@@ -1965,10 +1965,9 @@ builds:
   #  Next  #
   ##########
   - {<< : *arm32_v5,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
-  # Certain ARM builds disabled until next Android LLVM release: https://android-review.googlesource.com/c/toolchain/llvm_android/+/1983048
-  # - {<< : *arm32_v6,          << : *next,             << : *llvm,            boot: true,  << : *llvm_android}
-  # - {<< : *arm32_v7,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
-  # - {<< : *arm32_v7_t,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *arm32_v6,          << : *next,             << : *llvm,            boot: true,  << : *llvm_android}
+  - {<< : *arm32_v7,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *arm32_v7_t,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
   - {<< : *arm32_allmod,      << : *next,             << : *llvm,            boot: false, << : *llvm_android}
   - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
   - {<< : *arm32_allyes,      << : *next,             << : *llvm,            boot: false, << : *llvm_android}
@@ -1993,8 +1992,7 @@ builds:
   #  Android  #
   #############
   - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, << : *llvm_android}
-  # Certain ARM builds disabled until next Android LLVM release: https://android-review.googlesource.com/c/toolchain/llvm_android/+/1983048
-  # - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
   - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
   - {<< : *arm32_allmod,      << : *android13-5_15,   << : *llvm_full,       boot: false, << : *llvm_android}

--- a/generator.yml
+++ b/generator.yml
@@ -1983,10 +1983,11 @@ builds:
   - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
   - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
   - {<< : *x86_64_lto_thin,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
-  - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
-  - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
+  # x86_64 all{mod,yes}config disabled: https://github.com/ClangBuiltLinux/linux/issues/1606
+  # - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
+  # - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
   - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
-  - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
+  # - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
   - {<< : *x86_64_gcov,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
   #############
   #  Android  #

--- a/tuxsuite/android-mainline-clang-android.tux.yml
+++ b/tuxsuite/android-mainline-clang-android.tux.yml
@@ -8,6 +8,18 @@ sets:
   builds:
   - git_repo: https://android.googlesource.com/kernel/common.git
     git_ref: android-mainline
+    target_arch: arm
+    toolchain: clang-android
+    kconfig:
+    - multi_v7_defconfig
+    - CONFIG_THUMB2_KERNEL=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://android.googlesource.com/kernel/common.git
+    git_ref: android-mainline
     target_arch: arm64
     toolchain: clang-android
     kconfig: gki_defconfig

--- a/tuxsuite/next-clang-android.tux.yml
+++ b/tuxsuite/next-clang-android.tux.yml
@@ -19,6 +19,39 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
+    target_arch: arm
+    toolchain: clang-android
+    kconfig: aspeed_g5_defconfig
+    targets:
+    - kernel
+    - dtbs
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 0
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+    git_ref: master
+    target_arch: arm
+    toolchain: clang-android
+    kconfig: multi_v7_defconfig
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+    git_ref: master
+    target_arch: arm
+    toolchain: clang-android
+    kconfig:
+    - multi_v7_defconfig
+    - CONFIG_THUMB2_KERNEL=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
+    git_ref: master
     target_arch: arm64
     toolchain: clang-android
     kconfig: defconfig
@@ -209,46 +242,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-android
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
-    git_ref: master
-    target_arch: x86_64
-    toolchain: clang-android
-    kconfig:
-    - allmodconfig
-    - CONFIG_GCOV_KERNEL=n
-    - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
-    - CONFIG_LTO_CLANG_THIN=y
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
-    git_ref: master
-    target_arch: x86_64
-    toolchain: clang-android
     kconfig: allnoconfig
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
-    git_ref: master
-    target_arch: x86_64
-    toolchain: clang-android
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
     targets:
     - default
     make_variables:


### PR DESCRIPTION
We can re-enable the disabled ARM builds because the compiler has been upgraded.

With the upgrade, we now trigger the ld.lld .plt bug for CONFIG_X86_KERNEL_IBT, so the builds that enable that config need to be disabled until the next compiler upgrade.
