### PR TITLE
Build powerpc64le configs with LLVM=1 with LLVM 14

### DIFF
--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -473,10 +473,10 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _58f0a88b2eb14c651a657df2ed1232ce:
+  _bb6ccfec079fa3e317bf9277bd03f988:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
@@ -825,10 +825,10 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _aee5ba6d550b366b3aadb4a0bfd9906e:
+  _31aa346e99e6c1ab180670976fa2f7c4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
@@ -846,10 +846,10 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e8fe479b70c34d11aad415d50bf69af1:
+  _cf571a1439fb1c71dda033c022b1b7b6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     env:
       ARCH: powerpc
       LLVM_VERSION: 14

--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -473,10 +473,10 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _58f0a88b2eb14c651a657df2ed1232ce:
+  _bb6ccfec079fa3e317bf9277bd03f988:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
@@ -846,10 +846,10 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _aee5ba6d550b366b3aadb4a0bfd9906e:
+  _31aa346e99e6c1ab180670976fa2f7c4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
@@ -867,10 +867,10 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e8fe479b70c34d11aad415d50bf69af1:
+  _cf571a1439fb1c71dda033c022b1b7b6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     env:
       ARCH: powerpc
       LLVM_VERSION: 14

--- a/generator.yml
+++ b/generator.yml
@@ -669,9 +669,9 @@ builds:
   - {<< : *mipsel,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: true,  << : *llvm_latest}
   - {<< : *ppc64,             << : *mainline,         << : *ppc64_llvm,      boot: true,  << : *llvm_latest}
-  - {<< : *ppc64le,           << : *mainline,         << : *llvm,            boot: true,  << : *llvm_latest}
-  - {<< : *ppc64le_fedora,    << : *mainline,         << : *clang,           boot: true,  << : *llvm_latest}
-  - {<< : *ppc64le_suse,      << : *mainline,         << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le_fedora,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le_suse,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *riscv,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *s390,              << : *mainline,         << : *clang,           boot: true,  << : *llvm_latest}
@@ -729,9 +729,9 @@ builds:
   - {<< : *mipsel,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *ppc32,             << : *next,             << : *llvm,            boot: true,  << : *llvm_latest}
   - {<< : *ppc64,             << : *next,             << : *ppc64_llvm,      boot: true,  << : *llvm_latest}
-  - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  << : *llvm_latest}
-  - {<< : *ppc64le_fedora,    << : *next,             << : *clang,           boot: true,  << : *llvm_latest}
-  - {<< : *ppc64le_suse,      << : *next,             << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le_fedora,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le_suse,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *riscv_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *s390,              << : *next,             << : *clang,           boot: true,  << : *llvm_latest}

--- a/tuxsuite/mainline-clang-14.tux.yml
+++ b/tuxsuite/mainline-clang-14.tux.yml
@@ -266,7 +266,7 @@ sets:
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
-      LLVM_IAS: 0
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: riscv
@@ -455,7 +455,8 @@ sets:
     - kernel
     kernel_image: zImage.epapr
     make_variables:
-      LLVM_IAS: 0
+      LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: powerpc
@@ -465,7 +466,8 @@ sets:
     - kernel
     kernel_image: zImage.epapr
     make_variables:
-      LLVM_IAS: 0
+      LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
     git_ref: master
     target_arch: s390

--- a/tuxsuite/next-clang-14.tux.yml
+++ b/tuxsuite/next-clang-14.tux.yml
@@ -266,7 +266,7 @@ sets:
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
-      LLVM_IAS: 0
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: riscv
@@ -468,7 +468,8 @@ sets:
     - kernel
     kernel_image: zImage.epapr
     make_variables:
-      LLVM_IAS: 0
+      LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: powerpc
@@ -478,7 +479,8 @@ sets:
     - kernel
     kernel_image: zImage.epapr
     make_variables:
-      LLVM_IAS: 0
+      LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
     git_ref: master
     target_arch: s390


### PR DESCRIPTION
Same as commit 4eec5c4 ("generator.yml: Build powerpc64le configs with
LLVM=1 with LLVM ToT") but for LLVM 14, as the patch that allows us to
build with the integrated assembler has been merged into release/14.x:

https://github.com/llvm/llvm-project/commit/33504b3bbe10d5d4caae13efcb99bd159c126070

Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/358
