### PR TITLE
Disable CONFIG_WERROR for Hexagon

### DIFF
--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -1114,15 +1114,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ac59a19d0d87514204c03df7f611c521:
+  _abb94a8782c38ea37cd11446174ed1d2:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: hexagon
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -1114,15 +1114,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e606f3957a2810671c53ac83d3ab6b75:
+  _a6f04f545fccfc32da25289547d25b0c:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: hexagon
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -1114,15 +1114,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3665341be03a4a05bfabdd1bc9933c7c:
+  _9f293dd92be3a10a69990d95e83a006a:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: hexagon
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-16.yml
+++ b/.github/workflows/5.15-clang-16.yml
@@ -1114,15 +1114,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _114353f4a870e32d89f73f684f42055c:
+  _6474d8ce9c3931275c27da44aa7cef4f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: hexagon
       LLVM_VERSION: 16
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-13.yml
+++ b/.github/workflows/mainline-clang-13.yml
@@ -1009,15 +1009,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ac59a19d0d87514204c03df7f611c521:
+  _abb94a8782c38ea37cd11446174ed1d2:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: hexagon
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -1114,15 +1114,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e606f3957a2810671c53ac83d3ab6b75:
+  _a6f04f545fccfc32da25289547d25b0c:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: hexagon
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -1114,15 +1114,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3665341be03a4a05bfabdd1bc9933c7c:
+  _9f293dd92be3a10a69990d95e83a006a:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: hexagon
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -1114,15 +1114,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _114353f4a870e32d89f73f684f42055c:
+  _6474d8ce9c3931275c27da44aa7cef4f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: hexagon
       LLVM_VERSION: 16
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-13.yml
+++ b/.github/workflows/next-clang-13.yml
@@ -1030,15 +1030,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ac59a19d0d87514204c03df7f611c521:
+  _abb94a8782c38ea37cd11446174ed1d2:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: hexagon
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -1135,15 +1135,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e606f3957a2810671c53ac83d3ab6b75:
+  _a6f04f545fccfc32da25289547d25b0c:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: hexagon
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -1135,15 +1135,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3665341be03a4a05bfabdd1bc9933c7c:
+  _9f293dd92be3a10a69990d95e83a006a:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: hexagon
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -1135,15 +1135,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _114353f4a870e32d89f73f684f42055c:
+  _6474d8ce9c3931275c27da44aa7cef4f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: hexagon
       LLVM_VERSION: 16
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -1030,15 +1030,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ac59a19d0d87514204c03df7f611c521:
+  _abb94a8782c38ea37cd11446174ed1d2:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: hexagon
       LLVM_VERSION: 13
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -1135,15 +1135,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e606f3957a2810671c53ac83d3ab6b75:
+  _a6f04f545fccfc32da25289547d25b0c:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: hexagon
       LLVM_VERSION: 14
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -1135,15 +1135,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3665341be03a4a05bfabdd1bc9933c7c:
+  _9f293dd92be3a10a69990d95e83a006a:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: hexagon
       LLVM_VERSION: 15
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-16.yml
+++ b/.github/workflows/stable-clang-16.yml
@@ -1135,15 +1135,15 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _114353f4a870e32d89f73f684f42055c:
+  _6474d8ce9c3931275c27da44aa7cef4f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
+    name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n
     env:
       ARCH: hexagon
       LLVM_VERSION: 16
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_WERROR=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/generator.yml
+++ b/generator.yml
@@ -252,7 +252,7 @@ configs:
   # CONFIG_DEBUG_INFO_BTF disabled for certain SUSE configs due to pahole issue: https://lore.kernel.org/r/20210506205622.3663956-1-kafai@fb.com/
   - &arm64_suse        {config: [*arm64-suse-config-url, CONFIG_DEBUG_INFO_BTF=n],                                                         << : *arm64-triple,         << : *kernel}
   - &hexagon           {config: defconfig,                                                                                                 << : *hexagon-triple,       << : *default}
-  - &hexagon_allmod    {config: allmodconfig,                                                                                              << : *hexagon-triple,       << : *default}
+  - &hexagon_allmod    {config: [allmodconfig, CONFIG_WERROR=n],                                                                           << : *hexagon-triple,       << : *default}
   - &i386              {config: defconfig,                                                                                                 << : *i386-triple,          << : *kernel}
   - &i386_suse         {config: *i386-suse-config-url,                                                                                     << : *i386-triple,          << : *default}
   - &mips              {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y, CONFIG_CPU_BIG_ENDIAN=y],           kernel_image: vmlinux,      << : *mips-triple,          << : *kernel}

--- a/tuxsuite/5.15-clang-13.tux.yml
+++ b/tuxsuite/5.15-clang-13.tux.yml
@@ -493,7 +493,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: hexagon
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/5.15-clang-14.tux.yml
+++ b/tuxsuite/5.15-clang-14.tux.yml
@@ -493,7 +493,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: hexagon
     toolchain: clang-14
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/5.15-clang-15.tux.yml
+++ b/tuxsuite/5.15-clang-15.tux.yml
@@ -493,7 +493,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: hexagon
     toolchain: clang-15
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/5.15-clang-16.tux.yml
+++ b/tuxsuite/5.15-clang-16.tux.yml
@@ -493,7 +493,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: hexagon
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/mainline-clang-13.tux.yml
+++ b/tuxsuite/mainline-clang-13.tux.yml
@@ -446,7 +446,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: hexagon
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/mainline-clang-14.tux.yml
+++ b/tuxsuite/mainline-clang-14.tux.yml
@@ -494,7 +494,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: hexagon
     toolchain: clang-14
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/mainline-clang-15.tux.yml
+++ b/tuxsuite/mainline-clang-15.tux.yml
@@ -494,7 +494,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: hexagon
     toolchain: clang-15
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/mainline-clang-16.tux.yml
+++ b/tuxsuite/mainline-clang-16.tux.yml
@@ -494,7 +494,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: hexagon
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/next-clang-13.tux.yml
+++ b/tuxsuite/next-clang-13.tux.yml
@@ -457,7 +457,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: hexagon
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/next-clang-14.tux.yml
+++ b/tuxsuite/next-clang-14.tux.yml
@@ -505,7 +505,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: hexagon
     toolchain: clang-14
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/next-clang-15.tux.yml
+++ b/tuxsuite/next-clang-15.tux.yml
@@ -505,7 +505,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: hexagon
     toolchain: clang-15
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/next-clang-16.tux.yml
+++ b/tuxsuite/next-clang-16.tux.yml
@@ -505,7 +505,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: hexagon
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/stable-clang-13.tux.yml
+++ b/tuxsuite/stable-clang-13.tux.yml
@@ -455,7 +455,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: hexagon
     toolchain: clang-13
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/stable-clang-14.tux.yml
+++ b/tuxsuite/stable-clang-14.tux.yml
@@ -503,7 +503,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: hexagon
     toolchain: clang-14
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/stable-clang-15.tux.yml
+++ b/tuxsuite/stable-clang-15.tux.yml
@@ -503,7 +503,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: hexagon
     toolchain: clang-15
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/stable-clang-16.tux.yml
+++ b/tuxsuite/stable-clang-16.tux.yml
@@ -503,7 +503,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: hexagon
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
     targets:
     - default
     make_variables:


### PR DESCRIPTION
A patch in -next introduces the same NULL pointer arithmetic warnings
that we see on s390 to hexagon, which are fatal with -Werror. To keep
the build green, disable CONFIG_WERROR.

Link: https://git.kernel.org/broonie/regmap/c/81c0386c1376da54f05d6916936db5220df9f97d
Link: https://github.com/ClangBuiltLinux/linux/issues/1285
