### PR TITLE
Reduce permissions of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/4.14-clang-13.yml
+++ b/.github/workflows/4.14-clang-13.yml
@@ -14,6 +14,7 @@ name: 4.14 (clang-13)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/4.14-clang-14.yml
+++ b/.github/workflows/4.14-clang-14.yml
@@ -14,6 +14,7 @@ name: 4.14 (clang-14)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/4.14-clang-15.yml
+++ b/.github/workflows/4.14-clang-15.yml
@@ -14,6 +14,7 @@ name: 4.14 (clang-15)
   schedule:
   - cron: 0 12 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/4.14-clang-16.yml
+++ b/.github/workflows/4.14-clang-16.yml
@@ -14,6 +14,7 @@ name: 4.14 (clang-16)
   schedule:
   - cron: 0 12 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/4.19-clang-13.yml
+++ b/.github/workflows/4.19-clang-13.yml
@@ -14,6 +14,7 @@ name: 4.19 (clang-13)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/4.19-clang-14.yml
+++ b/.github/workflows/4.19-clang-14.yml
@@ -14,6 +14,7 @@ name: 4.19 (clang-14)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/4.19-clang-15.yml
+++ b/.github/workflows/4.19-clang-15.yml
@@ -14,6 +14,7 @@ name: 4.19 (clang-15)
   schedule:
   - cron: 0 12 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/4.19-clang-16.yml
+++ b/.github/workflows/4.19-clang-16.yml
@@ -14,6 +14,7 @@ name: 4.19 (clang-16)
   schedule:
   - cron: 0 12 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/4.9-clang-13.yml
+++ b/.github/workflows/4.9-clang-13.yml
@@ -14,6 +14,7 @@ name: 4.9 (clang-13)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/4.9-clang-14.yml
+++ b/.github/workflows/4.9-clang-14.yml
@@ -14,6 +14,7 @@ name: 4.9 (clang-14)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/4.9-clang-15.yml
+++ b/.github/workflows/4.9-clang-15.yml
@@ -14,6 +14,7 @@ name: 4.9 (clang-15)
   schedule:
   - cron: 0 12 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/4.9-clang-16.yml
+++ b/.github/workflows/4.9-clang-16.yml
@@ -14,6 +14,7 @@ name: 4.9 (clang-16)
   schedule:
   - cron: 0 12 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/5.10-clang-11.yml
+++ b/.github/workflows/5.10-clang-11.yml
@@ -14,6 +14,7 @@ name: 5.10 (clang-11)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/5.10-clang-12.yml
+++ b/.github/workflows/5.10-clang-12.yml
@@ -14,6 +14,7 @@ name: 5.10 (clang-12)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/5.10-clang-13.yml
+++ b/.github/workflows/5.10-clang-13.yml
@@ -14,6 +14,7 @@ name: 5.10 (clang-13)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/5.10-clang-14.yml
+++ b/.github/workflows/5.10-clang-14.yml
@@ -14,6 +14,7 @@ name: 5.10 (clang-14)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/5.10-clang-15.yml
+++ b/.github/workflows/5.10-clang-15.yml
@@ -14,6 +14,7 @@ name: 5.10 (clang-15)
   schedule:
   - cron: 0 12 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/5.10-clang-16.yml
+++ b/.github/workflows/5.10-clang-16.yml
@@ -14,6 +14,7 @@ name: 5.10 (clang-16)
   schedule:
   - cron: 0 12 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -14,6 +14,7 @@ name: 5.15 (clang-11)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -14,6 +14,7 @@ name: 5.15 (clang-12)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -14,6 +14,7 @@ name: 5.15 (clang-13)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -14,6 +14,7 @@ name: 5.15 (clang-14)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -14,6 +14,7 @@ name: 5.15 (clang-15)
   schedule:
   - cron: 0 12 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/5.15-clang-16.yml
+++ b/.github/workflows/5.15-clang-16.yml
@@ -14,6 +14,7 @@ name: 5.15 (clang-16)
   schedule:
   - cron: 0 12 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/5.4-clang-13.yml
+++ b/.github/workflows/5.4-clang-13.yml
@@ -14,6 +14,7 @@ name: 5.4 (clang-13)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/5.4-clang-14.yml
+++ b/.github/workflows/5.4-clang-14.yml
@@ -14,6 +14,7 @@ name: 5.4 (clang-14)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/5.4-clang-15.yml
+++ b/.github/workflows/5.4-clang-15.yml
@@ -14,6 +14,7 @@ name: 5.4 (clang-15)
   schedule:
   - cron: 0 12 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/5.4-clang-16.yml
+++ b/.github/workflows/5.4-clang-16.yml
@@ -14,6 +14,7 @@ name: 5.4 (clang-16)
   schedule:
   - cron: 0 12 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-4.14-clang-12.yml
+++ b/.github/workflows/android-4.14-clang-12.yml
@@ -14,6 +14,7 @@ name: android-4.14 (clang-12)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-4.14-clang-13.yml
+++ b/.github/workflows/android-4.14-clang-13.yml
@@ -14,6 +14,7 @@ name: android-4.14 (clang-13)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-4.14-clang-14.yml
+++ b/.github/workflows/android-4.14-clang-14.yml
@@ -14,6 +14,7 @@ name: android-4.14 (clang-14)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-4.14-clang-15.yml
+++ b/.github/workflows/android-4.14-clang-15.yml
@@ -14,6 +14,7 @@ name: android-4.14 (clang-15)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-4.14-clang-16.yml
+++ b/.github/workflows/android-4.14-clang-16.yml
@@ -14,6 +14,7 @@ name: android-4.14 (clang-16)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-4.14-clang-android.yml
+++ b/.github/workflows/android-4.14-clang-android.yml
@@ -14,6 +14,7 @@ name: android-4.14 (clang-android)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-4.19-clang-12.yml
+++ b/.github/workflows/android-4.19-clang-12.yml
@@ -14,6 +14,7 @@ name: android-4.19 (clang-12)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-4.19-clang-13.yml
+++ b/.github/workflows/android-4.19-clang-13.yml
@@ -14,6 +14,7 @@ name: android-4.19 (clang-13)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-4.19-clang-14.yml
+++ b/.github/workflows/android-4.19-clang-14.yml
@@ -14,6 +14,7 @@ name: android-4.19 (clang-14)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-4.19-clang-15.yml
+++ b/.github/workflows/android-4.19-clang-15.yml
@@ -14,6 +14,7 @@ name: android-4.19 (clang-15)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-4.19-clang-16.yml
+++ b/.github/workflows/android-4.19-clang-16.yml
@@ -14,6 +14,7 @@ name: android-4.19 (clang-16)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-4.19-clang-android.yml
+++ b/.github/workflows/android-4.19-clang-android.yml
@@ -14,6 +14,7 @@ name: android-4.19 (clang-android)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-4.9-clang-12.yml
+++ b/.github/workflows/android-4.9-clang-12.yml
@@ -14,6 +14,7 @@ name: android-4.9 (clang-12)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-4.9-clang-13.yml
+++ b/.github/workflows/android-4.9-clang-13.yml
@@ -14,6 +14,7 @@ name: android-4.9 (clang-13)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-4.9-clang-14.yml
+++ b/.github/workflows/android-4.9-clang-14.yml
@@ -14,6 +14,7 @@ name: android-4.9 (clang-14)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-4.9-clang-15.yml
+++ b/.github/workflows/android-4.9-clang-15.yml
@@ -14,6 +14,7 @@ name: android-4.9 (clang-15)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-4.9-clang-16.yml
+++ b/.github/workflows/android-4.9-clang-16.yml
@@ -14,6 +14,7 @@ name: android-4.9 (clang-16)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-4.9-clang-android.yml
+++ b/.github/workflows/android-4.9-clang-android.yml
@@ -14,6 +14,7 @@ name: android-4.9 (clang-android)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-mainline-clang-12.yml
+++ b/.github/workflows/android-mainline-clang-12.yml
@@ -14,6 +14,7 @@ name: android-mainline (clang-12)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-mainline-clang-13.yml
+++ b/.github/workflows/android-mainline-clang-13.yml
@@ -14,6 +14,7 @@ name: android-mainline (clang-13)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-mainline-clang-14.yml
+++ b/.github/workflows/android-mainline-clang-14.yml
@@ -14,6 +14,7 @@ name: android-mainline (clang-14)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-mainline-clang-15.yml
+++ b/.github/workflows/android-mainline-clang-15.yml
@@ -14,6 +14,7 @@ name: android-mainline (clang-15)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-mainline-clang-16.yml
+++ b/.github/workflows/android-mainline-clang-16.yml
@@ -14,6 +14,7 @@ name: android-mainline (clang-16)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android-mainline-clang-android.yml
+++ b/.github/workflows/android-mainline-clang-android.yml
@@ -14,6 +14,7 @@ name: android-mainline (clang-android)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android12-5.10-clang-12.yml
+++ b/.github/workflows/android12-5.10-clang-12.yml
@@ -14,6 +14,7 @@ name: android12-5.10 (clang-12)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android12-5.10-clang-13.yml
+++ b/.github/workflows/android12-5.10-clang-13.yml
@@ -14,6 +14,7 @@ name: android12-5.10 (clang-13)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android12-5.10-clang-14.yml
+++ b/.github/workflows/android12-5.10-clang-14.yml
@@ -14,6 +14,7 @@ name: android12-5.10 (clang-14)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android12-5.10-clang-15.yml
+++ b/.github/workflows/android12-5.10-clang-15.yml
@@ -14,6 +14,7 @@ name: android12-5.10 (clang-15)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android12-5.10-clang-16.yml
+++ b/.github/workflows/android12-5.10-clang-16.yml
@@ -14,6 +14,7 @@ name: android12-5.10 (clang-16)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android12-5.10-clang-android.yml
+++ b/.github/workflows/android12-5.10-clang-android.yml
@@ -14,6 +14,7 @@ name: android12-5.10 (clang-android)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android12-5.4-clang-12.yml
+++ b/.github/workflows/android12-5.4-clang-12.yml
@@ -14,6 +14,7 @@ name: android12-5.4 (clang-12)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android12-5.4-clang-13.yml
+++ b/.github/workflows/android12-5.4-clang-13.yml
@@ -14,6 +14,7 @@ name: android12-5.4 (clang-13)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android12-5.4-clang-14.yml
+++ b/.github/workflows/android12-5.4-clang-14.yml
@@ -14,6 +14,7 @@ name: android12-5.4 (clang-14)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android12-5.4-clang-15.yml
+++ b/.github/workflows/android12-5.4-clang-15.yml
@@ -14,6 +14,7 @@ name: android12-5.4 (clang-15)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android12-5.4-clang-16.yml
+++ b/.github/workflows/android12-5.4-clang-16.yml
@@ -14,6 +14,7 @@ name: android12-5.4 (clang-16)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android12-5.4-clang-android.yml
+++ b/.github/workflows/android12-5.4-clang-android.yml
@@ -14,6 +14,7 @@ name: android12-5.4 (clang-android)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android13-5.10-clang-12.yml
+++ b/.github/workflows/android13-5.10-clang-12.yml
@@ -14,6 +14,7 @@ name: android13-5.10 (clang-12)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android13-5.10-clang-13.yml
+++ b/.github/workflows/android13-5.10-clang-13.yml
@@ -14,6 +14,7 @@ name: android13-5.10 (clang-13)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android13-5.10-clang-14.yml
+++ b/.github/workflows/android13-5.10-clang-14.yml
@@ -14,6 +14,7 @@ name: android13-5.10 (clang-14)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android13-5.10-clang-15.yml
+++ b/.github/workflows/android13-5.10-clang-15.yml
@@ -14,6 +14,7 @@ name: android13-5.10 (clang-15)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android13-5.10-clang-16.yml
+++ b/.github/workflows/android13-5.10-clang-16.yml
@@ -14,6 +14,7 @@ name: android13-5.10 (clang-16)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android13-5.10-clang-android.yml
+++ b/.github/workflows/android13-5.10-clang-android.yml
@@ -14,6 +14,7 @@ name: android13-5.10 (clang-android)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android13-5.15-clang-12.yml
+++ b/.github/workflows/android13-5.15-clang-12.yml
@@ -14,6 +14,7 @@ name: android13-5.15 (clang-12)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android13-5.15-clang-13.yml
+++ b/.github/workflows/android13-5.15-clang-13.yml
@@ -14,6 +14,7 @@ name: android13-5.15 (clang-13)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android13-5.15-clang-14.yml
+++ b/.github/workflows/android13-5.15-clang-14.yml
@@ -14,6 +14,7 @@ name: android13-5.15 (clang-14)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android13-5.15-clang-15.yml
+++ b/.github/workflows/android13-5.15-clang-15.yml
@@ -14,6 +14,7 @@ name: android13-5.15 (clang-15)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android13-5.15-clang-16.yml
+++ b/.github/workflows/android13-5.15-clang-16.yml
@@ -14,6 +14,7 @@ name: android13-5.15 (clang-16)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android13-5.15-clang-android.yml
+++ b/.github/workflows/android13-5.15-clang-android.yml
@@ -14,6 +14,7 @@ name: android13-5.15 (clang-android)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android14-5.15-clang-12.yml
+++ b/.github/workflows/android14-5.15-clang-12.yml
@@ -14,6 +14,7 @@ name: android14-5.15 (clang-12)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android14-5.15-clang-13.yml
+++ b/.github/workflows/android14-5.15-clang-13.yml
@@ -14,6 +14,7 @@ name: android14-5.15 (clang-13)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android14-5.15-clang-14.yml
+++ b/.github/workflows/android14-5.15-clang-14.yml
@@ -14,6 +14,7 @@ name: android14-5.15 (clang-14)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android14-5.15-clang-15.yml
+++ b/.github/workflows/android14-5.15-clang-15.yml
@@ -14,6 +14,7 @@ name: android14-5.15 (clang-15)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android14-5.15-clang-16.yml
+++ b/.github/workflows/android14-5.15-clang-16.yml
@@ -14,6 +14,7 @@ name: android14-5.15 (clang-16)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/android14-5.15-clang-android.yml
+++ b/.github/workflows/android14-5.15-clang-android.yml
@@ -14,6 +14,7 @@ name: android14-5.15 (clang-android)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/arm64-clang-11.yml
+++ b/.github/workflows/arm64-clang-11.yml
@@ -14,6 +14,7 @@ name: arm64 (clang-11)
   schedule:
   - cron: 0 18 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/arm64-clang-12.yml
+++ b/.github/workflows/arm64-clang-12.yml
@@ -14,6 +14,7 @@ name: arm64 (clang-12)
   schedule:
   - cron: 0 18 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/arm64-clang-13.yml
+++ b/.github/workflows/arm64-clang-13.yml
@@ -14,6 +14,7 @@ name: arm64 (clang-13)
   schedule:
   - cron: 0 18 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/arm64-clang-14.yml
+++ b/.github/workflows/arm64-clang-14.yml
@@ -14,6 +14,7 @@ name: arm64 (clang-14)
   schedule:
   - cron: 0 18 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/arm64-clang-15.yml
+++ b/.github/workflows/arm64-clang-15.yml
@@ -14,6 +14,7 @@ name: arm64 (clang-15)
   schedule:
   - cron: 0 0 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/arm64-clang-16.yml
+++ b/.github/workflows/arm64-clang-16.yml
@@ -14,6 +14,7 @@ name: arm64 (clang-16)
   schedule:
   - cron: 0 0 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/arm64-fixes-clang-11.yml
+++ b/.github/workflows/arm64-fixes-clang-11.yml
@@ -14,6 +14,7 @@ name: arm64-fixes (clang-11)
   schedule:
   - cron: 0 18 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/arm64-fixes-clang-12.yml
+++ b/.github/workflows/arm64-fixes-clang-12.yml
@@ -14,6 +14,7 @@ name: arm64-fixes (clang-12)
   schedule:
   - cron: 0 18 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/arm64-fixes-clang-13.yml
+++ b/.github/workflows/arm64-fixes-clang-13.yml
@@ -14,6 +14,7 @@ name: arm64-fixes (clang-13)
   schedule:
   - cron: 0 18 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/arm64-fixes-clang-14.yml
+++ b/.github/workflows/arm64-fixes-clang-14.yml
@@ -14,6 +14,7 @@ name: arm64-fixes (clang-14)
   schedule:
   - cron: 0 18 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/arm64-fixes-clang-15.yml
+++ b/.github/workflows/arm64-fixes-clang-15.yml
@@ -14,6 +14,7 @@ name: arm64-fixes (clang-15)
   schedule:
   - cron: 0 0 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/arm64-fixes-clang-16.yml
+++ b/.github/workflows/arm64-fixes-clang-16.yml
@@ -14,6 +14,7 @@ name: arm64-fixes (clang-16)
   schedule:
   - cron: 0 0 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/chromeos-5.10-clang-12.yml
+++ b/.github/workflows/chromeos-5.10-clang-12.yml
@@ -14,6 +14,7 @@ name: chromeos-5.10 (clang-12)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/chromeos-5.10-clang-13.yml
+++ b/.github/workflows/chromeos-5.10-clang-13.yml
@@ -14,6 +14,7 @@ name: chromeos-5.10 (clang-13)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/chromeos-5.10-clang-14.yml
+++ b/.github/workflows/chromeos-5.10-clang-14.yml
@@ -14,6 +14,7 @@ name: chromeos-5.10 (clang-14)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/chromeos-5.10-clang-15.yml
+++ b/.github/workflows/chromeos-5.10-clang-15.yml
@@ -14,6 +14,7 @@ name: chromeos-5.10 (clang-15)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/chromeos-5.10-clang-16.yml
+++ b/.github/workflows/chromeos-5.10-clang-16.yml
@@ -14,6 +14,7 @@ name: chromeos-5.10 (clang-16)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/chromeos-5.15-clang-12.yml
+++ b/.github/workflows/chromeos-5.15-clang-12.yml
@@ -14,6 +14,7 @@ name: chromeos-5.15 (clang-12)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/chromeos-5.15-clang-13.yml
+++ b/.github/workflows/chromeos-5.15-clang-13.yml
@@ -14,6 +14,7 @@ name: chromeos-5.15 (clang-13)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/chromeos-5.15-clang-14.yml
+++ b/.github/workflows/chromeos-5.15-clang-14.yml
@@ -14,6 +14,7 @@ name: chromeos-5.15 (clang-14)
   schedule:
   - cron: 0 0 * * 0
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/chromeos-5.15-clang-15.yml
+++ b/.github/workflows/chromeos-5.15-clang-15.yml
@@ -14,6 +14,7 @@ name: chromeos-5.15 (clang-15)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/chromeos-5.15-clang-16.yml
+++ b/.github/workflows/chromeos-5.15-clang-16.yml
@@ -14,6 +14,7 @@ name: chromeos-5.15 (clang-16)
   schedule:
   - cron: 0 6 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/mainline-clang-11.yml
+++ b/.github/workflows/mainline-clang-11.yml
@@ -14,6 +14,7 @@ name: mainline (clang-11)
   schedule:
   - cron: 0 0,6,12,18 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/mainline-clang-12.yml
+++ b/.github/workflows/mainline-clang-12.yml
@@ -14,6 +14,7 @@ name: mainline (clang-12)
   schedule:
   - cron: 0 0,6,12,18 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/mainline-clang-13.yml
+++ b/.github/workflows/mainline-clang-13.yml
@@ -14,6 +14,7 @@ name: mainline (clang-13)
   schedule:
   - cron: 0 0,6,12,18 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -14,6 +14,7 @@ name: mainline (clang-14)
   schedule:
   - cron: 0 0,6,12,18 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -14,6 +14,7 @@ name: mainline (clang-15)
   schedule:
   - cron: 0 0,6,12,18 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -14,6 +14,7 @@ name: mainline (clang-16)
   schedule:
   - cron: 0 0,6,12,18 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/next-clang-11.yml
+++ b/.github/workflows/next-clang-11.yml
@@ -14,6 +14,7 @@ name: next (clang-11)
   schedule:
   - cron: 0 12 * * 1,2,3,4,5
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/next-clang-12.yml
+++ b/.github/workflows/next-clang-12.yml
@@ -14,6 +14,7 @@ name: next (clang-12)
   schedule:
   - cron: 0 12 * * 1,2,3,4,5
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/next-clang-13.yml
+++ b/.github/workflows/next-clang-13.yml
@@ -14,6 +14,7 @@ name: next (clang-13)
   schedule:
   - cron: 0 12 * * 1,2,3,4,5
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -14,6 +14,7 @@ name: next (clang-14)
   schedule:
   - cron: 0 12 * * 1,2,3,4,5
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -14,6 +14,7 @@ name: next (clang-15)
   schedule:
   - cron: 0 12 * * 1,2,3,4,5
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -14,6 +14,7 @@ name: next (clang-16)
   schedule:
   - cron: 0 12 * * 1,2,3,4,5
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/next-clang-android.yml
+++ b/.github/workflows/next-clang-android.yml
@@ -14,6 +14,7 @@ name: next (clang-android)
   schedule:
   - cron: 0 12 * * 1,2,3,4,5
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/stable-clang-11.yml
+++ b/.github/workflows/stable-clang-11.yml
@@ -14,6 +14,7 @@ name: stable (clang-11)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/stable-clang-12.yml
+++ b/.github/workflows/stable-clang-12.yml
@@ -14,6 +14,7 @@ name: stable (clang-12)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -14,6 +14,7 @@ name: stable (clang-13)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -14,6 +14,7 @@ name: stable (clang-14)
   schedule:
   - cron: 0 0 * * 3
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -14,6 +14,7 @@ name: stable (clang-15)
   schedule:
   - cron: 0 12 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/stable-clang-16.yml
+++ b/.github/workflows/stable-clang-16.yml
@@ -14,6 +14,7 @@ name: stable (clang-16)
   schedule:
   - cron: 0 12 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/tip-clang-11.yml
+++ b/.github/workflows/tip-clang-11.yml
@@ -14,6 +14,7 @@ name: tip (clang-11)
   schedule:
   - cron: 0 18 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/tip-clang-12.yml
+++ b/.github/workflows/tip-clang-12.yml
@@ -14,6 +14,7 @@ name: tip (clang-12)
   schedule:
   - cron: 0 18 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/tip-clang-13.yml
+++ b/.github/workflows/tip-clang-13.yml
@@ -14,6 +14,7 @@ name: tip (clang-13)
   schedule:
   - cron: 0 18 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/tip-clang-14.yml
+++ b/.github/workflows/tip-clang-14.yml
@@ -14,6 +14,7 @@ name: tip (clang-14)
   schedule:
   - cron: 0 18 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/tip-clang-15.yml
+++ b/.github/workflows/tip-clang-15.yml
@@ -14,6 +14,7 @@ name: tip (clang-15)
   schedule:
   - cron: 0 0 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/.github/workflows/tip-clang-16.yml
+++ b/.github/workflows/tip-clang-16.yml
@@ -14,6 +14,7 @@ name: tip (clang-16)
   schedule:
   - cron: 0 0 * * *
   workflow_dispatch: null
+permissions: read-all
 jobs:
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)

--- a/generate_workflow.py
+++ b/generate_workflow.py
@@ -42,6 +42,7 @@ def initial_workflow(name, cron, tuxsuite_yml, workflow_yml):
             # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_dispatch
             "workflow_dispatch": None
         },
+        "permissions": "read-all",
         "jobs": {}
     } # yapf: disable
 


### PR DESCRIPTION
This can help reduce our attack surface.

Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/447
Link: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
