### PR TITLE
check_logs.py: Set execute bit for UML images before running 'boot-uml.sh'

### DIFF
--- a/check_logs.py
+++ b/check_logs.py
@@ -208,6 +208,8 @@ def run_boot(build):
     kernel_image = cwd() + "/" + get_image_name()
     if cbl_arch == "um":
         boot_cmd = ["./boot-utils/boot-uml.sh"]
+        # The execute bit needs to be set to avoid "Permission denied" errors
+        os.chmod(kernel_img, 0o755)
     else:
         boot_cmd = ["./boot-utils/boot-qemu.sh", "-a", cbl_arch]
     boot_cmd += ["-k", kernel_image]


### PR DESCRIPTION
Otherwise, we will run into "Permission denied" errors.

Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/349
Link: https://github.com/ClangBuiltLinux/continuous-integration2/runs/5851165483?check_suite_focus=true
