### PR TITLE
patches: mainline: Add -Wimplicit-fallthrough fix for KVM

### DIFF
--- a/patches/mainline/20220322_nathan_kvm_x86_fix_clang_wimplicit_fallthrough_in_do_host_cpuid.patch
+++ b/patches/mainline/20220322_nathan_kvm_x86_fix_clang_wimplicit_fallthrough_in_do_host_cpuid.patch
@@ -1,0 +1,57 @@
+From git@z Thu Jan  1 00:00:00 1970
+Subject: [PATCH] KVM: x86: Fix clang -Wimplicit-fallthrough in do_host_cpuid()
+From: Nathan Chancellor <nathan@kernel.org>
+Date: Tue, 22 Mar 2022 08:29:06 -0700
+Message-Id: <20220322152906.112164-1-nathan@kernel.org>
+To: Paolo Bonzini <pbonzini@redhat.com>
+Cc: kvm@vger.kernel.org, linux-kernel@vger.kernel.org, llvm@lists.linux.dev, Nathan Chancellor <nathan@kernel.org>, kernel test robot <lkp@intel.com>
+List-Id: <llvm.lists.linux.dev>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+Clang warns:
+
+  arch/x86/kvm/cpuid.c:739:2: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
+          default:
+          ^
+  arch/x86/kvm/cpuid.c:739:2: note: insert 'break;' to avoid fall-through
+          default:
+          ^
+          break;
+  1 error generated.
+
+Clang is a little more pedantic than GCC, which does not warn when
+falling through to a case that is just break or return. Clang's version
+is more in line with the kernel's own stance in deprecated.rst, which
+states that all switch/case blocks must end in either break,
+fallthrough, continue, goto, or return. Add the missing break to silence
+the warning.
+
+Fixes: f144c49e8c39 ("KVM: x86: synthesize CPUID leaf 0x80000021h if useful")
+Reported-by: kernel test robot <lkp@intel.com>
+Signed-off-by: Nathan Chancellor <nathan@kernel.org>
+Link: https://lore.kernel.org/r/20220322152906.112164-1-nathan@kernel.org
+---
+ arch/x86/kvm/cpuid.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/x86/kvm/cpuid.c b/arch/x86/kvm/cpuid.c
+index 58b0b4e0263c..a3c87d2882ad 100644
+--- a/arch/x86/kvm/cpuid.c
++++ b/arch/x86/kvm/cpuid.c
+@@ -735,6 +735,7 @@ static struct kvm_cpuid_entry2 *do_host_cpuid(struct kvm_cpuid_array *array,
+ 			if (function > READ_ONCE(max_cpuid_80000000))
+ 				return entry;
+ 		}
++		break;
+ 
+ 	default:
+ 		break;
+
+base-commit: c9b8fecddb5bb4b67e351bbaeaa648a6f7456912
+
+-- 
+2.35.1
+
+

--- a/patches/mainline/series
+++ b/patches/mainline/series
@@ -1,2 +1,3 @@
 0001-powerpc-32-Remove-remaining-.stabs-annotations.patch
 0001-powerpc-64-Add-UADDR64-relocation-support.patch
+20220322_nathan_kvm_x86_fix_clang_wimplicit_fallthrough_in_do_host_cpuid.patch


### PR DESCRIPTION
KVM can enable -Werror independent of CONFIG_WERROR, which happens with
our allmodconfig + ThinLTO builds. Keep them green by applying this
already queued patch.
