### PR TITLE
generate_workflow.py: Do not run TuxSuite workflows on pushes to the main branch

### DIFF
--- a/.github/workflows/4.14-clang-13.yml
+++ b/.github/workflows/4.14-clang-13.yml
@@ -5,7 +5,6 @@ name: 4.14 (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/4.14-clang-14.yml
+++ b/.github/workflows/4.14-clang-14.yml
@@ -5,7 +5,6 @@ name: 4.14 (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/4.14-clang-15.yml
+++ b/.github/workflows/4.14-clang-15.yml
@@ -5,7 +5,6 @@ name: 4.14 (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/4.14-clang-16.yml
+++ b/.github/workflows/4.14-clang-16.yml
@@ -5,7 +5,6 @@ name: 4.14 (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/4.19-clang-13.yml
+++ b/.github/workflows/4.19-clang-13.yml
@@ -5,7 +5,6 @@ name: 4.19 (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/4.19-clang-14.yml
+++ b/.github/workflows/4.19-clang-14.yml
@@ -5,7 +5,6 @@ name: 4.19 (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/4.19-clang-15.yml
+++ b/.github/workflows/4.19-clang-15.yml
@@ -5,7 +5,6 @@ name: 4.19 (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/4.19-clang-16.yml
+++ b/.github/workflows/4.19-clang-16.yml
@@ -5,7 +5,6 @@ name: 4.19 (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/4.9-clang-13.yml
+++ b/.github/workflows/4.9-clang-13.yml
@@ -5,7 +5,6 @@ name: 4.9 (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/4.9-clang-14.yml
+++ b/.github/workflows/4.9-clang-14.yml
@@ -5,7 +5,6 @@ name: 4.9 (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/4.9-clang-15.yml
+++ b/.github/workflows/4.9-clang-15.yml
@@ -5,7 +5,6 @@ name: 4.9 (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/4.9-clang-16.yml
+++ b/.github/workflows/4.9-clang-16.yml
@@ -5,7 +5,6 @@ name: 4.9 (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/5.10-clang-11.yml
+++ b/.github/workflows/5.10-clang-11.yml
@@ -5,7 +5,6 @@ name: 5.10 (clang-11)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/5.10-clang-12.yml
+++ b/.github/workflows/5.10-clang-12.yml
@@ -5,7 +5,6 @@ name: 5.10 (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/5.10-clang-13.yml
+++ b/.github/workflows/5.10-clang-13.yml
@@ -5,7 +5,6 @@ name: 5.10 (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/5.10-clang-14.yml
+++ b/.github/workflows/5.10-clang-14.yml
@@ -5,7 +5,6 @@ name: 5.10 (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/5.10-clang-15.yml
+++ b/.github/workflows/5.10-clang-15.yml
@@ -5,7 +5,6 @@ name: 5.10 (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/5.10-clang-16.yml
+++ b/.github/workflows/5.10-clang-16.yml
@@ -5,7 +5,6 @@ name: 5.10 (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -5,7 +5,6 @@ name: 5.15 (clang-11)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -5,7 +5,6 @@ name: 5.15 (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -5,7 +5,6 @@ name: 5.15 (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -5,7 +5,6 @@ name: 5.15 (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -5,7 +5,6 @@ name: 5.15 (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/5.15-clang-16.yml
+++ b/.github/workflows/5.15-clang-16.yml
@@ -5,7 +5,6 @@ name: 5.15 (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/5.4-clang-13.yml
+++ b/.github/workflows/5.4-clang-13.yml
@@ -5,7 +5,6 @@ name: 5.4 (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/5.4-clang-14.yml
+++ b/.github/workflows/5.4-clang-14.yml
@@ -5,7 +5,6 @@ name: 5.4 (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/5.4-clang-15.yml
+++ b/.github/workflows/5.4-clang-15.yml
@@ -5,7 +5,6 @@ name: 5.4 (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/5.4-clang-16.yml
+++ b/.github/workflows/5.4-clang-16.yml
@@ -5,7 +5,6 @@ name: 5.4 (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-4.14-clang-12.yml
+++ b/.github/workflows/android-4.14-clang-12.yml
@@ -5,7 +5,6 @@ name: android-4.14 (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-4.14-clang-13.yml
+++ b/.github/workflows/android-4.14-clang-13.yml
@@ -5,7 +5,6 @@ name: android-4.14 (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-4.14-clang-14.yml
+++ b/.github/workflows/android-4.14-clang-14.yml
@@ -5,7 +5,6 @@ name: android-4.14 (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-4.14-clang-15.yml
+++ b/.github/workflows/android-4.14-clang-15.yml
@@ -5,7 +5,6 @@ name: android-4.14 (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-4.14-clang-16.yml
+++ b/.github/workflows/android-4.14-clang-16.yml
@@ -5,7 +5,6 @@ name: android-4.14 (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-4.14-clang-android.yml
+++ b/.github/workflows/android-4.14-clang-android.yml
@@ -5,7 +5,6 @@ name: android-4.14 (clang-android)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-4.19-clang-12.yml
+++ b/.github/workflows/android-4.19-clang-12.yml
@@ -5,7 +5,6 @@ name: android-4.19 (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-4.19-clang-13.yml
+++ b/.github/workflows/android-4.19-clang-13.yml
@@ -5,7 +5,6 @@ name: android-4.19 (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-4.19-clang-14.yml
+++ b/.github/workflows/android-4.19-clang-14.yml
@@ -5,7 +5,6 @@ name: android-4.19 (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-4.19-clang-15.yml
+++ b/.github/workflows/android-4.19-clang-15.yml
@@ -5,7 +5,6 @@ name: android-4.19 (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-4.19-clang-16.yml
+++ b/.github/workflows/android-4.19-clang-16.yml
@@ -5,7 +5,6 @@ name: android-4.19 (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-4.19-clang-android.yml
+++ b/.github/workflows/android-4.19-clang-android.yml
@@ -5,7 +5,6 @@ name: android-4.19 (clang-android)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-4.9-clang-12.yml
+++ b/.github/workflows/android-4.9-clang-12.yml
@@ -5,7 +5,6 @@ name: android-4.9 (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-4.9-clang-13.yml
+++ b/.github/workflows/android-4.9-clang-13.yml
@@ -5,7 +5,6 @@ name: android-4.9 (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-4.9-clang-14.yml
+++ b/.github/workflows/android-4.9-clang-14.yml
@@ -5,7 +5,6 @@ name: android-4.9 (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-4.9-clang-15.yml
+++ b/.github/workflows/android-4.9-clang-15.yml
@@ -5,7 +5,6 @@ name: android-4.9 (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-4.9-clang-16.yml
+++ b/.github/workflows/android-4.9-clang-16.yml
@@ -5,7 +5,6 @@ name: android-4.9 (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-4.9-clang-android.yml
+++ b/.github/workflows/android-4.9-clang-android.yml
@@ -5,7 +5,6 @@ name: android-4.9 (clang-android)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-mainline-clang-12.yml
+++ b/.github/workflows/android-mainline-clang-12.yml
@@ -5,7 +5,6 @@ name: android-mainline (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-mainline-clang-13.yml
+++ b/.github/workflows/android-mainline-clang-13.yml
@@ -5,7 +5,6 @@ name: android-mainline (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-mainline-clang-14.yml
+++ b/.github/workflows/android-mainline-clang-14.yml
@@ -5,7 +5,6 @@ name: android-mainline (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-mainline-clang-15.yml
+++ b/.github/workflows/android-mainline-clang-15.yml
@@ -5,7 +5,6 @@ name: android-mainline (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-mainline-clang-16.yml
+++ b/.github/workflows/android-mainline-clang-16.yml
@@ -5,7 +5,6 @@ name: android-mainline (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android-mainline-clang-android.yml
+++ b/.github/workflows/android-mainline-clang-android.yml
@@ -5,7 +5,6 @@ name: android-mainline (clang-android)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android12-5.10-clang-12.yml
+++ b/.github/workflows/android12-5.10-clang-12.yml
@@ -5,7 +5,6 @@ name: android12-5.10 (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android12-5.10-clang-13.yml
+++ b/.github/workflows/android12-5.10-clang-13.yml
@@ -5,7 +5,6 @@ name: android12-5.10 (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android12-5.10-clang-14.yml
+++ b/.github/workflows/android12-5.10-clang-14.yml
@@ -5,7 +5,6 @@ name: android12-5.10 (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android12-5.10-clang-15.yml
+++ b/.github/workflows/android12-5.10-clang-15.yml
@@ -5,7 +5,6 @@ name: android12-5.10 (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android12-5.10-clang-16.yml
+++ b/.github/workflows/android12-5.10-clang-16.yml
@@ -5,7 +5,6 @@ name: android12-5.10 (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android12-5.10-clang-android.yml
+++ b/.github/workflows/android12-5.10-clang-android.yml
@@ -5,7 +5,6 @@ name: android12-5.10 (clang-android)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android12-5.4-clang-12.yml
+++ b/.github/workflows/android12-5.4-clang-12.yml
@@ -5,7 +5,6 @@ name: android12-5.4 (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android12-5.4-clang-13.yml
+++ b/.github/workflows/android12-5.4-clang-13.yml
@@ -5,7 +5,6 @@ name: android12-5.4 (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android12-5.4-clang-14.yml
+++ b/.github/workflows/android12-5.4-clang-14.yml
@@ -5,7 +5,6 @@ name: android12-5.4 (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android12-5.4-clang-15.yml
+++ b/.github/workflows/android12-5.4-clang-15.yml
@@ -5,7 +5,6 @@ name: android12-5.4 (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android12-5.4-clang-16.yml
+++ b/.github/workflows/android12-5.4-clang-16.yml
@@ -5,7 +5,6 @@ name: android12-5.4 (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android12-5.4-clang-android.yml
+++ b/.github/workflows/android12-5.4-clang-android.yml
@@ -5,7 +5,6 @@ name: android12-5.4 (clang-android)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android13-5.10-clang-12.yml
+++ b/.github/workflows/android13-5.10-clang-12.yml
@@ -5,7 +5,6 @@ name: android13-5.10 (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android13-5.10-clang-13.yml
+++ b/.github/workflows/android13-5.10-clang-13.yml
@@ -5,7 +5,6 @@ name: android13-5.10 (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android13-5.10-clang-14.yml
+++ b/.github/workflows/android13-5.10-clang-14.yml
@@ -5,7 +5,6 @@ name: android13-5.10 (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android13-5.10-clang-15.yml
+++ b/.github/workflows/android13-5.10-clang-15.yml
@@ -5,7 +5,6 @@ name: android13-5.10 (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android13-5.10-clang-16.yml
+++ b/.github/workflows/android13-5.10-clang-16.yml
@@ -5,7 +5,6 @@ name: android13-5.10 (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android13-5.10-clang-android.yml
+++ b/.github/workflows/android13-5.10-clang-android.yml
@@ -5,7 +5,6 @@ name: android13-5.10 (clang-android)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android13-5.15-clang-12.yml
+++ b/.github/workflows/android13-5.15-clang-12.yml
@@ -5,7 +5,6 @@ name: android13-5.15 (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android13-5.15-clang-13.yml
+++ b/.github/workflows/android13-5.15-clang-13.yml
@@ -5,7 +5,6 @@ name: android13-5.15 (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android13-5.15-clang-14.yml
+++ b/.github/workflows/android13-5.15-clang-14.yml
@@ -5,7 +5,6 @@ name: android13-5.15 (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android13-5.15-clang-15.yml
+++ b/.github/workflows/android13-5.15-clang-15.yml
@@ -5,7 +5,6 @@ name: android13-5.15 (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android13-5.15-clang-16.yml
+++ b/.github/workflows/android13-5.15-clang-16.yml
@@ -5,7 +5,6 @@ name: android13-5.15 (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android13-5.15-clang-android.yml
+++ b/.github/workflows/android13-5.15-clang-android.yml
@@ -5,7 +5,6 @@ name: android13-5.15 (clang-android)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android14-5.15-clang-12.yml
+++ b/.github/workflows/android14-5.15-clang-12.yml
@@ -5,7 +5,6 @@ name: android14-5.15 (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android14-5.15-clang-13.yml
+++ b/.github/workflows/android14-5.15-clang-13.yml
@@ -5,7 +5,6 @@ name: android14-5.15 (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android14-5.15-clang-14.yml
+++ b/.github/workflows/android14-5.15-clang-14.yml
@@ -5,7 +5,6 @@ name: android14-5.15 (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android14-5.15-clang-15.yml
+++ b/.github/workflows/android14-5.15-clang-15.yml
@@ -5,7 +5,6 @@ name: android14-5.15 (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android14-5.15-clang-16.yml
+++ b/.github/workflows/android14-5.15-clang-16.yml
@@ -5,7 +5,6 @@ name: android14-5.15 (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/android14-5.15-clang-android.yml
+++ b/.github/workflows/android14-5.15-clang-android.yml
@@ -5,7 +5,6 @@ name: android14-5.15 (clang-android)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/arm64-clang-11.yml
+++ b/.github/workflows/arm64-clang-11.yml
@@ -5,7 +5,6 @@ name: arm64 (clang-11)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/arm64-clang-12.yml
+++ b/.github/workflows/arm64-clang-12.yml
@@ -5,7 +5,6 @@ name: arm64 (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/arm64-clang-13.yml
+++ b/.github/workflows/arm64-clang-13.yml
@@ -5,7 +5,6 @@ name: arm64 (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/arm64-clang-14.yml
+++ b/.github/workflows/arm64-clang-14.yml
@@ -5,7 +5,6 @@ name: arm64 (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/arm64-clang-15.yml
+++ b/.github/workflows/arm64-clang-15.yml
@@ -5,7 +5,6 @@ name: arm64 (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/arm64-clang-16.yml
+++ b/.github/workflows/arm64-clang-16.yml
@@ -5,7 +5,6 @@ name: arm64 (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/arm64-fixes-clang-11.yml
+++ b/.github/workflows/arm64-fixes-clang-11.yml
@@ -5,7 +5,6 @@ name: arm64-fixes (clang-11)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/arm64-fixes-clang-12.yml
+++ b/.github/workflows/arm64-fixes-clang-12.yml
@@ -5,7 +5,6 @@ name: arm64-fixes (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/arm64-fixes-clang-13.yml
+++ b/.github/workflows/arm64-fixes-clang-13.yml
@@ -5,7 +5,6 @@ name: arm64-fixes (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/arm64-fixes-clang-14.yml
+++ b/.github/workflows/arm64-fixes-clang-14.yml
@@ -5,7 +5,6 @@ name: arm64-fixes (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/arm64-fixes-clang-15.yml
+++ b/.github/workflows/arm64-fixes-clang-15.yml
@@ -5,7 +5,6 @@ name: arm64-fixes (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/arm64-fixes-clang-16.yml
+++ b/.github/workflows/arm64-fixes-clang-16.yml
@@ -5,7 +5,6 @@ name: arm64-fixes (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/chromeos-5.10-clang-12.yml
+++ b/.github/workflows/chromeos-5.10-clang-12.yml
@@ -5,7 +5,6 @@ name: chromeos-5.10 (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/chromeos-5.10-clang-13.yml
+++ b/.github/workflows/chromeos-5.10-clang-13.yml
@@ -5,7 +5,6 @@ name: chromeos-5.10 (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/chromeos-5.10-clang-14.yml
+++ b/.github/workflows/chromeos-5.10-clang-14.yml
@@ -5,7 +5,6 @@ name: chromeos-5.10 (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/chromeos-5.10-clang-15.yml
+++ b/.github/workflows/chromeos-5.10-clang-15.yml
@@ -5,7 +5,6 @@ name: chromeos-5.10 (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/chromeos-5.10-clang-16.yml
+++ b/.github/workflows/chromeos-5.10-clang-16.yml
@@ -5,7 +5,6 @@ name: chromeos-5.10 (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/chromeos-5.15-clang-12.yml
+++ b/.github/workflows/chromeos-5.15-clang-12.yml
@@ -5,7 +5,6 @@ name: chromeos-5.15 (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/chromeos-5.15-clang-13.yml
+++ b/.github/workflows/chromeos-5.15-clang-13.yml
@@ -5,7 +5,6 @@ name: chromeos-5.15 (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/chromeos-5.15-clang-14.yml
+++ b/.github/workflows/chromeos-5.15-clang-14.yml
@@ -5,7 +5,6 @@ name: chromeos-5.15 (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/chromeos-5.15-clang-15.yml
+++ b/.github/workflows/chromeos-5.15-clang-15.yml
@@ -5,7 +5,6 @@ name: chromeos-5.15 (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/chromeos-5.15-clang-16.yml
+++ b/.github/workflows/chromeos-5.15-clang-16.yml
@@ -5,7 +5,6 @@ name: chromeos-5.15 (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/mainline-clang-11.yml
+++ b/.github/workflows/mainline-clang-11.yml
@@ -5,7 +5,6 @@ name: mainline (clang-11)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/mainline-clang-12.yml
+++ b/.github/workflows/mainline-clang-12.yml
@@ -5,7 +5,6 @@ name: mainline (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/mainline-clang-13.yml
+++ b/.github/workflows/mainline-clang-13.yml
@@ -5,7 +5,6 @@ name: mainline (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -5,7 +5,6 @@ name: mainline (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -5,7 +5,6 @@ name: mainline (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -5,7 +5,6 @@ name: mainline (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/next-clang-11.yml
+++ b/.github/workflows/next-clang-11.yml
@@ -5,7 +5,6 @@ name: next (clang-11)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/next-clang-12.yml
+++ b/.github/workflows/next-clang-12.yml
@@ -5,7 +5,6 @@ name: next (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/next-clang-13.yml
+++ b/.github/workflows/next-clang-13.yml
@@ -5,7 +5,6 @@ name: next (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -5,7 +5,6 @@ name: next (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -5,7 +5,6 @@ name: next (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -5,7 +5,6 @@ name: next (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/next-clang-android.yml
+++ b/.github/workflows/next-clang-android.yml
@@ -5,7 +5,6 @@ name: next (clang-android)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/stable-clang-11.yml
+++ b/.github/workflows/stable-clang-11.yml
@@ -5,7 +5,6 @@ name: stable (clang-11)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/stable-clang-12.yml
+++ b/.github/workflows/stable-clang-12.yml
@@ -5,7 +5,6 @@ name: stable (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -5,7 +5,6 @@ name: stable (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -5,7 +5,6 @@ name: stable (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -5,7 +5,6 @@ name: stable (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/stable-clang-16.yml
+++ b/.github/workflows/stable-clang-16.yml
@@ -5,7 +5,6 @@ name: stable (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/tip-clang-11.yml
+++ b/.github/workflows/tip-clang-11.yml
@@ -5,7 +5,6 @@ name: tip (clang-11)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/tip-clang-12.yml
+++ b/.github/workflows/tip-clang-12.yml
@@ -5,7 +5,6 @@ name: tip (clang-12)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/tip-clang-13.yml
+++ b/.github/workflows/tip-clang-13.yml
@@ -5,7 +5,6 @@ name: tip (clang-13)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/tip-clang-14.yml
+++ b/.github/workflows/tip-clang-14.yml
@@ -5,7 +5,6 @@ name: tip (clang-14)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/tip-clang-15.yml
+++ b/.github/workflows/tip-clang-15.yml
@@ -5,7 +5,6 @@ name: tip (clang-15)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/.github/workflows/tip-clang-16.yml
+++ b/.github/workflows/tip-clang-16.yml
@@ -5,7 +5,6 @@ name: tip (clang-16)
 'on':
   push:
     branches:
-    - main
     - presubmit/*
     paths:
     - check_logs.py

--- a/generate_workflow.py
+++ b/generate_workflow.py
@@ -25,8 +25,6 @@ def initial_workflow(name, cron, tuxsuite_yml, workflow_yml):
             # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths
             "push": {
                 "branches": [
-                    # Always run on the main branch
-                    "main",
                     # Allow testing on branches with a presubmit/ prefix
                     "presubmit/*"
                 ],


### PR DESCRIPTION
We run all TuxSuite workflows on a schedule so they will eventually run
with whatever fixes are being pushed to the main branch. Automatically
running TuxSuite workflows when they are modified on the main branch is
potentially expensive and could jack up the schedule set in place by the
crons. Allow explicit presubmit runs via "presubmit/" prefixed branches
but do not run the workflows when pull requests are merged to main.

This matches the current reality when I merge pull requests, which is to
just add '[skip actions]' to the merge message so that they do not start
building.
