### PR TITLE
patches: mainline: Add a couple in-flight -Wformat fixes

### DIFF
--- a/patches/mainline/a44252d5c3bbd76efa7b65819712f0e2b1de54c0.patch
+++ b/patches/mainline/a44252d5c3bbd76efa7b65819712f0e2b1de54c0.patch
@@ -1,0 +1,81 @@
+From a44252d5c3bbd76efa7b65819712f0e2b1de54c0 Mon Sep 17 00:00:00 2001
+From: Justin Stitt <justinstitt@google.com>
+Date: Mon, 11 Jul 2022 16:01:48 -0700
+Subject: [PATCH] ntb: idt: fix clang -Wformat warnings
+
+When building with Clang we encounter these warnings:
+| drivers/ntb/hw/idt/ntb_hw_idt.c:2409:28: error: format specifies type
+| 'unsigned char' but the argument has type 'int' [-Werror,-Wformat]
+| "\t%hhu-%hhu.\t", idx + cnt - 1);
+-
+| drivers/ntb/hw/idt/ntb_hw_idt.c:2438:29: error: format specifies type
+| 'unsigned char' but the argument has type 'int' [-Werror,-Wformat]
+| "\t%hhu-%hhu.\t", idx + cnt - 1);
+-
+| drivers/ntb/hw/idt/ntb_hw_idt.c:2484:15: error: format specifies type
+| 'unsigned char' but the argument has type 'int' [-Werror,-Wformat], src);
+
+For the first two warnings the format specifier used is `%hhu` which
+describes a u8. Both `idx` and `cnt` are u8 as well. However, the
+expression as a whole is promoted to an int as you cannot get
+smaller-than-int from addition. Therefore, to fix the warning, use the
+promoted-to-type's format specifier -- in this case `%d`.
+
+example:
+``
+uint8_t a = 4, b = 7;
+int size = sizeof(a + b - 1);
+printf("%d\n", size);
+// output: 4
+```
+
+For the last warning, src is of type `int` while the format specifier
+describes a u8. The fix here is just to use the proper specifier `%d`.
+
+See more:
+(https://wiki.sei.cmu.edu/confluence/display/c/INT02-C.+Understand+integer+conversion+rules)
+"Integer types smaller than int are promoted when an operation is
+performed on them. If all values of the original type can be represented
+as an int, the value of the smaller type is converted to an int;
+otherwise, it is converted to an unsigned int."
+
+Link: https://github.com/ClangBuiltLinux/linux/issues/378
+Signed-off-by: Justin Stitt <justinstitt@google.com>
+Acked-by: Serge Semin <fancer.lancer@gmail.com>
+Signed-off-by: Jon Mason <jdmason@kudzu.us>
+Link: https://github.com/jonmason/ntb/commit/a44252d5c3bbd76efa7b65819712f0e2b1de54c0
+---
+ drivers/ntb/hw/idt/ntb_hw_idt.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/ntb/hw/idt/ntb_hw_idt.c b/drivers/ntb/hw/idt/ntb_hw_idt.c
+index 733557231ed0..0ed6f809ff2e 100644
+--- a/drivers/ntb/hw/idt/ntb_hw_idt.c
++++ b/drivers/ntb/hw/idt/ntb_hw_idt.c
+@@ -2406,7 +2406,7 @@ static ssize_t idt_dbgfs_info_read(struct file *filp, char __user *ubuf,
+ 				"\t%hhu.\t", idx);
+ 		else
+ 			off += scnprintf(strbuf + off, size - off,
+-				"\t%hhu-%hhu.\t", idx, idx + cnt - 1);
++				"\t%hhu-%d.\t", idx, idx + cnt - 1);
+ 
+ 		off += scnprintf(strbuf + off, size - off, "%s BAR%hhu, ",
+ 			idt_get_mw_name(data), ndev->mws[idx].bar);
+@@ -2435,7 +2435,7 @@ static ssize_t idt_dbgfs_info_read(struct file *filp, char __user *ubuf,
+ 					"\t%hhu.\t", idx);
+ 			else
+ 				off += scnprintf(strbuf + off, size - off,
+-					"\t%hhu-%hhu.\t", idx, idx + cnt - 1);
++					"\t%hhu-%d.\t", idx, idx + cnt - 1);
+ 
+ 			off += scnprintf(strbuf + off, size - off,
+ 				"%s BAR%hhu, ", idt_get_mw_name(data),
+@@ -2480,7 +2480,7 @@ static ssize_t idt_dbgfs_info_read(struct file *filp, char __user *ubuf,
+ 		int src;
+ 		data = idt_ntb_msg_read(&ndev->ntb, &src, idx);
+ 		off += scnprintf(strbuf + off, size - off,
+-			"\t%hhu. 0x%08x from peer %hhu (Port %hhu)\n",
++			"\t%hhu. 0x%08x from peer %d (Port %hhu)\n",
+ 			idx, data, src, ndev->peers[src].port);
+ 	}
+ 	off += scnprintf(strbuf + off, size - off, "\n");

--- a/patches/mainline/b7bf23c0865faac61564425ddc96a4a79ebf19b0.patch
+++ b/patches/mainline/b7bf23c0865faac61564425ddc96a4a79ebf19b0.patch
@@ -1,0 +1,42 @@
+From b7bf23c0865faac61564425ddc96a4a79ebf19b0 Mon Sep 17 00:00:00 2001
+From: Justin Stitt <justinstitt@google.com>
+Date: Wed, 3 Aug 2022 13:44:42 -0700
+Subject: ASoC: SOF: ipc3-topology: Fix clang -Wformat warning
+
+When building with Clang we encounter these warnings:
+| sound/soc/sof/ipc3-topology.c:2343:4: error: format specifies type
+| 'unsigned char' but the argument has type 'int' [-Werror,-Wformat]
+|                  SOF_ABI_MAJOR, SOF_ABI_MINOR, SOF_ABI_PATCH);
+|                  ^~~~~~~~~~~~~~~^~~~~~~~~~~~~~~^~~~~~~~~~~~~
+
+Use correct format specifier `%d` since args are of type int.
+
+Link: https://github.com/ClangBuiltLinux/linux/issues/378
+Reported-by: Nathan Chancellor <nathan@kernel.org>
+Suggested-by: Nathan Chancellor <nathan@kernel.org>
+Signed-off-by: Justin Stitt <justinstitt@google.com>
+Reviewed-by: Nathan Chancellor <nathan@kernel.org>
+Acked-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>
+Link: https://lore.kernel.org/r/20220803204442.2996580-1-justinstitt@google.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+Link: https://git.kernel.org/broonie/sound/c/b7bf23c0865faac61564425ddc96a4a79ebf19b0
+---
+ sound/soc/sof/ipc3-topology.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sound/soc/sof/ipc3-topology.c b/sound/soc/sof/ipc3-topology.c
+index b2cc046b9f606..65923e7a5976f 100644
+--- a/sound/soc/sof/ipc3-topology.c
++++ b/sound/soc/sof/ipc3-topology.c
+@@ -2338,7 +2338,7 @@ static int sof_ipc3_parse_manifest(struct snd_soc_component *scomp, int index,
+ 	}
+ 
+ 	dev_info(scomp->dev,
+-		 "Topology: ABI %d:%d:%d Kernel ABI %hhu:%hhu:%hhu\n",
++		 "Topology: ABI %d:%d:%d Kernel ABI %d:%d:%d\n",
+ 		 man->priv.data[0], man->priv.data[1], man->priv.data[2],
+ 		 SOF_ABI_MAJOR, SOF_ABI_MINOR, SOF_ABI_PATCH);
+ 
+-- 
+cgit 
+

--- a/patches/mainline/series
+++ b/patches/mainline/series
@@ -1,2 +1,4 @@
 0001-HACK-drm-amd-display-Increase-frame_warn_flag-value.patch
+a44252d5c3bbd76efa7b65819712f0e2b1de54c0.patch
+b7bf23c0865faac61564425ddc96a4a79ebf19b0.patch
 f0d749baaed896dfa02dcb6399f5febcca93931a.patch


### PR DESCRIPTION
The patch to enable `-Wformat` was merged before these fixes were
available in mainline. Apply them until they are merged so that we do
not have to disable `-Werror` for x86_64.
