### PR TITLE
Upgrade stable anchor to 5.18

### DIFF
--- a/.github/workflows/stable-clang-11.yml
+++ b/.github/workflows/stable-clang-11.yml
@@ -431,6 +431,27 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _4a3742e4906edde3d649253fb7933b23:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
+    env:
+      ARCH: um
+      LLVM_VERSION: 11
+      BOOT: 1
+      CONFIG: defconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _73f8d728902a8cc9c807d77d1aaaedaf:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
@@ -829,27 +850,6 @@ jobs:
       LLVM_VERSION: 11
       BOOT: 0
       CONFIG: allnoconfig
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
-  _0af3671327d46b593593448c6623f2c4:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 11
-      BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-12.yml
+++ b/.github/workflows/stable-clang-12.yml
@@ -494,6 +494,27 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _9e93b73ca7d90baea53da3d1e9613b4b:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
+    env:
+      ARCH: um
+      LLVM_VERSION: 12
+      BOOT: 1
+      CONFIG: defconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _d49633cca166398690b1f3ecad135a14:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
@@ -892,27 +913,6 @@ jobs:
       LLVM_VERSION: 12
       BOOT: 0
       CONFIG: allnoconfig
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v2
-      with:
-        name: output_artifact_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
-  _0287fe965f5b39fdfef64647c19b664d:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 12
-      BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -557,6 +557,27 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _171147249819cb6e8281ffa046070e68:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
+    env:
+      ARCH: um
+      LLVM_VERSION: 13
+      BOOT: 1
+      CONFIG: defconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _5725232ce5f790d6db053c3d226eead6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -473,10 +473,10 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _58f0a88b2eb14c651a657df2ed1232ce:
+  _bb6ccfec079fa3e317bf9277bd03f988:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
@@ -545,6 +545,27 @@ jobs:
       LLVM_VERSION: 14
       BOOT: 1
       CONFIG: defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
+  _159d60218d64add121c8e24ad1c4d12c:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
+    env:
+      ARCH: um
+      LLVM_VERSION: 14
+      BOOT: 1
+      CONFIG: defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -804,10 +825,10 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _aee5ba6d550b366b3aadb4a0bfd9906e:
+  _31aa346e99e6c1ab180670976fa2f7c4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
@@ -825,10 +846,10 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e8fe479b70c34d11aad415d50bf69af1:
+  _cf571a1439fb1c71dda033c022b1b7b6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     env:
       ARCH: powerpc
       LLVM_VERSION: 14

--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -473,10 +473,10 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b83e803d7dd6c3201bea198a418a70ce:
+  _184d8d4f81b0cb5c1f31ff3bfa495255:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 powernv_defconfig
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
@@ -545,6 +545,27 @@ jobs:
       LLVM_VERSION: 15
       BOOT: 1
       CONFIG: defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v2
+      with:
+        name: output_artifact_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
+  _2044a9c1a33925cd52ae6576ea495d7d:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
+    env:
+      ARCH: um
+      LLVM_VERSION: 15
+      BOOT: 1
+      CONFIG: defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -804,10 +825,10 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _08fb5d721ebe5360162eab624a731362:
+  _3604dd182915d18674b48e45803faa77:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
@@ -825,10 +846,10 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _cf214bc1ac3d0d1e5d672c288d3a49e6:
+  _3f59e2fc30565fc140588eaca2035b8c:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     env:
       ARCH: powerpc
       LLVM_VERSION: 15

--- a/generator.yml
+++ b/generator.yml
@@ -39,7 +39,7 @@ schedules:
 trees:
   - &mainline         {git_repo: *mainline-url, git_ref: master,              name: mainline}
   - &next             {git_repo: *next-url,     git_ref: master,              name: next}
-  - &stable           {git_repo: *stable-url,   git_ref: linux-5.17.y,        name: stable}
+  - &stable           {git_repo: *stable-url,   git_ref: linux-5.18.y,        name: stable}
   - &stable-5_15      {git_repo: *stable-url,   git_ref: linux-5.15.y,        name: "5.15"}
   - &stable-5_10      {git_repo: *stable-url,   git_ref: linux-5.10.y,        name: "5.10"}
   - &stable-5_4       {git_repo: *stable-url,   git_ref: linux-5.4.y,         name: "5.4"}
@@ -432,15 +432,16 @@ builds:
   - {<< : *mipsel,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *ppc32,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_tot}
   - {<< : *ppc64,             << : *stable,           << : *ppc64_llvm,      boot: true,  << : *llvm_tot}
-  - {<< : *ppc64le,           << : *stable,           << : *llvm,            boot: true,  << : *llvm_tot}
-  - {<< : *ppc64le_fedora,    << : *stable,           << : *clang,           boot: true,  << : *llvm_tot}
-  - {<< : *ppc64le_suse,      << : *stable,           << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le_fedora,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *ppc64le_suse,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *riscv,             << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *riscv_allmod,      << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *s390,              << : *stable,           << : *clang,           boot: true,  << : *llvm_tot}
   - {<< : *s390_kasan,        << : *stable,           << : *clang,           boot: true,  << : *llvm_tot}
   - {<< : *s390_fedora,       << : *stable,           << : *clang,           boot: true,  << : *llvm_tot}
   - {<< : *s390_suse,         << : *stable,           << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *um,                << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_full,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_thin,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -790,15 +791,16 @@ builds:
   - {<< : *mipsel,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *ppc32,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_latest}
   - {<< : *ppc64,             << : *stable,           << : *ppc64_llvm,      boot: true,  << : *llvm_latest}
-  - {<< : *ppc64le,           << : *stable,           << : *llvm,            boot: true,  << : *llvm_latest}
-  - {<< : *ppc64le_fedora,    << : *stable,           << : *clang,           boot: true,  << : *llvm_latest}
-  - {<< : *ppc64le_suse,      << : *stable,           << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le_fedora,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *ppc64le_suse,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *riscv,             << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *riscv_allmod,      << : *stable,           << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *s390,              << : *stable,           << : *clang,           boot: true,  << : *llvm_latest}
   - {<< : *s390_kasan,        << : *stable,           << : *clang,           boot: true,  << : *llvm_latest}
   - {<< : *s390_fedora,       << : *stable,           << : *clang,           boot: true,  << : *llvm_latest}
   - {<< : *s390_suse,         << : *stable,           << : *clang,           boot: true,  << : *llvm_latest}
+  - {<< : *um,                << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_lto_full,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_lto_thin,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -1155,6 +1157,7 @@ builds:
   - {<< : *s390_kasan,        << : *stable,           << : *clang,           boot: true,  << : *llvm_13}
   - {<< : *s390_fedora,       << : *stable,           << : *clang,           boot: true,  << : *llvm_13}
   - {<< : *s390_suse,         << : *stable,           << : *clang,           boot: true,  << : *llvm_13}
+  - {<< : *um,                << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *x86_64,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *x86_64_lto_full,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *x86_64_lto_thin,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
@@ -1472,7 +1475,8 @@ builds:
   - {<< : *arm32_lpae_fp,     << : *stable,           << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *arm32_allmod,      << : *stable,           << : *llvm,            boot: false, << : *llvm_12}
   - {<< : *arm32_allno,       << : *stable,           << : *llvm,            boot: false, << : *llvm_12}
-  - {<< : *arm32_allyes,      << : *stable,           << : *llvm,            boot: false, << : *llvm_12}
+  # ARM allyesconfig build disabled: https://github.com/ClangBuiltLinux/linux/issues/1615
+  # - {<< : *arm32_allyes,      << : *stable,           << : *llvm,            boot: false, << : *llvm_12}
   - {<< : *arm32_fedora,      << : *stable,           << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *arm32_suse,        << : *stable,           << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *arm64,             << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_12}
@@ -1503,6 +1507,7 @@ builds:
   - {<< : *riscv_allmod,      << : *stable,           << : *llvm,            boot: false, << : *llvm_12}
   # s390: Build disabled (https://lore.kernel.org/r/YMtib5hKVyNknZt3@osiris/)
   # - {<< : *s390,              << : *stable,           << : *clang,           boot: true,  << : *llvm_12}
+  - {<< : *um,                << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *x86_64,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *x86_64_lto_full,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *x86_64_lto_thin,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_12}
@@ -1777,7 +1782,8 @@ builds:
   - {<< : *arm32_lpae_fp,     << : *stable,           << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *arm32_allmod,      << : *stable,           << : *llvm,            boot: false, << : *llvm_11}
   - {<< : *arm32_allno,       << : *stable,           << : *llvm,            boot: false, << : *llvm_11}
-  - {<< : *arm32_allyes,      << : *stable,           << : *llvm,            boot: false, << : *llvm_11}
+  # ARM allyesconfig build disabled: https://github.com/ClangBuiltLinux/linux/issues/1615
+  # - {<< : *arm32_allyes,      << : *stable,           << : *llvm,            boot: false, << : *llvm_11}
   - {<< : *arm32_fedora,      << : *stable,           << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *arm32_suse,        << : *stable,           << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *arm64,             << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_11}
@@ -1807,6 +1813,7 @@ builds:
   - {<< : *riscv_allmod,      << : *stable,           << : *llvm,            boot: false, << : *llvm_11}
   # s390: Build disabled (https://lore.kernel.org/r/YMtib5hKVyNknZt3@osiris/)
   # - {<< : *s390,              << : *stable,           << : *clang,           boot: true,  << : *llvm_11}
+  - {<< : *um,                << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *x86_64,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *x86_64_lto_full,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *x86_64_lto_thin,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_11}

--- a/tuxsuite/stable-clang-11.tux.yml
+++ b/tuxsuite/stable-clang-11.tux.yml
@@ -7,7 +7,7 @@ sets:
 - name: defconfigs
   builds:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-11
     kconfig: multi_v5_defconfig
@@ -18,7 +18,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-11
     kconfig: aspeed_g5_defconfig
@@ -29,7 +29,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-11
     kconfig: multi_v7_defconfig
@@ -39,7 +39,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-11
     kconfig:
@@ -51,7 +51,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-11
     kconfig: imx_v4_v5_defconfig
@@ -61,7 +61,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-11
     kconfig: omap2plus_defconfig
@@ -71,7 +71,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-11
     kconfig:
@@ -84,7 +84,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-11
     kconfig: defconfig
@@ -94,7 +94,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-11
     kconfig:
@@ -106,7 +106,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-11
     kconfig:
@@ -118,7 +118,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-11
     kconfig:
@@ -133,7 +133,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-11
     kconfig:
@@ -148,7 +148,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-11
     kconfig:
@@ -160,7 +160,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: hexagon
     toolchain: clang-11
     kconfig: defconfig
@@ -170,7 +170,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: i386
     toolchain: clang-11
     kconfig: defconfig
@@ -180,7 +180,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: mips
     toolchain: clang-11
     kconfig:
@@ -195,7 +195,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: mips
     toolchain: clang-11
     kconfig:
@@ -208,7 +208,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-11
     kconfig: powernv_defconfig
@@ -220,7 +220,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: riscv
     toolchain: clang-11
     kconfig: defconfig
@@ -231,7 +231,17 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
+    target_arch: um
+    toolchain: clang-11
+    kconfig: defconfig
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-11
     kconfig: defconfig
@@ -241,7 +251,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-11
     kconfig:
@@ -253,7 +263,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-11
     kconfig:
@@ -265,7 +275,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-11
     kconfig:
@@ -280,7 +290,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-11
     kconfig:
@@ -294,7 +304,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-11
     kconfig:
@@ -308,7 +318,7 @@ sets:
 - name: distribution_configs
   builds:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-11
     kconfig:
@@ -320,7 +330,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
@@ -330,7 +340,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-11
     kconfig:
@@ -342,7 +352,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-11
     kconfig:
@@ -354,7 +364,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: i386
     toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
@@ -364,7 +374,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-11
     kconfig:
@@ -376,7 +386,7 @@ sets:
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
@@ -386,7 +396,7 @@ sets:
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-11
     kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
@@ -396,7 +406,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-11
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
@@ -406,7 +416,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
@@ -418,7 +428,7 @@ sets:
 - name: allconfigs
   builds:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-11
     kconfig:
@@ -430,7 +440,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-11
     kconfig: allnoconfig
@@ -440,19 +450,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
-    target_arch: arm
-    toolchain: clang-11
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
-  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-11
     kconfig:
@@ -464,7 +462,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-11
     kconfig:
@@ -479,7 +477,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-11
     kconfig: allnoconfig
@@ -489,7 +487,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-11
     kconfig:
@@ -501,7 +499,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: riscv
     toolchain: clang-11
     kconfig:
@@ -514,7 +512,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-11
     kconfig:
@@ -526,7 +524,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-11
     kconfig:
@@ -541,7 +539,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-11
     kconfig: allnoconfig
@@ -551,7 +549,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-11
     kconfig:

--- a/tuxsuite/stable-clang-12.tux.yml
+++ b/tuxsuite/stable-clang-12.tux.yml
@@ -7,7 +7,7 @@ sets:
 - name: defconfigs
   builds:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-12
     kconfig: multi_v5_defconfig
@@ -18,7 +18,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-12
     kconfig: aspeed_g5_defconfig
@@ -29,7 +29,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-12
     kconfig: multi_v7_defconfig
@@ -39,7 +39,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-12
     kconfig:
@@ -51,7 +51,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-12
     kconfig: imx_v4_v5_defconfig
@@ -61,7 +61,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-12
     kconfig: omap2plus_defconfig
@@ -71,7 +71,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-12
     kconfig:
@@ -84,7 +84,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-12
     kconfig: defconfig
@@ -94,7 +94,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-12
     kconfig:
@@ -106,7 +106,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-12
     kconfig:
@@ -118,7 +118,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-12
     kconfig:
@@ -131,7 +131,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-12
     kconfig:
@@ -146,7 +146,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-12
     kconfig:
@@ -161,7 +161,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-12
     kconfig:
@@ -173,7 +173,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: hexagon
     toolchain: clang-12
     kconfig: defconfig
@@ -183,7 +183,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: i386
     toolchain: clang-12
     kconfig: defconfig
@@ -193,7 +193,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: mips
     toolchain: clang-12
     kconfig:
@@ -208,7 +208,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: mips
     toolchain: clang-12
     kconfig:
@@ -221,7 +221,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-12
     kconfig: ppc44x_defconfig
@@ -232,7 +232,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-12
     kconfig:
@@ -246,7 +246,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-12
     kconfig: powernv_defconfig
@@ -257,7 +257,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: riscv
     toolchain: clang-12
     kconfig: defconfig
@@ -268,7 +268,17 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
+    target_arch: um
+    toolchain: clang-12
+    kconfig: defconfig
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-12
     kconfig: defconfig
@@ -278,7 +288,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-12
     kconfig:
@@ -290,7 +300,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-12
     kconfig:
@@ -302,7 +312,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-12
     kconfig:
@@ -317,7 +327,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-12
     kconfig:
@@ -331,7 +341,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-12
     kconfig:
@@ -345,7 +355,7 @@ sets:
 - name: distribution_configs
   builds:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-12
     kconfig:
@@ -357,7 +367,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
@@ -367,7 +377,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-12
     kconfig:
@@ -379,7 +389,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-12
     kconfig:
@@ -391,7 +401,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: i386
     toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
@@ -401,7 +411,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-12
     kconfig:
@@ -413,7 +423,7 @@ sets:
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
@@ -423,7 +433,7 @@ sets:
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-12
     kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
@@ -433,7 +443,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-12
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
@@ -443,7 +453,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
@@ -455,7 +465,7 @@ sets:
 - name: allconfigs
   builds:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-12
     kconfig:
@@ -467,7 +477,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-12
     kconfig: allnoconfig
@@ -477,19 +487,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
-    target_arch: arm
-    toolchain: clang-12
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
-  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-12
     kconfig:
@@ -501,7 +499,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-12
     kconfig:
@@ -516,7 +514,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-12
     kconfig: allnoconfig
@@ -526,7 +524,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-12
     kconfig:
@@ -538,7 +536,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: riscv
     toolchain: clang-12
     kconfig:
@@ -551,7 +549,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-12
     kconfig:
@@ -563,7 +561,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-12
     kconfig:
@@ -578,7 +576,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-12
     kconfig: allnoconfig
@@ -588,7 +586,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-12
     kconfig:

--- a/tuxsuite/stable-clang-13.tux.yml
+++ b/tuxsuite/stable-clang-13.tux.yml
@@ -7,7 +7,7 @@ sets:
 - name: defconfigs
   builds:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-13
     kconfig: multi_v5_defconfig
@@ -18,7 +18,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-13
     kconfig: aspeed_g5_defconfig
@@ -29,7 +29,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-13
     kconfig: multi_v7_defconfig
@@ -39,7 +39,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-13
     kconfig:
@@ -51,7 +51,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-13
     kconfig: imx_v4_v5_defconfig
@@ -61,7 +61,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-13
     kconfig: omap2plus_defconfig
@@ -71,7 +71,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-13
     kconfig:
@@ -84,7 +84,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-13
     kconfig: defconfig
@@ -94,7 +94,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-13
     kconfig:
@@ -106,7 +106,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-13
     kconfig:
@@ -118,7 +118,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-13
     kconfig:
@@ -130,7 +130,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-13
     kconfig:
@@ -143,7 +143,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-13
     kconfig:
@@ -158,7 +158,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-13
     kconfig:
@@ -173,7 +173,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-13
     kconfig:
@@ -185,7 +185,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: hexagon
     toolchain: clang-13
     kconfig: defconfig
@@ -195,7 +195,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: i386
     toolchain: clang-13
     kconfig: defconfig
@@ -205,7 +205,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: mips
     toolchain: clang-13
     kconfig:
@@ -219,7 +219,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: mips
     toolchain: clang-13
     kconfig:
@@ -232,7 +232,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-13
     kconfig: ppc44x_defconfig
@@ -243,7 +243,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-13
     kconfig:
@@ -257,7 +257,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-13
     kconfig: powernv_defconfig
@@ -268,7 +268,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: riscv
     toolchain: clang-13
     kconfig: defconfig
@@ -279,7 +279,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: s390
     toolchain: clang-13
     kconfig: defconfig
@@ -288,7 +288,7 @@ sets:
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: s390
     toolchain: clang-13
     kconfig:
@@ -302,7 +302,17 @@ sets:
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
+    target_arch: um
+    toolchain: clang-13
+    kconfig: defconfig
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-13
     kconfig: defconfig
@@ -312,7 +322,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-13
     kconfig:
@@ -324,7 +334,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-13
     kconfig:
@@ -336,7 +346,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-13
     kconfig:
@@ -351,7 +361,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-13
     kconfig:
@@ -365,7 +375,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-13
     kconfig:
@@ -379,7 +389,7 @@ sets:
 - name: distribution_configs
   builds:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-13
     kconfig:
@@ -391,7 +401,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
@@ -401,7 +411,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-13
     kconfig:
@@ -413,7 +423,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-13
     kconfig:
@@ -425,7 +435,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: i386
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
@@ -435,7 +445,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-13
     kconfig:
@@ -447,7 +457,7 @@ sets:
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
@@ -457,7 +467,7 @@ sets:
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: s390
     toolchain: clang-13
     kconfig:
@@ -468,7 +478,7 @@ sets:
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: s390
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
@@ -477,7 +487,7 @@ sets:
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-13
     kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
@@ -487,7 +497,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
@@ -497,7 +507,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
@@ -509,7 +519,7 @@ sets:
 - name: allconfigs
   builds:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-13
     kconfig:
@@ -521,7 +531,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-13
     kconfig: allnoconfig
@@ -531,7 +541,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-13
     kconfig:
@@ -543,7 +553,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-13
     kconfig:
@@ -555,7 +565,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-13
     kconfig:
@@ -570,7 +580,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-13
     kconfig: allnoconfig
@@ -580,7 +590,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-13
     kconfig:
@@ -592,7 +602,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: hexagon
     toolchain: clang-13
     kconfig: allmodconfig
@@ -602,7 +612,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: riscv
     toolchain: clang-13
     kconfig:
@@ -615,7 +625,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-13
     kconfig:
@@ -627,7 +637,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-13
     kconfig:
@@ -642,7 +652,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-13
     kconfig: allnoconfig
@@ -652,7 +662,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-13
     kconfig:

--- a/tuxsuite/stable-clang-14.tux.yml
+++ b/tuxsuite/stable-clang-14.tux.yml
@@ -7,7 +7,7 @@ sets:
 - name: defconfigs
   builds:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-14
     kconfig: multi_v5_defconfig
@@ -18,7 +18,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-14
     kconfig: aspeed_g5_defconfig
@@ -29,7 +29,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-14
     kconfig: multi_v7_defconfig
@@ -39,7 +39,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-14
     kconfig:
@@ -51,7 +51,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-14
     kconfig: imx_v4_v5_defconfig
@@ -61,7 +61,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-14
     kconfig: omap2plus_defconfig
@@ -71,7 +71,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-14
     kconfig:
@@ -84,7 +84,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-14
     kconfig: defconfig
@@ -94,7 +94,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-14
     kconfig:
@@ -106,7 +106,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-14
     kconfig:
@@ -118,7 +118,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-14
     kconfig:
@@ -130,7 +130,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-14
     kconfig:
@@ -143,7 +143,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-14
     kconfig:
@@ -158,7 +158,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-14
     kconfig:
@@ -173,7 +173,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-14
     kconfig:
@@ -185,7 +185,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: hexagon
     toolchain: clang-14
     kconfig: defconfig
@@ -195,7 +195,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: i386
     toolchain: clang-14
     kconfig: defconfig
@@ -205,7 +205,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: mips
     toolchain: clang-14
     kconfig:
@@ -219,7 +219,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: mips
     toolchain: clang-14
     kconfig:
@@ -232,7 +232,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-14
     kconfig: ppc44x_defconfig
@@ -243,7 +243,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-14
     kconfig:
@@ -257,7 +257,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-14
     kconfig: powernv_defconfig
@@ -266,9 +266,9 @@ sets:
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
-      LLVM_IAS: 0
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: riscv
     toolchain: clang-14
     kconfig: defconfig
@@ -279,7 +279,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: s390
     toolchain: clang-14
     kconfig: defconfig
@@ -288,7 +288,7 @@ sets:
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: s390
     toolchain: clang-14
     kconfig:
@@ -302,7 +302,17 @@ sets:
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
+    target_arch: um
+    toolchain: clang-14
+    kconfig: defconfig
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-14
     kconfig: defconfig
@@ -312,7 +322,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-14
     kconfig:
@@ -324,7 +334,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-14
     kconfig:
@@ -336,7 +346,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-14
     kconfig:
@@ -351,7 +361,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-14
     kconfig:
@@ -365,7 +375,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-14
     kconfig:
@@ -379,7 +389,7 @@ sets:
 - name: distribution_configs
   builds:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-14
     kconfig:
@@ -391,7 +401,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
@@ -401,7 +411,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-14
     kconfig:
@@ -413,7 +423,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-14
     kconfig:
@@ -425,7 +435,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: i386
     toolchain: clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
@@ -435,7 +445,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-14
     kconfig:
@@ -445,9 +455,10 @@ sets:
     - kernel
     kernel_image: zImage.epapr
     make_variables:
-      LLVM_IAS: 0
+      LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
@@ -455,9 +466,10 @@ sets:
     - kernel
     kernel_image: zImage.epapr
     make_variables:
-      LLVM_IAS: 0
+      LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: s390
     toolchain: clang-14
     kconfig:
@@ -468,7 +480,7 @@ sets:
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: s390
     toolchain: clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
@@ -477,7 +489,7 @@ sets:
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-14
     kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
@@ -487,7 +499,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-14
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
@@ -497,7 +509,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
@@ -509,7 +521,7 @@ sets:
 - name: allconfigs
   builds:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-14
     kconfig:
@@ -521,7 +533,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-14
     kconfig: allnoconfig
@@ -531,7 +543,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-14
     kconfig:
@@ -543,7 +555,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-14
     kconfig:
@@ -555,7 +567,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-14
     kconfig:
@@ -570,7 +582,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-14
     kconfig: allnoconfig
@@ -580,7 +592,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-14
     kconfig:
@@ -592,7 +604,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: hexagon
     toolchain: clang-14
     kconfig: allmodconfig
@@ -602,7 +614,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: riscv
     toolchain: clang-14
     kconfig:
@@ -615,7 +627,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-14
     kconfig:
@@ -627,7 +639,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-14
     kconfig:
@@ -642,7 +654,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-14
     kconfig: allnoconfig
@@ -652,7 +664,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-14
     kconfig:

--- a/tuxsuite/stable-clang-15.tux.yml
+++ b/tuxsuite/stable-clang-15.tux.yml
@@ -7,7 +7,7 @@ sets:
 - name: defconfigs
   builds:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-nightly
     kconfig: multi_v5_defconfig
@@ -18,7 +18,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-nightly
     kconfig: aspeed_g5_defconfig
@@ -29,7 +29,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-nightly
     kconfig: multi_v7_defconfig
@@ -39,7 +39,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-nightly
     kconfig:
@@ -51,7 +51,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-nightly
     kconfig: imx_v4_v5_defconfig
@@ -61,7 +61,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-nightly
     kconfig: omap2plus_defconfig
@@ -71,7 +71,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-nightly
     kconfig:
@@ -84,7 +84,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-nightly
     kconfig: defconfig
@@ -94,7 +94,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-nightly
     kconfig:
@@ -106,7 +106,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-nightly
     kconfig:
@@ -118,7 +118,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-nightly
     kconfig:
@@ -130,7 +130,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-nightly
     kconfig:
@@ -143,7 +143,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-nightly
     kconfig:
@@ -158,7 +158,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-nightly
     kconfig:
@@ -173,7 +173,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-nightly
     kconfig:
@@ -185,7 +185,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: hexagon
     toolchain: clang-nightly
     kconfig: defconfig
@@ -195,7 +195,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: i386
     toolchain: clang-nightly
     kconfig: defconfig
@@ -205,7 +205,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: mips
     toolchain: clang-nightly
     kconfig:
@@ -219,7 +219,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: mips
     toolchain: clang-nightly
     kconfig:
@@ -232,7 +232,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-nightly
     kconfig: ppc44x_defconfig
@@ -243,7 +243,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-nightly
     kconfig:
@@ -257,7 +257,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-nightly
     kconfig: powernv_defconfig
@@ -266,9 +266,9 @@ sets:
     kernel_image: zImage.epapr
     make_variables:
       LLVM: 1
-      LLVM_IAS: 0
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: riscv
     toolchain: clang-nightly
     kconfig: defconfig
@@ -279,7 +279,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: s390
     toolchain: clang-nightly
     kconfig: defconfig
@@ -288,7 +288,7 @@ sets:
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: s390
     toolchain: clang-nightly
     kconfig:
@@ -302,7 +302,17 @@ sets:
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
+    target_arch: um
+    toolchain: clang-nightly
+    kconfig: defconfig
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-nightly
     kconfig: defconfig
@@ -312,7 +322,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-nightly
     kconfig:
@@ -324,7 +334,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-nightly
     kconfig:
@@ -336,7 +346,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-nightly
     kconfig:
@@ -351,7 +361,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-nightly
     kconfig:
@@ -365,7 +375,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-nightly
     kconfig:
@@ -379,7 +389,7 @@ sets:
 - name: distribution_configs
   builds:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-nightly
     kconfig:
@@ -391,7 +401,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
@@ -401,7 +411,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-nightly
     kconfig:
@@ -413,7 +423,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-nightly
     kconfig:
@@ -425,7 +435,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: i386
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
@@ -435,7 +445,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-nightly
     kconfig:
@@ -445,9 +455,10 @@ sets:
     - kernel
     kernel_image: zImage.epapr
     make_variables:
-      LLVM_IAS: 0
+      LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: powerpc
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
@@ -455,9 +466,10 @@ sets:
     - kernel
     kernel_image: zImage.epapr
     make_variables:
-      LLVM_IAS: 0
+      LLVM: 1
+      LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: s390
     toolchain: clang-nightly
     kconfig:
@@ -468,7 +480,7 @@ sets:
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: s390
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
@@ -477,7 +489,7 @@ sets:
     make_variables:
       LLVM_IAS: 0
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-nightly
     kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
@@ -487,7 +499,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-nightly
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
@@ -497,7 +509,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
@@ -509,7 +521,7 @@ sets:
 - name: allconfigs
   builds:
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-nightly
     kconfig:
@@ -521,7 +533,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-nightly
     kconfig: allnoconfig
@@ -531,7 +543,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm
     toolchain: clang-nightly
     kconfig:
@@ -543,7 +555,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-nightly
     kconfig:
@@ -555,7 +567,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-nightly
     kconfig:
@@ -570,7 +582,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-nightly
     kconfig: allnoconfig
@@ -580,7 +592,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: arm64
     toolchain: clang-nightly
     kconfig:
@@ -592,7 +604,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: hexagon
     toolchain: clang-nightly
     kconfig: allmodconfig
@@ -602,7 +614,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: riscv
     toolchain: clang-nightly
     kconfig:
@@ -615,7 +627,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-nightly
     kconfig:
@@ -627,7 +639,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-nightly
     kconfig:
@@ -642,7 +654,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-nightly
     kconfig: allnoconfig
@@ -652,7 +664,7 @@ sets:
       LLVM: 1
       LLVM_IAS: 1
   - git_repo: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-    git_ref: linux-5.17.y
+    git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-nightly
     kconfig:


### PR DESCRIPTION
Linux 5.18 is the latest stable release, mark it as such.

Copy all the mainline builds so that our coverage matches all the new
development that has happened from 5.17 to 5.18.
