### PR TITLE
patches: arm64: Update mchp-spdiftx.c patch

### DIFF
--- a/patches/arm64/eab9100d9898cbd37882b04415b12156f8942f18.patch
+++ b/patches/arm64/eab9100d9898cbd37882b04415b12156f8942f18.patch
@@ -1,7 +1,7 @@
-From a11dcc8bccf7a59de6c72379876aca38b1ea0072 Mon Sep 17 00:00:00 2001
+From eab9100d9898cbd37882b04415b12156f8942f18 Mon Sep 17 00:00:00 2001
 From: Nathan Chancellor <nathan@kernel.org>
 Date: Tue, 9 Aug 2022 18:08:09 -0700
-Subject: [PATCH] ASoC: mchp-spdiftx: Fix clang -Wbitfield-constant-conversion
+Subject: ASoC: mchp-spdiftx: Fix clang -Wbitfield-constant-conversion
 
 A recent change in clang strengthened its -Wbitfield-constant-conversion
 to warn when 1 is assigned to a 1-bit signed integer bitfield, as it can
@@ -29,18 +29,18 @@ Signed-off-by: Mark Brown <broonie@kernel.org>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/sound/soc/atmel/mchp-spdiftx.c b/sound/soc/atmel/mchp-spdiftx.c
-index d24380046435..98363da83731 100644
+index 4850a177803db..ab2d7a791f39c 100644
 --- a/sound/soc/atmel/mchp-spdiftx.c
 +++ b/sound/soc/atmel/mchp-spdiftx.c
-@@ -197,7 +197,7 @@ struct mchp_spdiftx_dev {
+@@ -196,7 +196,7 @@ struct mchp_spdiftx_dev {
+ 	struct clk				*pclk;
  	struct clk				*gclk;
  	unsigned int				fmt;
- 	const struct mchp_i2s_caps		*caps;
 -	int					gclk_enabled:1;
 +	unsigned int				gclk_enabled:1;
  };
  
  static inline int mchp_spdiftx_is_running(struct mchp_spdiftx_dev *dev)
 -- 
-2.37.2
+cgit 
 


### PR DESCRIPTION
I forgot to update this patch as part of #415. The previous version was
a backport targeting 5.19, this version applies to current mainline.
