### PR TITLE
Disable CONFIG_FPE_NWFPE for ARCH=arm all{mod,yes}config for now

### DIFF
--- a/.github/workflows/5.10-clang-11.yml
+++ b/.github/workflows/5.10-clang-11.yml
@@ -300,15 +300,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _a1932acc412460b9d73716e877b74b94:
+  _f02675c3e269d82807266635c02ad7b6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -342,15 +342,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _0af3671327d46b593593448c6623f2c4:
+  _ef06c7c3553967153842b94a3e5b69ce:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-12.yml
+++ b/.github/workflows/5.10-clang-12.yml
@@ -342,15 +342,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _3f7ecca7b1ed43660ac6389359fde646:
+  _a9653b7f736b9d77c0e99a7f0587b2bd:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -384,15 +384,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _0287fe965f5b39fdfef64647c19b664d:
+  _66e62a66df581e4d1847b05642e966b4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-13.yml
+++ b/.github/workflows/5.10-clang-13.yml
@@ -363,15 +363,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _1dd519d5e67fb6542ee595775814d363:
+  _f69f1db27f3120bd068ddd81c87c4512:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -405,15 +405,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _787230103202571eafef247f0ba0902e:
+  _0cdfd515237a66ae544413732ce4286f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-14.yml
+++ b/.github/workflows/5.10-clang-14.yml
@@ -363,15 +363,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _b9ae95a23a1f9360fe123a358ba16974:
+  _f29ee517d5a8d568bb07496490023d6b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -405,15 +405,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _f49c5df18e6ea748aaf9d1d04f3d3907:
+  _3c292d8add930f888cf1e0a238a0ea6a:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-15.yml
+++ b/.github/workflows/5.10-clang-15.yml
@@ -363,15 +363,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _89051d3c5ecc875fceed0120161e60ba:
+  _e7a467dbea4670b144b99068c39dcd10:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -405,15 +405,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b60653a6655790e7286714ed9e126317:
+  _84048f3c8552420d4faf1cd5214207d0:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -799,15 +799,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _a1932acc412460b9d73716e877b74b94:
+  _f02675c3e269d82807266635c02ad7b6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -841,15 +841,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _0af3671327d46b593593448c6623f2c4:
+  _ef06c7c3553967153842b94a3e5b69ce:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -862,15 +862,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _3f7ecca7b1ed43660ac6389359fde646:
+  _a9653b7f736b9d77c0e99a7f0587b2bd:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -904,15 +904,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _0287fe965f5b39fdfef64647c19b664d:
+  _66e62a66df581e4d1847b05642e966b4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -967,15 +967,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _90e50b201f4f50c1f1feb26d2c87a1a9:
+  _48a27f895bb2eedb3973ddb638fde578:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1009,15 +1009,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _cf4e033c76b67da6682ed807aa8174de:
+  _fe86242f562cc59e73c0af1f30b64916:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -967,15 +967,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _972694df5ee8d4da71b17b0ab28548fd:
+  _2fd88355de29f2c8b4b2a26c9d5cf595:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1009,15 +1009,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5bf2903b396e202f5ba34d9bb7b23d68:
+  _9b3033950c3fab2b0c7f8380baab91ca:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -967,15 +967,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _4b115193ceb7dddbc6b11c715fd79f88:
+  _a6e4dbbc13eec2f96f00a68caa1d5d54:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1009,15 +1009,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d7282ad84ff6423a6e0888102438a759:
+  _d40524afd9ba79a47e83f27ae867eb14:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android-mainline-clang-12.yml
+++ b/.github/workflows/android-mainline-clang-12.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _3f7ecca7b1ed43660ac6389359fde646:
+  _a9653b7f736b9d77c0e99a7f0587b2bd:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android-mainline-clang-13.yml
+++ b/.github/workflows/android-mainline-clang-13.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _90e50b201f4f50c1f1feb26d2c87a1a9:
+  _48a27f895bb2eedb3973ddb638fde578:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android-mainline-clang-14.yml
+++ b/.github/workflows/android-mainline-clang-14.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _972694df5ee8d4da71b17b0ab28548fd:
+  _2fd88355de29f2c8b4b2a26c9d5cf595:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android-mainline-clang-15.yml
+++ b/.github/workflows/android-mainline-clang-15.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _4b115193ceb7dddbc6b11c715fd79f88:
+  _a6e4dbbc13eec2f96f00a68caa1d5d54:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android-mainline-clang-android.yml
+++ b/.github/workflows/android-mainline-clang-android.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _3e71a2c8bacb12efca0c94754c72d387:
+  _9b3dcc46eb702001e4e00806ea56eb1b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: android
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android12-5.10-clang-12.yml
+++ b/.github/workflows/android12-5.10-clang-12.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _3f7ecca7b1ed43660ac6389359fde646:
+  _a9653b7f736b9d77c0e99a7f0587b2bd:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android12-5.10-clang-13.yml
+++ b/.github/workflows/android12-5.10-clang-13.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _90e50b201f4f50c1f1feb26d2c87a1a9:
+  _48a27f895bb2eedb3973ddb638fde578:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android12-5.10-clang-14.yml
+++ b/.github/workflows/android12-5.10-clang-14.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _972694df5ee8d4da71b17b0ab28548fd:
+  _2fd88355de29f2c8b4b2a26c9d5cf595:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android12-5.10-clang-15.yml
+++ b/.github/workflows/android12-5.10-clang-15.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _4b115193ceb7dddbc6b11c715fd79f88:
+  _a6e4dbbc13eec2f96f00a68caa1d5d54:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android12-5.10-clang-android.yml
+++ b/.github/workflows/android12-5.10-clang-android.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _3e71a2c8bacb12efca0c94754c72d387:
+  _9b3dcc46eb702001e4e00806ea56eb1b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: android
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android12-5.4-clang-12.yml
+++ b/.github/workflows/android12-5.4-clang-12.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _3f7ecca7b1ed43660ac6389359fde646:
+  _a9653b7f736b9d77c0e99a7f0587b2bd:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android12-5.4-clang-13.yml
+++ b/.github/workflows/android12-5.4-clang-13.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _90e50b201f4f50c1f1feb26d2c87a1a9:
+  _48a27f895bb2eedb3973ddb638fde578:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android12-5.4-clang-14.yml
+++ b/.github/workflows/android12-5.4-clang-14.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _972694df5ee8d4da71b17b0ab28548fd:
+  _2fd88355de29f2c8b4b2a26c9d5cf595:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android12-5.4-clang-15.yml
+++ b/.github/workflows/android12-5.4-clang-15.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _4b115193ceb7dddbc6b11c715fd79f88:
+  _a6e4dbbc13eec2f96f00a68caa1d5d54:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android12-5.4-clang-android.yml
+++ b/.github/workflows/android12-5.4-clang-android.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _3e71a2c8bacb12efca0c94754c72d387:
+  _9b3dcc46eb702001e4e00806ea56eb1b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: android
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android13-5.10-clang-12.yml
+++ b/.github/workflows/android13-5.10-clang-12.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _3f7ecca7b1ed43660ac6389359fde646:
+  _a9653b7f736b9d77c0e99a7f0587b2bd:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android13-5.10-clang-13.yml
+++ b/.github/workflows/android13-5.10-clang-13.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _90e50b201f4f50c1f1feb26d2c87a1a9:
+  _48a27f895bb2eedb3973ddb638fde578:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android13-5.10-clang-14.yml
+++ b/.github/workflows/android13-5.10-clang-14.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _972694df5ee8d4da71b17b0ab28548fd:
+  _2fd88355de29f2c8b4b2a26c9d5cf595:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android13-5.10-clang-15.yml
+++ b/.github/workflows/android13-5.10-clang-15.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _4b115193ceb7dddbc6b11c715fd79f88:
+  _a6e4dbbc13eec2f96f00a68caa1d5d54:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android13-5.10-clang-android.yml
+++ b/.github/workflows/android13-5.10-clang-android.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _3e71a2c8bacb12efca0c94754c72d387:
+  _9b3dcc46eb702001e4e00806ea56eb1b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: android
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android13-5.15-clang-12.yml
+++ b/.github/workflows/android13-5.15-clang-12.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _3f7ecca7b1ed43660ac6389359fde646:
+  _a9653b7f736b9d77c0e99a7f0587b2bd:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android13-5.15-clang-13.yml
+++ b/.github/workflows/android13-5.15-clang-13.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _90e50b201f4f50c1f1feb26d2c87a1a9:
+  _48a27f895bb2eedb3973ddb638fde578:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android13-5.15-clang-14.yml
+++ b/.github/workflows/android13-5.15-clang-14.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _972694df5ee8d4da71b17b0ab28548fd:
+  _2fd88355de29f2c8b4b2a26c9d5cf595:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android13-5.15-clang-15.yml
+++ b/.github/workflows/android13-5.15-clang-15.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _4b115193ceb7dddbc6b11c715fd79f88:
+  _a6e4dbbc13eec2f96f00a68caa1d5d54:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android13-5.15-clang-android.yml
+++ b/.github/workflows/android13-5.15-clang-android.yml
@@ -111,15 +111,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _3e71a2c8bacb12efca0c94754c72d387:
+  _9b3dcc46eb702001e4e00806ea56eb1b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: android
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-11.yml
+++ b/.github/workflows/mainline-clang-11.yml
@@ -820,15 +820,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _a1932acc412460b9d73716e877b74b94:
+  _f02675c3e269d82807266635c02ad7b6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-12.yml
+++ b/.github/workflows/mainline-clang-12.yml
@@ -862,15 +862,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _3f7ecca7b1ed43660ac6389359fde646:
+  _a9653b7f736b9d77c0e99a7f0587b2bd:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-13.yml
+++ b/.github/workflows/mainline-clang-13.yml
@@ -883,15 +883,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _90e50b201f4f50c1f1feb26d2c87a1a9:
+  _48a27f895bb2eedb3973ddb638fde578:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -925,15 +925,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _cf4e033c76b67da6682ed807aa8174de:
+  _fe86242f562cc59e73c0af1f30b64916:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -988,15 +988,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _972694df5ee8d4da71b17b0ab28548fd:
+  _2fd88355de29f2c8b4b2a26c9d5cf595:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1030,15 +1030,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5bf2903b396e202f5ba34d9bb7b23d68:
+  _9b3033950c3fab2b0c7f8380baab91ca:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -988,15 +988,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _4b115193ceb7dddbc6b11c715fd79f88:
+  _a6e4dbbc13eec2f96f00a68caa1d5d54:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1030,15 +1030,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d7282ad84ff6423a6e0888102438a759:
+  _d40524afd9ba79a47e83f27ae867eb14:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-11.yml
+++ b/.github/workflows/next-clang-11.yml
@@ -820,15 +820,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _a1932acc412460b9d73716e877b74b94:
+  _f02675c3e269d82807266635c02ad7b6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-12.yml
+++ b/.github/workflows/next-clang-12.yml
@@ -862,15 +862,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _3f7ecca7b1ed43660ac6389359fde646:
+  _a9653b7f736b9d77c0e99a7f0587b2bd:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-13.yml
+++ b/.github/workflows/next-clang-13.yml
@@ -904,15 +904,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _90e50b201f4f50c1f1feb26d2c87a1a9:
+  _48a27f895bb2eedb3973ddb638fde578:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -946,15 +946,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _cf4e033c76b67da6682ed807aa8174de:
+  _fe86242f562cc59e73c0af1f30b64916:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -1009,15 +1009,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _972694df5ee8d4da71b17b0ab28548fd:
+  _2fd88355de29f2c8b4b2a26c9d5cf595:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1051,15 +1051,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5bf2903b396e202f5ba34d9bb7b23d68:
+  _9b3033950c3fab2b0c7f8380baab91ca:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -1009,15 +1009,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _4b115193ceb7dddbc6b11c715fd79f88:
+  _a6e4dbbc13eec2f96f00a68caa1d5d54:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1051,15 +1051,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d7282ad84ff6423a6e0888102438a759:
+  _d40524afd9ba79a47e83f27ae867eb14:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-android.yml
+++ b/.github/workflows/next-clang-android.yml
@@ -321,15 +321,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _bcc4f57380794ab069ddb0e22c4e2db4:
+  _0071e5d41b9df421b32247bb69e720e1:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=android allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: android
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-11.yml
+++ b/.github/workflows/stable-clang-11.yml
@@ -820,15 +820,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _a1932acc412460b9d73716e877b74b94:
+  _f02675c3e269d82807266635c02ad7b6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 11
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-12.yml
+++ b/.github/workflows/stable-clang-12.yml
@@ -883,15 +883,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _3f7ecca7b1ed43660ac6389359fde646:
+  _a9653b7f736b9d77c0e99a7f0587b2bd:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 12
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -988,15 +988,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _90e50b201f4f50c1f1feb26d2c87a1a9:
+  _48a27f895bb2eedb3973ddb638fde578:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1030,15 +1030,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _cf4e033c76b67da6682ed807aa8174de:
+  _fe86242f562cc59e73c0af1f30b64916:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -988,15 +988,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _972694df5ee8d4da71b17b0ab28548fd:
+  _2fd88355de29f2c8b4b2a26c9d5cf595:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1030,15 +1030,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5bf2903b396e202f5ba34d9bb7b23d68:
+  _9b3033950c3fab2b0c7f8380baab91ca:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -988,15 +988,15 @@ jobs:
         path: builds.json
         name: output_artifact_allconfigs
         if-no-files-found: error
-  _4b115193ceb7dddbc6b11c715fd79f88:
+  _a6e4dbbc13eec2f96f00a68caa1d5d54:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n
+      CONFIG: allmodconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -1030,15 +1030,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _d7282ad84ff6423a6e0888102438a759:
+  _d40524afd9ba79a47e83f27ae867eb14:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n
+    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     env:
       ARCH: arm
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n
+      CONFIG: allyesconfig+CONFIG_FPE_NWFPE=n+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/generator.yml
+++ b/generator.yml
@@ -201,9 +201,9 @@ configs:
   - &arm32_imx         {config: imx_v4_v5_defconfig,                                                                                       << : *arm-triple,           << : *default}
   - &arm32_omap        {config: omap2plus_defconfig,                                                                                       << : *arm-triple,           << : *default}
   - &arm32_lpae_fp     {config: [multi_v7_defconfig, CONFIG_ARM_LPAE=y, CONFIG_UNWINDER_FRAME_POINTER=y],                                  << : *arm-triple,           << : *kernel}
-  - &arm32_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                                                           << : *arm-triple,           << : *default}
+  - &arm32_allmod      {config: [allmodconfig, CONFIG_FPE_NWFPE=n, CONFIG_WERROR=n],                                                       << : *arm-triple,           << : *default}
   - &arm32_allno       {config: allnoconfig,                                                                                               << : *arm-triple,           << : *default}
-  - &arm32_allyes      {config: [allyesconfig, CONFIG_WERROR=n],                                                                           << : *arm-triple,           << : *default}
+  - &arm32_allyes      {config: [allyesconfig, CONFIG_FPE_NWFPE=n, CONFIG_WERROR=n],                                                       << : *arm-triple,           << : *default}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
   - &arm32_fedora      {config: [*arm32-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                          << : *arm-triple,           << : *kernel}
   - &arm32_suse        {config: *arm32-suse-config-url,                                                                                    << : *arm-triple,           << : *kernel}

--- a/tuxsuite/5.10-clang-11.tux.yml
+++ b/tuxsuite/5.10-clang-11.tux.yml
@@ -150,6 +150,7 @@ sets:
     toolchain: clang-11
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -172,6 +173,7 @@ sets:
     toolchain: clang-11
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/5.10-clang-12.tux.yml
+++ b/tuxsuite/5.10-clang-12.tux.yml
@@ -175,6 +175,7 @@ sets:
     toolchain: clang-12
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -197,6 +198,7 @@ sets:
     toolchain: clang-12
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/5.10-clang-13.tux.yml
+++ b/tuxsuite/5.10-clang-13.tux.yml
@@ -184,6 +184,7 @@ sets:
     toolchain: clang-13
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -206,6 +207,7 @@ sets:
     toolchain: clang-13
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/5.10-clang-14.tux.yml
+++ b/tuxsuite/5.10-clang-14.tux.yml
@@ -184,6 +184,7 @@ sets:
     toolchain: clang-14
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -206,6 +207,7 @@ sets:
     toolchain: clang-14
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/5.10-clang-15.tux.yml
+++ b/tuxsuite/5.10-clang-15.tux.yml
@@ -184,6 +184,7 @@ sets:
     toolchain: clang-nightly
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -206,6 +207,7 @@ sets:
     toolchain: clang-nightly
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/5.15-clang-11.tux.yml
+++ b/tuxsuite/5.15-clang-11.tux.yml
@@ -423,6 +423,7 @@ sets:
     toolchain: clang-11
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -445,6 +446,7 @@ sets:
     toolchain: clang-11
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/5.15-clang-12.tux.yml
+++ b/tuxsuite/5.15-clang-12.tux.yml
@@ -460,6 +460,7 @@ sets:
     toolchain: clang-12
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -482,6 +483,7 @@ sets:
     toolchain: clang-12
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/5.15-clang-13.tux.yml
+++ b/tuxsuite/5.15-clang-13.tux.yml
@@ -514,6 +514,7 @@ sets:
     toolchain: clang-13
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -536,6 +537,7 @@ sets:
     toolchain: clang-13
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/5.15-clang-14.tux.yml
+++ b/tuxsuite/5.15-clang-14.tux.yml
@@ -514,6 +514,7 @@ sets:
     toolchain: clang-14
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -536,6 +537,7 @@ sets:
     toolchain: clang-14
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/5.15-clang-15.tux.yml
+++ b/tuxsuite/5.15-clang-15.tux.yml
@@ -514,6 +514,7 @@ sets:
     toolchain: clang-nightly
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -536,6 +537,7 @@ sets:
     toolchain: clang-nightly
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android-mainline-clang-12.tux.yml
+++ b/tuxsuite/android-mainline-clang-12.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-12
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android-mainline-clang-13.tux.yml
+++ b/tuxsuite/android-mainline-clang-13.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-13
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android-mainline-clang-14.tux.yml
+++ b/tuxsuite/android-mainline-clang-14.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-14
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android-mainline-clang-15.tux.yml
+++ b/tuxsuite/android-mainline-clang-15.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-nightly
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android-mainline-clang-android.tux.yml
+++ b/tuxsuite/android-mainline-clang-android.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-android
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android12-5.10-clang-12.tux.yml
+++ b/tuxsuite/android12-5.10-clang-12.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-12
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android12-5.10-clang-13.tux.yml
+++ b/tuxsuite/android12-5.10-clang-13.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-13
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android12-5.10-clang-14.tux.yml
+++ b/tuxsuite/android12-5.10-clang-14.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-14
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android12-5.10-clang-15.tux.yml
+++ b/tuxsuite/android12-5.10-clang-15.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-nightly
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android12-5.10-clang-android.tux.yml
+++ b/tuxsuite/android12-5.10-clang-android.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-android
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android12-5.4-clang-12.tux.yml
+++ b/tuxsuite/android12-5.4-clang-12.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-12
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android12-5.4-clang-13.tux.yml
+++ b/tuxsuite/android12-5.4-clang-13.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-13
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android12-5.4-clang-14.tux.yml
+++ b/tuxsuite/android12-5.4-clang-14.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-14
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android12-5.4-clang-15.tux.yml
+++ b/tuxsuite/android12-5.4-clang-15.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-nightly
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android12-5.4-clang-android.tux.yml
+++ b/tuxsuite/android12-5.4-clang-android.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-android
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android13-5.10-clang-12.tux.yml
+++ b/tuxsuite/android13-5.10-clang-12.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-12
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android13-5.10-clang-13.tux.yml
+++ b/tuxsuite/android13-5.10-clang-13.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-13
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android13-5.10-clang-14.tux.yml
+++ b/tuxsuite/android13-5.10-clang-14.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-14
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android13-5.10-clang-15.tux.yml
+++ b/tuxsuite/android13-5.10-clang-15.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-nightly
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android13-5.10-clang-android.tux.yml
+++ b/tuxsuite/android13-5.10-clang-android.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-android
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android13-5.15-clang-12.tux.yml
+++ b/tuxsuite/android13-5.15-clang-12.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-12
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android13-5.15-clang-13.tux.yml
+++ b/tuxsuite/android13-5.15-clang-13.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-13
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android13-5.15-clang-14.tux.yml
+++ b/tuxsuite/android13-5.15-clang-14.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-14
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android13-5.15-clang-15.tux.yml
+++ b/tuxsuite/android13-5.15-clang-15.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-nightly
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/android13-5.15-clang-android.tux.yml
+++ b/tuxsuite/android13-5.15-clang-android.tux.yml
@@ -46,6 +46,7 @@ sets:
     toolchain: clang-android
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/mainline-clang-11.tux.yml
+++ b/tuxsuite/mainline-clang-11.tux.yml
@@ -433,6 +433,7 @@ sets:
     toolchain: clang-11
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/mainline-clang-12.tux.yml
+++ b/tuxsuite/mainline-clang-12.tux.yml
@@ -457,6 +457,7 @@ sets:
     toolchain: clang-12
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/mainline-clang-13.tux.yml
+++ b/tuxsuite/mainline-clang-13.tux.yml
@@ -468,6 +468,7 @@ sets:
     toolchain: clang-13
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -490,6 +491,7 @@ sets:
     toolchain: clang-13
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/mainline-clang-14.tux.yml
+++ b/tuxsuite/mainline-clang-14.tux.yml
@@ -526,6 +526,7 @@ sets:
     toolchain: clang-14
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -548,6 +549,7 @@ sets:
     toolchain: clang-14
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/mainline-clang-15.tux.yml
+++ b/tuxsuite/mainline-clang-15.tux.yml
@@ -526,6 +526,7 @@ sets:
     toolchain: clang-nightly
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -548,6 +549,7 @@ sets:
     toolchain: clang-nightly
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/next-clang-11.tux.yml
+++ b/tuxsuite/next-clang-11.tux.yml
@@ -433,6 +433,7 @@ sets:
     toolchain: clang-11
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/next-clang-12.tux.yml
+++ b/tuxsuite/next-clang-12.tux.yml
@@ -457,6 +457,7 @@ sets:
     toolchain: clang-12
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/next-clang-13.tux.yml
+++ b/tuxsuite/next-clang-13.tux.yml
@@ -481,6 +481,7 @@ sets:
     toolchain: clang-13
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -503,6 +504,7 @@ sets:
     toolchain: clang-13
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/next-clang-14.tux.yml
+++ b/tuxsuite/next-clang-14.tux.yml
@@ -539,6 +539,7 @@ sets:
     toolchain: clang-14
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -561,6 +562,7 @@ sets:
     toolchain: clang-14
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/next-clang-15.tux.yml
+++ b/tuxsuite/next-clang-15.tux.yml
@@ -539,6 +539,7 @@ sets:
     toolchain: clang-nightly
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -561,6 +562,7 @@ sets:
     toolchain: clang-nightly
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/next-clang-android.tux.yml
+++ b/tuxsuite/next-clang-android.tux.yml
@@ -161,6 +161,7 @@ sets:
     toolchain: clang-android
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/stable-clang-11.tux.yml
+++ b/tuxsuite/stable-clang-11.tux.yml
@@ -433,6 +433,7 @@ sets:
     toolchain: clang-11
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/stable-clang-12.tux.yml
+++ b/tuxsuite/stable-clang-12.tux.yml
@@ -470,6 +470,7 @@ sets:
     toolchain: clang-12
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/stable-clang-13.tux.yml
+++ b/tuxsuite/stable-clang-13.tux.yml
@@ -524,6 +524,7 @@ sets:
     toolchain: clang-13
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -546,6 +547,7 @@ sets:
     toolchain: clang-13
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/stable-clang-14.tux.yml
+++ b/tuxsuite/stable-clang-14.tux.yml
@@ -526,6 +526,7 @@ sets:
     toolchain: clang-14
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -548,6 +549,7 @@ sets:
     toolchain: clang-14
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default

--- a/tuxsuite/stable-clang-15.tux.yml
+++ b/tuxsuite/stable-clang-15.tux.yml
@@ -526,6 +526,7 @@ sets:
     toolchain: clang-nightly
     kconfig:
     - allmodconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default
@@ -548,6 +549,7 @@ sets:
     toolchain: clang-nightly
     kconfig:
     - allyesconfig
+    - CONFIG_FPE_NWFPE=n
     - CONFIG_WERROR=n
     targets:
     - default


### PR DESCRIPTION
There is a compiler inserted call to `__aeabi_uldivmod`, which causes an
error at link time because the kernel does not link against compiler-rt.

Disable this configuration until it can be dealt with.

Link: https://github.com/ClangBuiltLinux/linux/issues/1666
