### PR TITLE
Remove CONFIG_PPC_DISABLE_WERROR from powernv_defconfig

### DIFF
--- a/.github/workflows/4.14-clang-13.yml
+++ b/.github/workflows/4.14-clang-13.yml
@@ -116,15 +116,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _8bdfe8f660ca284393c576d9b4563ba6:
+  _f4d3de3db46c87da313d87e1f3f6dc29:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/4.14-clang-14.yml
+++ b/.github/workflows/4.14-clang-14.yml
@@ -116,15 +116,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _57c46a362e1b56b6f82fdd197bd5d18b:
+  _93adcc31e3e500dcde3470940f30d9f4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=14 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=14 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/4.14-clang-16.yml
+++ b/.github/workflows/4.14-clang-16.yml
@@ -116,15 +116,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ac3b935c868a9b249dd1545e5f5e68ae:
+  _55e7f18babe91e14f4c76373037be43e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=16 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=16 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/4.19-clang-13.yml
+++ b/.github/workflows/4.19-clang-13.yml
@@ -116,15 +116,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _8bdfe8f660ca284393c576d9b4563ba6:
+  _f4d3de3db46c87da313d87e1f3f6dc29:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/4.19-clang-14.yml
+++ b/.github/workflows/4.19-clang-14.yml
@@ -116,15 +116,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _57c46a362e1b56b6f82fdd197bd5d18b:
+  _93adcc31e3e500dcde3470940f30d9f4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=14 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=14 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/4.19-clang-16.yml
+++ b/.github/workflows/4.19-clang-16.yml
@@ -116,15 +116,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ac3b935c868a9b249dd1545e5f5e68ae:
+  _55e7f18babe91e14f4c76373037be43e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=16 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=16 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-11.yml
+++ b/.github/workflows/5.10-clang-11.yml
@@ -200,15 +200,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _eb179ee8cabd84de827f89a3a56cb369:
+  _479b82ae68113f446f1f8a6cd14f002e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-12.yml
+++ b/.github/workflows/5.10-clang-12.yml
@@ -242,15 +242,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _92f8acd7507e587d5a6ed01881cec762:
+  _e7d400a7f60ea696f730ba8de7f3d281:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-13.yml
+++ b/.github/workflows/5.10-clang-13.yml
@@ -263,15 +263,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2736eb7d845c26849f2e1e671de1c4c6:
+  _848b558acb7e2487ba2d59cd1a85aa7a:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-14.yml
+++ b/.github/workflows/5.10-clang-14.yml
@@ -263,15 +263,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e3cfe7a1328a1ea5b426c454c9171682:
+  _58f0a88b2eb14c651a657df2ed1232ce:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-16.yml
+++ b/.github/workflows/5.10-clang-16.yml
@@ -263,15 +263,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _db17b98945f52822a31848f55c60a97c:
+  _85efced33a2a95489133da95197716f3:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -389,15 +389,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b790b8d0484994cda5c42e47c497f636:
+  _e96b0d0f9698e45a12b0f7d394eaa634:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -452,15 +452,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _92f8acd7507e587d5a6ed01881cec762:
+  _e7d400a7f60ea696f730ba8de7f3d281:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -473,15 +473,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2736eb7d845c26849f2e1e671de1c4c6:
+  _848b558acb7e2487ba2d59cd1a85aa7a:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -473,15 +473,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e3cfe7a1328a1ea5b426c454c9171682:
+  _58f0a88b2eb14c651a657df2ed1232ce:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-16.yml
+++ b/.github/workflows/5.15-clang-16.yml
@@ -473,15 +473,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _db17b98945f52822a31848f55c60a97c:
+  _85efced33a2a95489133da95197716f3:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.4-clang-13.yml
+++ b/.github/workflows/5.4-clang-13.yml
@@ -200,15 +200,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2736eb7d845c26849f2e1e671de1c4c6:
+  _848b558acb7e2487ba2d59cd1a85aa7a:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.4-clang-14.yml
+++ b/.github/workflows/5.4-clang-14.yml
@@ -200,15 +200,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e3cfe7a1328a1ea5b426c454c9171682:
+  _58f0a88b2eb14c651a657df2ed1232ce:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.4-clang-16.yml
+++ b/.github/workflows/5.4-clang-16.yml
@@ -200,15 +200,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _db17b98945f52822a31848f55c60a97c:
+  _85efced33a2a95489133da95197716f3:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-11.yml
+++ b/.github/workflows/mainline-clang-11.yml
@@ -389,15 +389,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b790b8d0484994cda5c42e47c497f636:
+  _e96b0d0f9698e45a12b0f7d394eaa634:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-12.yml
+++ b/.github/workflows/mainline-clang-12.yml
@@ -410,15 +410,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _92f8acd7507e587d5a6ed01881cec762:
+  _e7d400a7f60ea696f730ba8de7f3d281:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-13.yml
+++ b/.github/workflows/mainline-clang-13.yml
@@ -431,15 +431,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2736eb7d845c26849f2e1e671de1c4c6:
+  _848b558acb7e2487ba2d59cd1a85aa7a:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -452,15 +452,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _8cf2cd85fe85d2a203f29424b6d94430:
+  _bb6ccfec079fa3e317bf9277bd03f988:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -452,15 +452,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _f802ff95ecc0ddac450ec9dca367b1db:
+  _66b11476fd94a8edd812ef3f2955f594:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-11.yml
+++ b/.github/workflows/next-clang-11.yml
@@ -389,15 +389,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b790b8d0484994cda5c42e47c497f636:
+  _e96b0d0f9698e45a12b0f7d394eaa634:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-12.yml
+++ b/.github/workflows/next-clang-12.yml
@@ -410,15 +410,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _92f8acd7507e587d5a6ed01881cec762:
+  _e7d400a7f60ea696f730ba8de7f3d281:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-13.yml
+++ b/.github/workflows/next-clang-13.yml
@@ -431,15 +431,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2736eb7d845c26849f2e1e671de1c4c6:
+  _848b558acb7e2487ba2d59cd1a85aa7a:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -452,15 +452,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _8cf2cd85fe85d2a203f29424b6d94430:
+  _bb6ccfec079fa3e317bf9277bd03f988:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -452,15 +452,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _f802ff95ecc0ddac450ec9dca367b1db:
+  _66b11476fd94a8edd812ef3f2955f594:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-11.yml
+++ b/.github/workflows/stable-clang-11.yml
@@ -389,15 +389,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b790b8d0484994cda5c42e47c497f636:
+  _e96b0d0f9698e45a12b0f7d394eaa634:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-12.yml
+++ b/.github/workflows/stable-clang-12.yml
@@ -431,15 +431,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _92f8acd7507e587d5a6ed01881cec762:
+  _e7d400a7f60ea696f730ba8de7f3d281:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -452,15 +452,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2736eb7d845c26849f2e1e671de1c4c6:
+  _848b558acb7e2487ba2d59cd1a85aa7a:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -473,15 +473,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _8cf2cd85fe85d2a203f29424b6d94430:
+  _bb6ccfec079fa3e317bf9277bd03f988:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-16.yml
+++ b/.github/workflows/stable-clang-16.yml
@@ -473,15 +473,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _f802ff95ecc0ddac450ec9dca367b1db:
+  _66b11476fd94a8edd812ef3f2955f594:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 powernv_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: powernv_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: powernv_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/generator.yml
+++ b/generator.yml
@@ -237,7 +237,7 @@ configs:
   - &ppc32             {config: ppc44x_defconfig,                                                              kernel_image: uImage,       << : *powerpc-triple,       << : *kernel}
   # Disable -Werror for pseries_defconfig for now: https://github.com/ClangBuiltLinux/linux/issues/1445
   - &ppc64             {config: [pseries_defconfig, CONFIG_PPC_DISABLE_WERROR=y],                              kernel_image: vmlinux,      << : *powerpc64-triple,     << : *kernel}
-  - &ppc64le           {config: [powernv_defconfig, CONFIG_PPC_DISABLE_WERROR=y],                              kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel}
+  - &ppc64le           {config: powernv_defconfig,                                                             kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
   - &ppc64le_fedora    {config: [*ppc64le-fedora-config-url, CONFIG_BPF_PRELOAD=n],                            kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel}
   - &ppc64le_suse      {config: *ppc64le-suse-config-url,                                                      kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel}

--- a/tuxsuite/4.14-clang-13.tux.yml
+++ b/tuxsuite/4.14-clang-13.tux.yml
@@ -45,9 +45,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-13
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/4.14-clang-14.tux.yml
+++ b/tuxsuite/4.14-clang-14.tux.yml
@@ -45,9 +45,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-14
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/4.14-clang-16.tux.yml
+++ b/tuxsuite/4.14-clang-16.tux.yml
@@ -45,9 +45,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/4.19-clang-13.tux.yml
+++ b/tuxsuite/4.19-clang-13.tux.yml
@@ -47,9 +47,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-13
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/4.19-clang-14.tux.yml
+++ b/tuxsuite/4.19-clang-14.tux.yml
@@ -47,9 +47,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-14
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/4.19-clang-16.tux.yml
+++ b/tuxsuite/4.19-clang-16.tux.yml
@@ -47,9 +47,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/5.10-clang-11.tux.yml
+++ b/tuxsuite/5.10-clang-11.tux.yml
@@ -87,9 +87,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-11
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/5.10-clang-12.tux.yml
+++ b/tuxsuite/5.10-clang-12.tux.yml
@@ -108,9 +108,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-12
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/5.10-clang-13.tux.yml
+++ b/tuxsuite/5.10-clang-13.tux.yml
@@ -117,9 +117,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-13
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/5.10-clang-14.tux.yml
+++ b/tuxsuite/5.10-clang-14.tux.yml
@@ -117,9 +117,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-14
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/5.10-clang-16.tux.yml
+++ b/tuxsuite/5.10-clang-16.tux.yml
@@ -117,9 +117,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/5.15-clang-11.tux.yml
+++ b/tuxsuite/5.15-clang-11.tux.yml
@@ -178,9 +178,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-11
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/5.15-clang-12.tux.yml
+++ b/tuxsuite/5.15-clang-12.tux.yml
@@ -210,9 +210,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-12
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/5.15-clang-13.tux.yml
+++ b/tuxsuite/5.15-clang-13.tux.yml
@@ -219,9 +219,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-13
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/5.15-clang-14.tux.yml
+++ b/tuxsuite/5.15-clang-14.tux.yml
@@ -219,9 +219,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-14
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/5.15-clang-16.tux.yml
+++ b/tuxsuite/5.15-clang-16.tux.yml
@@ -219,9 +219,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/5.4-clang-13.tux.yml
+++ b/tuxsuite/5.4-clang-13.tux.yml
@@ -93,9 +93,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-13
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/5.4-clang-14.tux.yml
+++ b/tuxsuite/5.4-clang-14.tux.yml
@@ -93,9 +93,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-14
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/5.4-clang-16.tux.yml
+++ b/tuxsuite/5.4-clang-16.tux.yml
@@ -93,9 +93,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/mainline-clang-11.tux.yml
+++ b/tuxsuite/mainline-clang-11.tux.yml
@@ -178,9 +178,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-11
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/mainline-clang-12.tux.yml
+++ b/tuxsuite/mainline-clang-12.tux.yml
@@ -190,9 +190,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-12
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/mainline-clang-13.tux.yml
+++ b/tuxsuite/mainline-clang-13.tux.yml
@@ -199,9 +199,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-13
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/mainline-clang-14.tux.yml
+++ b/tuxsuite/mainline-clang-14.tux.yml
@@ -210,9 +210,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-14
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/mainline-clang-16.tux.yml
+++ b/tuxsuite/mainline-clang-16.tux.yml
@@ -210,9 +210,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/next-clang-11.tux.yml
+++ b/tuxsuite/next-clang-11.tux.yml
@@ -178,9 +178,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-11
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/next-clang-12.tux.yml
+++ b/tuxsuite/next-clang-12.tux.yml
@@ -190,9 +190,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-12
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/next-clang-13.tux.yml
+++ b/tuxsuite/next-clang-13.tux.yml
@@ -199,9 +199,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-13
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/next-clang-14.tux.yml
+++ b/tuxsuite/next-clang-14.tux.yml
@@ -210,9 +210,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-14
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/next-clang-16.tux.yml
+++ b/tuxsuite/next-clang-16.tux.yml
@@ -210,9 +210,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/stable-clang-11.tux.yml
+++ b/tuxsuite/stable-clang-11.tux.yml
@@ -178,9 +178,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-11
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/stable-clang-12.tux.yml
+++ b/tuxsuite/stable-clang-12.tux.yml
@@ -199,9 +199,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-12
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/stable-clang-13.tux.yml
+++ b/tuxsuite/stable-clang-13.tux.yml
@@ -208,9 +208,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-13
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/stable-clang-14.tux.yml
+++ b/tuxsuite/stable-clang-14.tux.yml
@@ -219,9 +219,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-14
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/stable-clang-16.tux.yml
+++ b/tuxsuite/stable-clang-16.tux.yml
@@ -219,9 +219,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig:
-    - powernv_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: powernv_defconfig
     targets:
     - kernel
     kernel_image: zImage.epapr


### PR DESCRIPTION
This has been resolved with commit 83ee9f23763a ("powerpc/kexec: Fix
build failure from uninitialised variable"), which is in 6.0-rc1 and
next-20220815.

Link: https://git.kernel.org/linus/83ee9f23763a432a4077bf20624ee35de87bce99
