### PR TITLE
check_logs.py: Increase attempts to verify build status to 9

### DIFF
--- a/check_logs.py
+++ b/check_logs.py
@@ -59,9 +59,9 @@ def verify_build():
 
     # If the build was neither fail nor pass, we need to fetch the status.json
     # of the particular build to try and get an updated result. We attempt this
-    # up to 7 times.
+    # up to 9 times.
     retries = 0
-    max_retries = 7
+    max_retries = 9
     while retries < max_retries:
         if build["result"] == "fail" or build["result"] == "pass":
             break


### PR DESCRIPTION
Even with the current max retries of 7, we still occasionally see builds
that do not have a pass/fail status. Remi recommends pinging the tuxapi
endpoint but further investigation will be needed to see if this is
feasible across the GitHub Actions job boundary. In the meantime,
increase the maximum number of retries to 9, which will result in an 8m
30s final wait and a total of 17 minutes of waiting for an updated
result.
