### PR TITLE
Stop disabling CONFIG_WERROR on x86_64

### DIFF
--- a/.github/workflows/5.10-clang-11.yml
+++ b/.github/workflows/5.10-clang-11.yml
@@ -426,15 +426,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _0d027f6d4a4d947cffb7496e1c16a135:
+  _315a83fa22517db93a5781d3052eb372:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -468,15 +468,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _7325bb746df1b067e4e5f94ea088cb6d:
+  _f93dc26c868cb14278bd57d172f7b70e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-12.yml
+++ b/.github/workflows/5.10-clang-12.yml
@@ -468,15 +468,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _fa482dc7e25eed59da05016a93e8278c:
+  _ae767e9ca71f590a84808a724ec476e4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -510,15 +510,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _34a42eb37f34ff66ca3fcb80b692fc4d:
+  _2dff3a82fb364654e103e70b4b546e45:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-13.yml
+++ b/.github/workflows/5.10-clang-13.yml
@@ -489,15 +489,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3d883b6dd7ce3b5941eac52b8e5d255a:
+  _ff86d54e6acbce65590f71efbb2f826b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -531,15 +531,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _24a02828373c02a9d349a03fab7edbb8:
+  _02922017f2cb19d45aba8492132c7804:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-14.yml
+++ b/.github/workflows/5.10-clang-14.yml
@@ -489,15 +489,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _992af5860bcc9a1c28b228d2673cfcde:
+  _fe2c9057aa7118b7ceddc2c7bbdc8e2d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -531,15 +531,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d1f6821de38423146e72153d995ad97f:
+  _fb32e519cea6f2c116bd013eec8409de:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-15.yml
+++ b/.github/workflows/5.10-clang-15.yml
@@ -489,15 +489,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _7e04bc59253307d951350724fa2f04ce:
+  _fa860e93e45cbc4100d2fba75f35b51d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -531,15 +531,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5e22a044c054c7a918d76a9a7eb61878:
+  _2761279f511773a7e0d3689117cf5c33:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -967,15 +967,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _0d027f6d4a4d947cffb7496e1c16a135:
+  _315a83fa22517db93a5781d3052eb372:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -988,15 +988,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _be008c19ad3aa8d719caa3a336df796a:
+  _ad4a14cfdd7a60aff188af10540352b6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1030,15 +1030,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _7325bb746df1b067e4e5f94ea088cb6d:
+  _f93dc26c868cb14278bd57d172f7b70e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -1030,15 +1030,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _fa482dc7e25eed59da05016a93e8278c:
+  _ae767e9ca71f590a84808a724ec476e4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1051,15 +1051,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d742dae58084b6c129fe894dca38faba:
+  _2dc2c1c0431802a1cd5273e93cf3a433:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1093,15 +1093,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _34a42eb37f34ff66ca3fcb80b692fc4d:
+  _2dff3a82fb364654e103e70b4b546e45:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -1156,15 +1156,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3d883b6dd7ce3b5941eac52b8e5d255a:
+  _ff86d54e6acbce65590f71efbb2f826b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1177,15 +1177,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b76c6c40ae03e6a8764f2546e04a6020:
+  _51db4df26ea58b68c19901411e605b2e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1219,15 +1219,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _24a02828373c02a9d349a03fab7edbb8:
+  _02922017f2cb19d45aba8492132c7804:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -1156,15 +1156,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _992af5860bcc9a1c28b228d2673cfcde:
+  _fe2c9057aa7118b7ceddc2c7bbdc8e2d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1177,15 +1177,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e8497445432edceef823741fc78e44b2:
+  _fabeff65b904378ceac6cc67064323fe:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1219,15 +1219,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d1f6821de38423146e72153d995ad97f:
+  _fb32e519cea6f2c116bd013eec8409de:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -1156,15 +1156,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _7e04bc59253307d951350724fa2f04ce:
+  _fa860e93e45cbc4100d2fba75f35b51d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1177,15 +1177,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _0e162fef712aa9193d65f7d9c9cacec8:
+  _368f2d7a32dba79e3122c95cc87a906e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1219,15 +1219,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5e22a044c054c7a918d76a9a7eb61878:
+  _2761279f511773a7e0d3689117cf5c33:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-11.yml
+++ b/.github/workflows/mainline-clang-11.yml
@@ -967,15 +967,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _0d027f6d4a4d947cffb7496e1c16a135:
+  _315a83fa22517db93a5781d3052eb372:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -988,15 +988,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _be008c19ad3aa8d719caa3a336df796a:
+  _ad4a14cfdd7a60aff188af10540352b6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1030,15 +1030,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _7325bb746df1b067e4e5f94ea088cb6d:
+  _f93dc26c868cb14278bd57d172f7b70e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-12.yml
+++ b/.github/workflows/mainline-clang-12.yml
@@ -1009,15 +1009,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _fa482dc7e25eed59da05016a93e8278c:
+  _ae767e9ca71f590a84808a724ec476e4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1030,15 +1030,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d742dae58084b6c129fe894dca38faba:
+  _2dc2c1c0431802a1cd5273e93cf3a433:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1072,15 +1072,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _34a42eb37f34ff66ca3fcb80b692fc4d:
+  _2dff3a82fb364654e103e70b4b546e45:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-13.yml
+++ b/.github/workflows/mainline-clang-13.yml
@@ -1072,15 +1072,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3d883b6dd7ce3b5941eac52b8e5d255a:
+  _ff86d54e6acbce65590f71efbb2f826b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1093,15 +1093,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b76c6c40ae03e6a8764f2546e04a6020:
+  _51db4df26ea58b68c19901411e605b2e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1135,15 +1135,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _24a02828373c02a9d349a03fab7edbb8:
+  _02922017f2cb19d45aba8492132c7804:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -1177,15 +1177,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _992af5860bcc9a1c28b228d2673cfcde:
+  _fe2c9057aa7118b7ceddc2c7bbdc8e2d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1198,15 +1198,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e8497445432edceef823741fc78e44b2:
+  _fabeff65b904378ceac6cc67064323fe:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1240,15 +1240,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d1f6821de38423146e72153d995ad97f:
+  _fb32e519cea6f2c116bd013eec8409de:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -1177,15 +1177,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _7e04bc59253307d951350724fa2f04ce:
+  _fa860e93e45cbc4100d2fba75f35b51d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1198,15 +1198,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _0e162fef712aa9193d65f7d9c9cacec8:
+  _368f2d7a32dba79e3122c95cc87a906e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1240,15 +1240,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5e22a044c054c7a918d76a9a7eb61878:
+  _2761279f511773a7e0d3689117cf5c33:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-11.yml
+++ b/.github/workflows/next-clang-11.yml
@@ -967,15 +967,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _0d027f6d4a4d947cffb7496e1c16a135:
+  _315a83fa22517db93a5781d3052eb372:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -988,15 +988,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _be008c19ad3aa8d719caa3a336df796a:
+  _ad4a14cfdd7a60aff188af10540352b6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1030,15 +1030,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _7325bb746df1b067e4e5f94ea088cb6d:
+  _f93dc26c868cb14278bd57d172f7b70e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-12.yml
+++ b/.github/workflows/next-clang-12.yml
@@ -1009,15 +1009,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _fa482dc7e25eed59da05016a93e8278c:
+  _ae767e9ca71f590a84808a724ec476e4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1030,15 +1030,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d742dae58084b6c129fe894dca38faba:
+  _2dc2c1c0431802a1cd5273e93cf3a433:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1072,15 +1072,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _34a42eb37f34ff66ca3fcb80b692fc4d:
+  _2dff3a82fb364654e103e70b4b546e45:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-13.yml
+++ b/.github/workflows/next-clang-13.yml
@@ -1093,15 +1093,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3d883b6dd7ce3b5941eac52b8e5d255a:
+  _ff86d54e6acbce65590f71efbb2f826b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1114,15 +1114,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b76c6c40ae03e6a8764f2546e04a6020:
+  _51db4df26ea58b68c19901411e605b2e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1156,15 +1156,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _24a02828373c02a9d349a03fab7edbb8:
+  _02922017f2cb19d45aba8492132c7804:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -1198,15 +1198,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _992af5860bcc9a1c28b228d2673cfcde:
+  _fe2c9057aa7118b7ceddc2c7bbdc8e2d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1219,15 +1219,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e8497445432edceef823741fc78e44b2:
+  _fabeff65b904378ceac6cc67064323fe:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1261,15 +1261,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d1f6821de38423146e72153d995ad97f:
+  _fb32e519cea6f2c116bd013eec8409de:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -1198,15 +1198,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _7e04bc59253307d951350724fa2f04ce:
+  _fa860e93e45cbc4100d2fba75f35b51d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1219,15 +1219,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _0e162fef712aa9193d65f7d9c9cacec8:
+  _368f2d7a32dba79e3122c95cc87a906e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1261,15 +1261,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5e22a044c054c7a918d76a9a7eb61878:
+  _2761279f511773a7e0d3689117cf5c33:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-11.yml
+++ b/.github/workflows/stable-clang-11.yml
@@ -967,15 +967,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _0d027f6d4a4d947cffb7496e1c16a135:
+  _315a83fa22517db93a5781d3052eb372:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -988,15 +988,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _be008c19ad3aa8d719caa3a336df796a:
+  _ad4a14cfdd7a60aff188af10540352b6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1030,15 +1030,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _7325bb746df1b067e4e5f94ea088cb6d:
+  _f93dc26c868cb14278bd57d172f7b70e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-12.yml
+++ b/.github/workflows/stable-clang-12.yml
@@ -1030,15 +1030,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _fa482dc7e25eed59da05016a93e8278c:
+  _ae767e9ca71f590a84808a724ec476e4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1051,15 +1051,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d742dae58084b6c129fe894dca38faba:
+  _2dc2c1c0431802a1cd5273e93cf3a433:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1093,15 +1093,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _34a42eb37f34ff66ca3fcb80b692fc4d:
+  _2dff3a82fb364654e103e70b4b546e45:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -1177,15 +1177,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3d883b6dd7ce3b5941eac52b8e5d255a:
+  _ff86d54e6acbce65590f71efbb2f826b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1198,15 +1198,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b76c6c40ae03e6a8764f2546e04a6020:
+  _51db4df26ea58b68c19901411e605b2e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1240,15 +1240,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _24a02828373c02a9d349a03fab7edbb8:
+  _02922017f2cb19d45aba8492132c7804:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -1177,15 +1177,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _992af5860bcc9a1c28b228d2673cfcde:
+  _fe2c9057aa7118b7ceddc2c7bbdc8e2d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1198,15 +1198,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e8497445432edceef823741fc78e44b2:
+  _fabeff65b904378ceac6cc67064323fe:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1240,15 +1240,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d1f6821de38423146e72153d995ad97f:
+  _fb32e519cea6f2c116bd013eec8409de:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -1177,15 +1177,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _7e04bc59253307d951350724fa2f04ce:
+  _fa860e93e45cbc4100d2fba75f35b51d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1198,15 +1198,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _0e162fef712aa9193d65f7d9c9cacec8:
+  _368f2d7a32dba79e3122c95cc87a906e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_WERROR=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1240,15 +1240,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5e22a044c054c7a918d76a9a7eb61878:
+  _2761279f511773a7e0d3689117cf5c33:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/tip-clang-11.yml
+++ b/.github/workflows/tip-clang-11.yml
@@ -90,15 +90,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _0d027f6d4a4d947cffb7496e1c16a135:
+  _315a83fa22517db93a5781d3052eb372:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -132,15 +132,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _7325bb746df1b067e4e5f94ea088cb6d:
+  _f93dc26c868cb14278bd57d172f7b70e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/tip-clang-12.yml
+++ b/.github/workflows/tip-clang-12.yml
@@ -90,15 +90,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _fa482dc7e25eed59da05016a93e8278c:
+  _ae767e9ca71f590a84808a724ec476e4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -132,15 +132,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _34a42eb37f34ff66ca3fcb80b692fc4d:
+  _2dff3a82fb364654e103e70b4b546e45:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/tip-clang-13.yml
+++ b/.github/workflows/tip-clang-13.yml
@@ -90,15 +90,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _3d883b6dd7ce3b5941eac52b8e5d255a:
+  _ff86d54e6acbce65590f71efbb2f826b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -132,15 +132,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _24a02828373c02a9d349a03fab7edbb8:
+  _02922017f2cb19d45aba8492132c7804:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/tip-clang-14.yml
+++ b/.github/workflows/tip-clang-14.yml
@@ -90,15 +90,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _992af5860bcc9a1c28b228d2673cfcde:
+  _fe2c9057aa7118b7ceddc2c7bbdc8e2d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -132,15 +132,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d1f6821de38423146e72153d995ad97f:
+  _fb32e519cea6f2c116bd013eec8409de:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/tip-clang-15.yml
+++ b/.github/workflows/tip-clang-15.yml
@@ -90,15 +90,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _7e04bc59253307d951350724fa2f04ce:
+  _fa860e93e45cbc4100d2fba75f35b51d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -132,15 +132,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5e22a044c054c7a918d76a9a7eb61878:
+  _2761279f511773a7e0d3689117cf5c33:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/generator.yml
+++ b/generator.yml
@@ -258,10 +258,10 @@ configs:
   - &x86_64_cros       {<< : *x86_64-cros-configs,                                                                                                                     << : *kernel}
   - &x86_64_gki        {config: gki_defconfig,                                                                                                                         << : *kernel}
   - &x86_64_cut        {config: x86_64_cuttlefish_defconfig,                                                                                                           << : *kernel}
-  - &x86_64_allmod     {config: [allmodconfig, CONFIG_WERROR=n],                                                                                                       << : *default}
-  - &x86_64_allmod_lto {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_WERROR=n, CONFIG_LTO_CLANG_THIN=y],                                        << : *default}
+  - &x86_64_allmod     {config: allmodconfig,                                                                                                                          << : *default}
+  - &x86_64_allmod_lto {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_LTO_CLANG_THIN=y],                                                         << : *default}
   - &x86_64_allno      {config: allnoconfig,                                                                                                                           << : *default}
-  - &x86_64_allyes     {config: [allyesconfig, CONFIG_WERROR=n],                                                                                                       << : *default}
+  - &x86_64_allyes     {config: allyesconfig,                                                                                                                          << : *default}
   - &x86_64_gcov       {config: [defconfig, CONFIG_GCOV_KERNEL=y, CONFIG_GCOV_PROFILE_ALL=y],                                                                          << : *kernel}
   - &x86_64_kasan      {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],                                        << : *kernel}
   - &x86_64_kcsan      {config: [defconfig, CONFIG_KCSAN=y, CONFIG_KCSAN_KUNIT_TEST=y, CONFIG_KUNIT=y],                                                                << : *kernel}

--- a/tuxsuite/5.10-clang-11.tux.yml
+++ b/tuxsuite/5.10-clang-11.tux.yml
@@ -216,9 +216,7 @@ sets:
     git_ref: linux-5.10.y
     target_arch: x86_64
     toolchain: clang-11
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -238,9 +236,7 @@ sets:
     git_ref: linux-5.10.y
     target_arch: x86_64
     toolchain: clang-11
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/5.10-clang-12.tux.yml
+++ b/tuxsuite/5.10-clang-12.tux.yml
@@ -241,9 +241,7 @@ sets:
     git_ref: linux-5.10.y
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -263,9 +261,7 @@ sets:
     git_ref: linux-5.10.y
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/5.10-clang-13.tux.yml
+++ b/tuxsuite/5.10-clang-13.tux.yml
@@ -250,9 +250,7 @@ sets:
     git_ref: linux-5.10.y
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -272,9 +270,7 @@ sets:
     git_ref: linux-5.10.y
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/5.10-clang-14.tux.yml
+++ b/tuxsuite/5.10-clang-14.tux.yml
@@ -250,9 +250,7 @@ sets:
     git_ref: linux-5.10.y
     target_arch: x86_64
     toolchain: clang-14
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -272,9 +270,7 @@ sets:
     git_ref: linux-5.10.y
     target_arch: x86_64
     toolchain: clang-14
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/5.10-clang-15.tux.yml
+++ b/tuxsuite/5.10-clang-15.tux.yml
@@ -250,9 +250,7 @@ sets:
     git_ref: linux-5.10.y
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -272,9 +270,7 @@ sets:
     git_ref: linux-5.10.y
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/5.15-clang-11.tux.yml
+++ b/tuxsuite/5.15-clang-11.tux.yml
@@ -517,9 +517,7 @@ sets:
     git_ref: linux-5.15.y
     target_arch: x86_64
     toolchain: clang-11
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -533,7 +531,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -554,9 +551,7 @@ sets:
     git_ref: linux-5.15.y
     target_arch: x86_64
     toolchain: clang-11
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/5.15-clang-12.tux.yml
+++ b/tuxsuite/5.15-clang-12.tux.yml
@@ -554,9 +554,7 @@ sets:
     git_ref: linux-5.15.y
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -570,7 +568,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -591,9 +588,7 @@ sets:
     git_ref: linux-5.15.y
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/5.15-clang-13.tux.yml
+++ b/tuxsuite/5.15-clang-13.tux.yml
@@ -618,9 +618,7 @@ sets:
     git_ref: linux-5.15.y
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -634,7 +632,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -655,9 +652,7 @@ sets:
     git_ref: linux-5.15.y
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/5.15-clang-14.tux.yml
+++ b/tuxsuite/5.15-clang-14.tux.yml
@@ -618,9 +618,7 @@ sets:
     git_ref: linux-5.15.y
     target_arch: x86_64
     toolchain: clang-14
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -634,7 +632,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -655,9 +652,7 @@ sets:
     git_ref: linux-5.15.y
     target_arch: x86_64
     toolchain: clang-14
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/5.15-clang-15.tux.yml
+++ b/tuxsuite/5.15-clang-15.tux.yml
@@ -618,9 +618,7 @@ sets:
     git_ref: linux-5.15.y
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -634,7 +632,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -655,9 +652,7 @@ sets:
     git_ref: linux-5.15.y
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/mainline-clang-11.tux.yml
+++ b/tuxsuite/mainline-clang-11.tux.yml
@@ -515,9 +515,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-11
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -531,7 +529,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -552,9 +549,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-11
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/mainline-clang-12.tux.yml
+++ b/tuxsuite/mainline-clang-12.tux.yml
@@ -539,9 +539,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -555,7 +553,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -576,9 +573,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/mainline-clang-13.tux.yml
+++ b/tuxsuite/mainline-clang-13.tux.yml
@@ -572,9 +572,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -588,7 +586,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -609,9 +606,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/mainline-clang-14.tux.yml
+++ b/tuxsuite/mainline-clang-14.tux.yml
@@ -630,9 +630,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-14
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -646,7 +644,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -667,9 +664,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-14
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/mainline-clang-15.tux.yml
+++ b/tuxsuite/mainline-clang-15.tux.yml
@@ -630,9 +630,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -646,7 +644,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -667,9 +664,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/next-clang-11.tux.yml
+++ b/tuxsuite/next-clang-11.tux.yml
@@ -515,9 +515,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-11
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -531,7 +529,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -552,9 +549,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-11
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/next-clang-12.tux.yml
+++ b/tuxsuite/next-clang-12.tux.yml
@@ -539,9 +539,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -555,7 +553,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -576,9 +573,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/next-clang-13.tux.yml
+++ b/tuxsuite/next-clang-13.tux.yml
@@ -585,9 +585,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -601,7 +599,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -622,9 +619,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/next-clang-14.tux.yml
+++ b/tuxsuite/next-clang-14.tux.yml
@@ -643,9 +643,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-14
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -659,7 +657,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -680,9 +677,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-14
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/next-clang-15.tux.yml
+++ b/tuxsuite/next-clang-15.tux.yml
@@ -643,9 +643,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -659,7 +657,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -680,9 +677,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/stable-clang-11.tux.yml
+++ b/tuxsuite/stable-clang-11.tux.yml
@@ -515,9 +515,7 @@ sets:
     git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-11
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -531,7 +529,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -552,9 +549,7 @@ sets:
     git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-11
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/stable-clang-12.tux.yml
+++ b/tuxsuite/stable-clang-12.tux.yml
@@ -552,9 +552,7 @@ sets:
     git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -568,7 +566,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -589,9 +586,7 @@ sets:
     git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/stable-clang-13.tux.yml
+++ b/tuxsuite/stable-clang-13.tux.yml
@@ -628,9 +628,7 @@ sets:
     git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -644,7 +642,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -665,9 +662,7 @@ sets:
     git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/stable-clang-14.tux.yml
+++ b/tuxsuite/stable-clang-14.tux.yml
@@ -630,9 +630,7 @@ sets:
     git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-14
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -646,7 +644,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -667,9 +664,7 @@ sets:
     git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-14
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/stable-clang-15.tux.yml
+++ b/tuxsuite/stable-clang-15.tux.yml
@@ -630,9 +630,7 @@ sets:
     git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -646,7 +644,6 @@ sets:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_KASAN=n
-    - CONFIG_WERROR=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
@@ -667,9 +664,7 @@ sets:
     git_ref: linux-5.18.y
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/tip-clang-11.tux.yml
+++ b/tuxsuite/tip-clang-11.tux.yml
@@ -32,9 +32,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-11
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -54,9 +52,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-11
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/tip-clang-12.tux.yml
+++ b/tuxsuite/tip-clang-12.tux.yml
@@ -32,9 +32,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -54,9 +52,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-12
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/tip-clang-13.tux.yml
+++ b/tuxsuite/tip-clang-13.tux.yml
@@ -32,9 +32,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -54,9 +52,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-13
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/tip-clang-14.tux.yml
+++ b/tuxsuite/tip-clang-14.tux.yml
@@ -32,9 +32,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-14
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -54,9 +52,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-14
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:

--- a/tuxsuite/tip-clang-15.tux.yml
+++ b/tuxsuite/tip-clang-15.tux.yml
@@ -32,9 +32,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -54,9 +52,7 @@ sets:
     git_ref: master
     target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
+    kconfig: allyesconfig
     targets:
     - default
     make_variables:


### PR DESCRIPTION
x86_64 all{mod,yes}config are now -Werror clean on 5.15, stable (5.18),
mainline (5.19-rc5), and next-20220705. Turn this on so we can catch new
warnings easier.

Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/245
