### PR TITLE
patches: mainline: Add a fix for ARCH=arm allmodconfig

### DIFF
--- a/patches/mainline/20220603_linux_watchdog_gxp_add_missing_module_license.patch
+++ b/patches/mainline/20220603_linux_watchdog_gxp_add_missing_module_license.patch
@@ -1,0 +1,40 @@
+From git@z Thu Jan  1 00:00:00 1970
+Subject: [PATCH] watchdog: gxp: Add missing MODULE_LICENSE
+From: Guenter Roeck <linux@roeck-us.net>
+Date: Fri, 03 Jun 2022 06:14:19 -0700
+Message-Id: <20220603131419.2948578-1-linux@roeck-us.net>
+To: Wim Van Sebroeck <wim@linux-watchdog.org>
+Cc: Jean-Marie Verdun <verdun@hpe.com>, linux-watchdog@vger.kernel.org, linux-kernel@vger.kernel.org, Guenter Roeck <linux@roeck-us.net>, Nick Hawkins <nick.hawkins@hpe.com>, Arnd Bergmann <arnd@arndb.de>
+List-Id: <linux-kernel.vger.kernel.org>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+The build system says:
+
+ERROR: modpost: missing MODULE_LICENSE() in drivers/watchdog/gxp-wdt.o
+
+Add the missing MODULE_LICENSE.
+
+Signed-off-by: Nick Hawkins <nick.hawkins@hpe.com>
+Signed-off-by: Arnd Bergmann <arnd@arndb.de>
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+Link: https://lore.kernel.org/r/20220603131419.2948578-1-linux@roeck-us.net
+---
+ drivers/watchdog/gxp-wdt.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/watchdog/gxp-wdt.c b/drivers/watchdog/gxp-wdt.c
+index b0b2d7a6fdde..2fd85be88278 100644
+--- a/drivers/watchdog/gxp-wdt.c
++++ b/drivers/watchdog/gxp-wdt.c
+@@ -172,3 +172,4 @@ module_platform_driver(gxp_wdt_driver);
+ MODULE_AUTHOR("Nick Hawkins <nick.hawkins@hpe.com>");
+ MODULE_AUTHOR("Jean-Marie Verdun <verdun@hpe.com>");
+ MODULE_DESCRIPTION("Driver for GXP watchdog timer");
++MODULE_LICENSE("GPL");
+
+-- 
+2.35.1
+
+

--- a/patches/mainline/series
+++ b/patches/mainline/series
@@ -1,1 +1,2 @@
 20220518_nathan_riscv_fix_alt_thead_pma_s_asm_parameters.patch
+20220603_linux_watchdog_gxp_add_missing_module_license.patch


### PR DESCRIPTION
This is breaking our builds for ARCH=arm allmodconfig. Add the patch
even though it is not related to LLVM so that we can catch other
breakage easier.
