### PR TITLE
utils.py: Handle OpenSUSE riscv64 configuration in get_cbl_name()

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -63,6 +63,7 @@ def get_cbl_name():
                 "armv7hl": "arm32_v7",
                 "i386": "x86",
                 "ppc64le": "ppc64le",
+                "riscv64": "riscv",
                 "s390x": "s390",
                 "x86_64": "x86_64"
             }


### PR DESCRIPTION
Otherwise, `check_logs.py` will fail.
