### PR TITLE
patches: Add mchp-spdiftx.c to -tip trees

### DIFF
--- a/patches/tip/eab9100d9898cbd37882b04415b12156f8942f18.patch
+++ b/patches/tip/eab9100d9898cbd37882b04415b12156f8942f18.patch
@@ -1,0 +1,46 @@
+From eab9100d9898cbd37882b04415b12156f8942f18 Mon Sep 17 00:00:00 2001
+From: Nathan Chancellor <nathan@kernel.org>
+Date: Tue, 9 Aug 2022 18:08:09 -0700
+Subject: ASoC: mchp-spdiftx: Fix clang -Wbitfield-constant-conversion
+
+A recent change in clang strengthened its -Wbitfield-constant-conversion
+to warn when 1 is assigned to a 1-bit signed integer bitfield, as it can
+only be 0 or -1, not 1:
+
+  sound/soc/atmel/mchp-spdiftx.c:505:20: error: implicit truncation from 'int' to bit-field changes value from 1 to -1 [-Werror,-Wbitfield-constant-conversion]
+          dev->gclk_enabled = 1;
+                            ^ ~
+  1 error generated.
+
+The actual value of the field is never checked, just that it is not
+zero, so there is not a real bug here. However, it is simple enough to
+silence the warning by making the bitfield unsigned, which matches the
+mchp-spdifrx driver.
+
+Fixes: 06ca24e98e6b ("ASoC: mchp-spdiftx: add driver for S/PDIF TX Controller")
+Link: https://github.com/ClangBuiltLinux/linux/issues/1686
+Link: https://github.com/llvm/llvm-project/commit/82afc9b169a67e8b8a1862fb9c41a2cd974d6691
+Signed-off-by: Nathan Chancellor <nathan@kernel.org>
+Reviewed-by: Nick Desaulniers <ndesaulniers@google.com>
+Link: https://lore.kernel.org/r/20220810010809.2024482-1-nathan@kernel.org
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ sound/soc/atmel/mchp-spdiftx.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sound/soc/atmel/mchp-spdiftx.c b/sound/soc/atmel/mchp-spdiftx.c
+index 4850a177803db..ab2d7a791f39c 100644
+--- a/sound/soc/atmel/mchp-spdiftx.c
++++ b/sound/soc/atmel/mchp-spdiftx.c
+@@ -196,7 +196,7 @@ struct mchp_spdiftx_dev {
+ 	struct clk				*pclk;
+ 	struct clk				*gclk;
+ 	unsigned int				fmt;
+-	int					gclk_enabled:1;
++	unsigned int				gclk_enabled:1;
+ };
+ 
+ static inline int mchp_spdiftx_is_running(struct mchp_spdiftx_dev *dev)
+-- 
+cgit 
+

--- a/patches/tip/series
+++ b/patches/tip/series
@@ -1,1 +1,2 @@
 0001-HACK-drm-amd-display-Increase-frame_warn_flag-value.patch
+eab9100d9898cbd37882b04415b12156f8942f18.patch


### PR DESCRIPTION
This patch is needed in the -tip tree as well.
