### PR TITLE
Disable arm64 CFI builds on -next for clang-{12,13}

### DIFF
--- a/.github/workflows/next-clang-12.yml
+++ b/.github/workflows/next-clang-12.yml
@@ -242,27 +242,6 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _8c5abf2855f7fef8f5d67ba30dcc77b2:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 12
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _327acfd14f0ecf18c6c0081651c20370:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/next-clang-13.yml
+++ b/.github/workflows/next-clang-13.yml
@@ -263,27 +263,6 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _0727f525f2017b393835d55bbffbb6ab:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y+CONFIG_CFI_CLANG=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _6260e216d2cb5ff467f4ec71a6822fe9:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/generator.yml
+++ b/generator.yml
@@ -1068,7 +1068,6 @@ builds:
   - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_kasan_sw,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_ubsan,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
@@ -1423,7 +1422,6 @@ builds:
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
-  - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *arm64_kasan_sw,    << : *next,             << : *llvm_full,       boot: false, << : *llvm_12}
   - {<< : *arm64_ubsan,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}

--- a/tuxsuite/next-clang-12.tux.yml
+++ b/tuxsuite/next-clang-12.tux.yml
@@ -123,19 +123,6 @@ sets:
     toolchain: clang-12
     kconfig:
     - defconfig
-    - CONFIG_LTO_CLANG_THIN=y
-    - CONFIG_CFI_CLANG=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
-    git_ref: master
-    target_arch: arm64
-    toolchain: clang-12
-    kconfig:
-    - defconfig
     - CONFIG_KASAN=y
     - CONFIG_KASAN_KUNIT_TEST=y
     - CONFIG_KASAN_VMALLOC=y

--- a/tuxsuite/next-clang-13.tux.yml
+++ b/tuxsuite/next-clang-13.tux.yml
@@ -135,19 +135,6 @@ sets:
     toolchain: clang-13
     kconfig:
     - defconfig
-    - CONFIG_LTO_CLANG_THIN=y
-    - CONFIG_CFI_CLANG=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
-    git_ref: master
-    target_arch: arm64
-    toolchain: clang-13
-    kconfig:
-    - defconfig
     - CONFIG_KASAN=y
     - CONFIG_KASAN_KUNIT_TEST=y
     - CONFIG_KASAN_VMALLOC=y


### PR DESCRIPTION
Commit e6f3b3c9c109 ("cfi: Use __builtin_function_start") in -next bumps
the required Clang version for CFI to 14.0.0, meaning our configuration
checks will now fail for clang-12 and clang-13. Disable these builds, as
they are no different from the ThinLTO ones.

Link: https://git.kernel.org/kees/c/e6f3b3c9c109ed57230996cf4a4c1b8ae7e36a81
Link: https://github.com/ClangBuiltLinux/continuous-integration2/runs/6114009943?check_suite_focus=true
