### PR TITLE
Enable x86_64 KCSAN build on -next

### DIFF
--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -641,6 +641,27 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _48c41e4e5e13211d8ff54789923d9f62:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 16
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _e98954bd48107de7f6b05104ae100c80:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/generator.yml
+++ b/generator.yml
@@ -439,8 +439,7 @@ builds:
   - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_thin,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_kasan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
-  # x86_64_kcsan: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1704)
-  # - {<< : *x86_64_kcsan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_kcsan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_ubsan,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}

--- a/tuxsuite/next-clang-16.tux.yml
+++ b/tuxsuite/next-clang-16.tux.yml
@@ -298,6 +298,18 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - defconfig
+    - CONFIG_KCSAN=y
+    - CONFIG_KCSAN_KUNIT_TEST=y
+    - CONFIG_KUNIT=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-nightly
+    kconfig:
+    - defconfig
     - CONFIG_UBSAN=y
     targets:
     - kernel


### PR DESCRIPTION
The patch that we need for ToT LLVM is now available:

https://git.kernel.org/next/linux-next/c/fdc1eea7a8473ca30ef8d180e3f99a4955155c7f
