### PR TITLE
Enable ARCH=hexagon allmodconfig on 5.15

### DIFF
--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -1114,6 +1114,27 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _ac59a19d0d87514204c03df7f611c521:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    env:
+      ARCH: hexagon
+      LLVM_VERSION: 13
+      BOOT: 0
+      CONFIG: allmodconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _c3c4f67a014e1c3e5f3e9dca28d684ea:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -1114,6 +1114,27 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _e606f3957a2810671c53ac83d3ab6b75:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    env:
+      ARCH: hexagon
+      LLVM_VERSION: 14
+      BOOT: 0
+      CONFIG: allmodconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _d95abc502ea347d9e174e4ada03a7ee5:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -1114,6 +1114,27 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _3665341be03a4a05bfabdd1bc9933c7c:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
+    env:
+      ARCH: hexagon
+      LLVM_VERSION: 15
+      BOOT: 0
+      CONFIG: allmodconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _5173235a7c271979a177be1eb5cb40b0:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs

--- a/generator.yml
+++ b/generator.yml
@@ -484,6 +484,7 @@ builds:
   - {<< : *arm64_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *hexagon_allmod,    << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *i386_suse,         << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *mips,              << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -841,6 +842,7 @@ builds:
   - {<< : *arm64_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *hexagon_allmod,    << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *i386_suse,         << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *mips,              << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -1197,6 +1199,7 @@ builds:
   - {<< : *arm64_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *hexagon_allmod,    << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *i386_suse,         << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *mips,              << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}

--- a/tuxsuite/5.15-clang-13.tux.yml
+++ b/tuxsuite/5.15-clang-13.tux.yml
@@ -593,6 +593,16 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.15.y
+    target_arch: hexagon
+    toolchain: clang-13
+    kconfig: allmodconfig
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+    git_ref: linux-5.15.y
     target_arch: riscv
     toolchain: clang-13
     kconfig:

--- a/tuxsuite/5.15-clang-14.tux.yml
+++ b/tuxsuite/5.15-clang-14.tux.yml
@@ -593,6 +593,16 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.15.y
+    target_arch: hexagon
+    toolchain: clang-14
+    kconfig: allmodconfig
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+    git_ref: linux-5.15.y
     target_arch: riscv
     toolchain: clang-14
     kconfig:

--- a/tuxsuite/5.15-clang-15.tux.yml
+++ b/tuxsuite/5.15-clang-15.tux.yml
@@ -593,6 +593,16 @@ sets:
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
     git_ref: linux-5.15.y
+    target_arch: hexagon
+    toolchain: clang-nightly
+    kconfig: allmodconfig
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+    git_ref: linux-5.15.y
     target_arch: riscv
     toolchain: clang-nightly
     kconfig:


### PR DESCRIPTION
I am not sure why this was not enabled already but it builds cleanly so
enable it for more stable coverage.

NOTE: This currently requires https://lore.kernel.org/YliEOSL8z3%2Fs7DGG@dev-arch.thelio-3990X/ so I have marked this a draft until those patches are released.
