### PR TITLE
github: workflows: Fix clang-version

### DIFF
--- a/.github/workflows/clang-version.yml
+++ b/.github/workflows/clang-version.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: parse-debian-clang.sh --check
-      run: bash parse-debian-clang.sh --check
+      run: bash scripts/parse-debian-clang.sh --check


### PR DESCRIPTION
This has not been running properly since commit 1c6961d ("Move shell
scripts to scripts/").
