### PR TITLE
utils.py: Adjust for new builds.json output with 'tuxsuite plan'

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -111,7 +111,7 @@ def _read_builds():
     except FileNotFoundError as e:
         print_red("Unable to find %s. Artifact not saved?" % (builds))
         raise e
-    return builds
+    return builds["builds"].values()
 
 
 def get_requested_llvm_version():


### PR DESCRIPTION
After the switch to `tuxsuite plan`, `builds.json` cannot be parsed
properly in `get_build()`:

```
  Traceback (most recent call last):
    File "/__w/continuous-integration2/continuous-integration2/./check_logs.py", line 267, in <module>
      build = verify_build()
    File "/__w/continuous-integration2/continuous-integration2/./check_logs.py", line 58, in verify_build
      build = get_build()
    File "/__w/continuous-integration2/continuous-integration2/utils.py", line 138, in get_build
      if build["target_arch"] == arch and \
  TypeError: string indices must be integers
```

This is because the format of `builds.json` has been changed to be a
dictionary with a `builds` key and `tests` key, as opposed to a list of
build dictionaries like before.

To resolve this, get the values of the `build` dictionary, which will be
the same format as `tuxsuite build-set`, so that we can continue to
iterate through and test kernels that we build with the scheme we know
works.
