### PR TITLE
Fix ChromeOS runs

### DIFF
--- a/.github/workflows/chromeos-5.10-clang-12.yml
+++ b/.github/workflows/chromeos-5.10-clang-12.yml
@@ -32,25 +32,9 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  kick_tuxsuite_allconfigs:
-    name: TuxSuite (allconfigs)
-    runs-on: ubuntu-latest
-    container: tuxsuite/tuxsuite
-    env:
-      TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
-    steps:
-    - uses: actions/checkout@v3
-    - name: tuxsuite
-      run: tuxsuite build-set --set-name allconfigs --json-out builds.json --tux-config tuxsuite/chromeos-5.10-clang-12.tux.yml || true
-    - name: save output
-      uses: actions/upload-artifact@v2
-      with:
-        path: builds.json
-        name: output_artifact_allconfigs
-        if-no-files-found: error
   _e7ae88f2477be7c2a0091d6ac55d4ea1:
     runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
+    needs: kick_tuxsuite_defconfigs
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
     env:
       ARCH: arm64
@@ -66,12 +50,12 @@ jobs:
         submodules: true
     - uses: actions/download-artifact@v2
       with:
-        name: output_artifact_allconfigs
+        name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
   _c2223ae17627d3ac3ca928be5d5b2eb1:
     runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
+    needs: kick_tuxsuite_defconfigs
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
     env:
       ARCH: x86_64
@@ -87,7 +71,7 @@ jobs:
         submodules: true
     - uses: actions/download-artifact@v2
       with:
-        name: output_artifact_allconfigs
+        name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
 

--- a/.github/workflows/chromeos-5.10-clang-13.yml
+++ b/.github/workflows/chromeos-5.10-clang-13.yml
@@ -32,25 +32,9 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  kick_tuxsuite_allconfigs:
-    name: TuxSuite (allconfigs)
-    runs-on: ubuntu-latest
-    container: tuxsuite/tuxsuite
-    env:
-      TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
-    steps:
-    - uses: actions/checkout@v3
-    - name: tuxsuite
-      run: tuxsuite build-set --set-name allconfigs --json-out builds.json --tux-config tuxsuite/chromeos-5.10-clang-13.tux.yml || true
-    - name: save output
-      uses: actions/upload-artifact@v2
-      with:
-        path: builds.json
-        name: output_artifact_allconfigs
-        if-no-files-found: error
   _05bbbf8cf9e223c1ac9169bb92e8ae61:
     runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
+    needs: kick_tuxsuite_defconfigs
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
     env:
       ARCH: arm64
@@ -66,12 +50,12 @@ jobs:
         submodules: true
     - uses: actions/download-artifact@v2
       with:
-        name: output_artifact_allconfigs
+        name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
   _bdf80a4aa66677b6a5e7b0bea831512b:
     runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
+    needs: kick_tuxsuite_defconfigs
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
     env:
       ARCH: x86_64
@@ -87,7 +71,7 @@ jobs:
         submodules: true
     - uses: actions/download-artifact@v2
       with:
-        name: output_artifact_allconfigs
+        name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
 

--- a/.github/workflows/chromeos-5.10-clang-14.yml
+++ b/.github/workflows/chromeos-5.10-clang-14.yml
@@ -32,25 +32,9 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  kick_tuxsuite_allconfigs:
-    name: TuxSuite (allconfigs)
-    runs-on: ubuntu-latest
-    container: tuxsuite/tuxsuite
-    env:
-      TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
-    steps:
-    - uses: actions/checkout@v3
-    - name: tuxsuite
-      run: tuxsuite build-set --set-name allconfigs --json-out builds.json --tux-config tuxsuite/chromeos-5.10-clang-14.tux.yml || true
-    - name: save output
-      uses: actions/upload-artifact@v2
-      with:
-        path: builds.json
-        name: output_artifact_allconfigs
-        if-no-files-found: error
   _cfc1a1cb0eb857521422f1c94c6463e6:
     runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
+    needs: kick_tuxsuite_defconfigs
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
     env:
       ARCH: arm64
@@ -66,12 +50,12 @@ jobs:
         submodules: true
     - uses: actions/download-artifact@v2
       with:
-        name: output_artifact_allconfigs
+        name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
   _ddbccfcffb83310bca0e7b1f5f48397b:
     runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
+    needs: kick_tuxsuite_defconfigs
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
     env:
       ARCH: x86_64
@@ -87,7 +71,7 @@ jobs:
         submodules: true
     - uses: actions/download-artifact@v2
       with:
-        name: output_artifact_allconfigs
+        name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
 

--- a/.github/workflows/chromeos-5.10-clang-15.yml
+++ b/.github/workflows/chromeos-5.10-clang-15.yml
@@ -32,25 +32,9 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  kick_tuxsuite_allconfigs:
-    name: TuxSuite (allconfigs)
-    runs-on: ubuntu-latest
-    container: tuxsuite/tuxsuite
-    env:
-      TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
-    steps:
-    - uses: actions/checkout@v3
-    - name: tuxsuite
-      run: tuxsuite build-set --set-name allconfigs --json-out builds.json --tux-config tuxsuite/chromeos-5.10-clang-15.tux.yml || true
-    - name: save output
-      uses: actions/upload-artifact@v2
-      with:
-        path: builds.json
-        name: output_artifact_allconfigs
-        if-no-files-found: error
   _b2bc2e58c295bb3a09d49521768e8fde:
     runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
+    needs: kick_tuxsuite_defconfigs
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
     env:
       ARCH: arm64
@@ -66,12 +50,12 @@ jobs:
         submodules: true
     - uses: actions/download-artifact@v2
       with:
-        name: output_artifact_allconfigs
+        name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
   _7b55b1e60f66604dead64940c8a187ac:
     runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
+    needs: kick_tuxsuite_defconfigs
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
     env:
       ARCH: x86_64
@@ -87,7 +71,7 @@ jobs:
         submodules: true
     - uses: actions/download-artifact@v2
       with:
-        name: output_artifact_allconfigs
+        name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
 

--- a/.github/workflows/chromeos-5.15-clang-12.yml
+++ b/.github/workflows/chromeos-5.15-clang-12.yml
@@ -32,25 +32,9 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  kick_tuxsuite_allconfigs:
-    name: TuxSuite (allconfigs)
-    runs-on: ubuntu-latest
-    container: tuxsuite/tuxsuite
-    env:
-      TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
-    steps:
-    - uses: actions/checkout@v3
-    - name: tuxsuite
-      run: tuxsuite build-set --set-name allconfigs --json-out builds.json --tux-config tuxsuite/chromeos-5.15-clang-12.tux.yml || true
-    - name: save output
-      uses: actions/upload-artifact@v2
-      with:
-        path: builds.json
-        name: output_artifact_allconfigs
-        if-no-files-found: error
   _e7ae88f2477be7c2a0091d6ac55d4ea1:
     runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
+    needs: kick_tuxsuite_defconfigs
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
     env:
       ARCH: arm64
@@ -66,12 +50,12 @@ jobs:
         submodules: true
     - uses: actions/download-artifact@v2
       with:
-        name: output_artifact_allconfigs
+        name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
   _c2223ae17627d3ac3ca928be5d5b2eb1:
     runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
+    needs: kick_tuxsuite_defconfigs
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
     env:
       ARCH: x86_64
@@ -87,7 +71,7 @@ jobs:
         submodules: true
     - uses: actions/download-artifact@v2
       with:
-        name: output_artifact_allconfigs
+        name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
 

--- a/.github/workflows/chromeos-5.15-clang-13.yml
+++ b/.github/workflows/chromeos-5.15-clang-13.yml
@@ -32,25 +32,9 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  kick_tuxsuite_allconfigs:
-    name: TuxSuite (allconfigs)
-    runs-on: ubuntu-latest
-    container: tuxsuite/tuxsuite
-    env:
-      TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
-    steps:
-    - uses: actions/checkout@v3
-    - name: tuxsuite
-      run: tuxsuite build-set --set-name allconfigs --json-out builds.json --tux-config tuxsuite/chromeos-5.15-clang-13.tux.yml || true
-    - name: save output
-      uses: actions/upload-artifact@v2
-      with:
-        path: builds.json
-        name: output_artifact_allconfigs
-        if-no-files-found: error
   _05bbbf8cf9e223c1ac9169bb92e8ae61:
     runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
+    needs: kick_tuxsuite_defconfigs
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
     env:
       ARCH: arm64
@@ -66,12 +50,12 @@ jobs:
         submodules: true
     - uses: actions/download-artifact@v2
       with:
-        name: output_artifact_allconfigs
+        name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
   _bdf80a4aa66677b6a5e7b0bea831512b:
     runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
+    needs: kick_tuxsuite_defconfigs
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
     env:
       ARCH: x86_64
@@ -87,7 +71,7 @@ jobs:
         submodules: true
     - uses: actions/download-artifact@v2
       with:
-        name: output_artifact_allconfigs
+        name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
 

--- a/.github/workflows/chromeos-5.15-clang-14.yml
+++ b/.github/workflows/chromeos-5.15-clang-14.yml
@@ -32,25 +32,9 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  kick_tuxsuite_allconfigs:
-    name: TuxSuite (allconfigs)
-    runs-on: ubuntu-latest
-    container: tuxsuite/tuxsuite
-    env:
-      TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
-    steps:
-    - uses: actions/checkout@v3
-    - name: tuxsuite
-      run: tuxsuite build-set --set-name allconfigs --json-out builds.json --tux-config tuxsuite/chromeos-5.15-clang-14.tux.yml || true
-    - name: save output
-      uses: actions/upload-artifact@v2
-      with:
-        path: builds.json
-        name: output_artifact_allconfigs
-        if-no-files-found: error
   _cfc1a1cb0eb857521422f1c94c6463e6:
     runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
+    needs: kick_tuxsuite_defconfigs
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
     env:
       ARCH: arm64
@@ -66,12 +50,12 @@ jobs:
         submodules: true
     - uses: actions/download-artifact@v2
       with:
-        name: output_artifact_allconfigs
+        name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
   _ddbccfcffb83310bca0e7b1f5f48397b:
     runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
+    needs: kick_tuxsuite_defconfigs
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
     env:
       ARCH: x86_64
@@ -87,7 +71,7 @@ jobs:
         submodules: true
     - uses: actions/download-artifact@v2
       with:
-        name: output_artifact_allconfigs
+        name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
 

--- a/.github/workflows/chromeos-5.15-clang-15.yml
+++ b/.github/workflows/chromeos-5.15-clang-15.yml
@@ -32,25 +32,9 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  kick_tuxsuite_allconfigs:
-    name: TuxSuite (allconfigs)
-    runs-on: ubuntu-latest
-    container: tuxsuite/tuxsuite
-    env:
-      TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
-    steps:
-    - uses: actions/checkout@v3
-    - name: tuxsuite
-      run: tuxsuite build-set --set-name allconfigs --json-out builds.json --tux-config tuxsuite/chromeos-5.15-clang-15.tux.yml || true
-    - name: save output
-      uses: actions/upload-artifact@v2
-      with:
-        path: builds.json
-        name: output_artifact_allconfigs
-        if-no-files-found: error
   _b2bc2e58c295bb3a09d49521768e8fde:
     runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
+    needs: kick_tuxsuite_defconfigs
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
     env:
       ARCH: arm64
@@ -66,12 +50,12 @@ jobs:
         submodules: true
     - uses: actions/download-artifact@v2
       with:
-        name: output_artifact_allconfigs
+        name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
   _7b55b1e60f66604dead64940c8a187ac:
     runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
+    needs: kick_tuxsuite_defconfigs
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
     env:
       ARCH: x86_64
@@ -87,7 +71,7 @@ jobs:
         submodules: true
     - uses: actions/download-artifact@v2
       with:
-        name: output_artifact_allconfigs
+        name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
 

--- a/generate_tuxsuite.py
+++ b/generate_tuxsuite.py
@@ -77,9 +77,10 @@ def emit_tuxsuite_yml(config, tree, llvm_version):
                     current_build.update(
                         {"make_variables": build["make_variables"]})
 
-                if "defconfig" in str(build["config"]):
+                cfg_str = str(build["config"])
+                if "defconfig" in cfg_str or "chromeos" in cfg_str:
                     defconfigs.append(current_build)
-                elif "https://" in str(build["config"]):
+                elif "https://" in cfg_str:
                     distribution_configs.append(current_build)
                 else:
                     allconfigs.append(current_build)

--- a/generate_workflow.py
+++ b/generate_workflow.py
@@ -183,9 +183,10 @@ def print_builds(config, tree_name, llvm_version):
         if build["git_repo"] == repo and \
            build["git_ref"] == ref and \
            build["llvm_version"] == llvm_version:
-            if "defconfig" in str(build["config"]):
+            cfg_str = str(build["config"])
+            if "defconfig" in cfg_str or "chromeos" in cfg_str:
                 check_logs_defconfigs.update(get_steps(build, "defconfigs"))
-            elif "https://" in str(build["config"]):
+            elif "https://" in cfg_str:
                 check_logs_distribution_configs.update(
                     get_steps(build, "distribution_configs"))
             else:

--- a/tuxsuite/chromeos-5.10-clang-12.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-12.tux.yml
@@ -5,8 +5,6 @@
 # $ tuxsuite build-set --set-name defconfigs --json-out builds.json --tux-config tuxsuite/chromeos-5.10-clang-12.tux.yml
 sets:
 - name: defconfigs
-  builds: []
-- name: allconfigs
   builds:
   - git_repo: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
     git_ref: chromeos-5.10

--- a/tuxsuite/chromeos-5.10-clang-13.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-13.tux.yml
@@ -5,8 +5,6 @@
 # $ tuxsuite build-set --set-name defconfigs --json-out builds.json --tux-config tuxsuite/chromeos-5.10-clang-13.tux.yml
 sets:
 - name: defconfigs
-  builds: []
-- name: allconfigs
   builds:
   - git_repo: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
     git_ref: chromeos-5.10

--- a/tuxsuite/chromeos-5.10-clang-14.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-14.tux.yml
@@ -5,8 +5,6 @@
 # $ tuxsuite build-set --set-name defconfigs --json-out builds.json --tux-config tuxsuite/chromeos-5.10-clang-14.tux.yml
 sets:
 - name: defconfigs
-  builds: []
-- name: allconfigs
   builds:
   - git_repo: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
     git_ref: chromeos-5.10

--- a/tuxsuite/chromeos-5.10-clang-15.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-15.tux.yml
@@ -5,8 +5,6 @@
 # $ tuxsuite build-set --set-name defconfigs --json-out builds.json --tux-config tuxsuite/chromeos-5.10-clang-15.tux.yml
 sets:
 - name: defconfigs
-  builds: []
-- name: allconfigs
   builds:
   - git_repo: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
     git_ref: chromeos-5.10

--- a/tuxsuite/chromeos-5.15-clang-12.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-12.tux.yml
@@ -5,8 +5,6 @@
 # $ tuxsuite build-set --set-name defconfigs --json-out builds.json --tux-config tuxsuite/chromeos-5.15-clang-12.tux.yml
 sets:
 - name: defconfigs
-  builds: []
-- name: allconfigs
   builds:
   - git_repo: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
     git_ref: chromeos-5.15

--- a/tuxsuite/chromeos-5.15-clang-13.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-13.tux.yml
@@ -5,8 +5,6 @@
 # $ tuxsuite build-set --set-name defconfigs --json-out builds.json --tux-config tuxsuite/chromeos-5.15-clang-13.tux.yml
 sets:
 - name: defconfigs
-  builds: []
-- name: allconfigs
   builds:
   - git_repo: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
     git_ref: chromeos-5.15

--- a/tuxsuite/chromeos-5.15-clang-14.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-14.tux.yml
@@ -5,8 +5,6 @@
 # $ tuxsuite build-set --set-name defconfigs --json-out builds.json --tux-config tuxsuite/chromeos-5.15-clang-14.tux.yml
 sets:
 - name: defconfigs
-  builds: []
-- name: allconfigs
   builds:
   - git_repo: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
     git_ref: chromeos-5.15

--- a/tuxsuite/chromeos-5.15-clang-15.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-15.tux.yml
@@ -5,8 +5,6 @@
 # $ tuxsuite build-set --set-name defconfigs --json-out builds.json --tux-config tuxsuite/chromeos-5.15-clang-15.tux.yml
 sets:
 - name: defconfigs
-  builds: []
-- name: allconfigs
   builds:
   - git_repo: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
     git_ref: chromeos-5.15


### PR DESCRIPTION
Currently, `generate_tuxsuite.py` and `generate_workflow.py` assume we
always generate a set of defconfig builds. However, it checks this by
looking for "defconfig" in the config, which is not true for the
ChromeOS configs. As a result, we generate an empty list of defconfigs,
which tuxsuite does not like.

To fix this, consider ChromeOS configurations defconfigs, as those are
the default configurations for the ChromeOS trees; they just do not live
in the arch folder because they are split up for the different boards
that are supported by ChromeOS.

Link: https://github.com/ClangBuiltLinux/continuous-integration2/runs/6400686892?check_suite_focus=true

