### PR TITLE
Increase 'tuxsuite plan' step timeout to eight hours

### DIFF
--- a/.github/workflows/4.14-clang-13.yml
+++ b/.github/workflows/4.14-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.14.y --job-name defconfigs --json-out builds.json tuxsuite/4.14-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.14-clang-14.yml
+++ b/.github/workflows/4.14-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.14.y --job-name defconfigs --json-out builds.json tuxsuite/4.14-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.14-clang-15.yml
+++ b/.github/workflows/4.14-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.14.y --job-name defconfigs --json-out builds.json tuxsuite/4.14-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.14-clang-16.yml
+++ b/.github/workflows/4.14-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.14.y --job-name defconfigs --json-out builds.json tuxsuite/4.14-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.19-clang-13.yml
+++ b/.github/workflows/4.19-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.19.y --job-name defconfigs --json-out builds.json tuxsuite/4.19-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.19-clang-14.yml
+++ b/.github/workflows/4.19-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.19.y --job-name defconfigs --json-out builds.json tuxsuite/4.19-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.19-clang-15.yml
+++ b/.github/workflows/4.19-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.19.y --job-name defconfigs --json-out builds.json tuxsuite/4.19-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.19-clang-16.yml
+++ b/.github/workflows/4.19-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.19.y --job-name defconfigs --json-out builds.json tuxsuite/4.19-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.9-clang-13.yml
+++ b/.github/workflows/4.9-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.9.y --job-name defconfigs --json-out builds.json tuxsuite/4.9-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.9-clang-14.yml
+++ b/.github/workflows/4.9-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.9.y --job-name defconfigs --json-out builds.json tuxsuite/4.9-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.9-clang-15.yml
+++ b/.github/workflows/4.9-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.9.y --job-name defconfigs --json-out builds.json tuxsuite/4.9-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.9-clang-16.yml
+++ b/.github/workflows/4.9-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.9.y --job-name defconfigs --json-out builds.json tuxsuite/4.9-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.10-clang-11.yml
+++ b/.github/workflows/5.10-clang-11.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name defconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -294,6 +295,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name allconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.10-clang-12.yml
+++ b/.github/workflows/5.10-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name defconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -336,6 +337,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name allconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.10-clang-13.yml
+++ b/.github/workflows/5.10-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name defconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -357,6 +358,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name allconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.10-clang-14.yml
+++ b/.github/workflows/5.10-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name defconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -357,6 +358,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name allconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.10-clang-15.yml
+++ b/.github/workflows/5.10-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name defconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -357,6 +358,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name allconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.10-clang-16.yml
+++ b/.github/workflows/5.10-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name defconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -357,6 +358,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name allconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name defconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -567,6 +568,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name distribution_configs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -877,6 +879,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name allconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name defconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -630,6 +631,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name distribution_configs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -940,6 +942,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name allconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name defconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -693,6 +694,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name distribution_configs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1066,6 +1068,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name allconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name defconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -693,6 +694,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name distribution_configs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1066,6 +1068,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name allconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name defconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -693,6 +694,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name distribution_configs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1066,6 +1068,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name allconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.15-clang-16.yml
+++ b/.github/workflows/5.15-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name defconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -672,6 +673,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name distribution_configs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1045,6 +1047,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name allconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.4-clang-13.yml
+++ b/.github/workflows/5.4-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.4.y --job-name defconfigs --json-out builds.json tuxsuite/5.4-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.4-clang-14.yml
+++ b/.github/workflows/5.4-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.4.y --job-name defconfigs --json-out builds.json tuxsuite/5.4-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.4-clang-15.yml
+++ b/.github/workflows/5.4-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.4.y --job-name defconfigs --json-out builds.json tuxsuite/5.4-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.4-clang-16.yml
+++ b/.github/workflows/5.4-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.4.y --job-name defconfigs --json-out builds.json tuxsuite/5.4-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.14-clang-12.yml
+++ b/.github/workflows/android-4.14-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.14-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.14-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.14-clang-13.yml
+++ b/.github/workflows/android-4.14-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.14-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.14-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.14-clang-14.yml
+++ b/.github/workflows/android-4.14-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.14-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.14-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.14-clang-15.yml
+++ b/.github/workflows/android-4.14-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.14-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.14-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.14-clang-16.yml
+++ b/.github/workflows/android-4.14-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.14-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.14-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.14-clang-android.yml
+++ b/.github/workflows/android-4.14-clang-android.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.14-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.14-clang-android.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.19-clang-12.yml
+++ b/.github/workflows/android-4.19-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.19-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.19-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.19-clang-13.yml
+++ b/.github/workflows/android-4.19-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.19-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.19-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.19-clang-14.yml
+++ b/.github/workflows/android-4.19-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.19-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.19-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.19-clang-15.yml
+++ b/.github/workflows/android-4.19-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.19-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.19-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.19-clang-16.yml
+++ b/.github/workflows/android-4.19-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.19-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.19-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.19-clang-android.yml
+++ b/.github/workflows/android-4.19-clang-android.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.19-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.19-clang-android.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.9-clang-12.yml
+++ b/.github/workflows/android-4.9-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.9-q --job-name defconfigs --json-out builds.json tuxsuite/android-4.9-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.9-clang-13.yml
+++ b/.github/workflows/android-4.9-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.9-q --job-name defconfigs --json-out builds.json tuxsuite/android-4.9-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.9-clang-14.yml
+++ b/.github/workflows/android-4.9-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.9-q --job-name defconfigs --json-out builds.json tuxsuite/android-4.9-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.9-clang-15.yml
+++ b/.github/workflows/android-4.9-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.9-q --job-name defconfigs --json-out builds.json tuxsuite/android-4.9-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.9-clang-16.yml
+++ b/.github/workflows/android-4.9-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.9-q --job-name defconfigs --json-out builds.json tuxsuite/android-4.9-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.9-clang-android.yml
+++ b/.github/workflows/android-4.9-clang-android.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.9-q --job-name defconfigs --json-out builds.json tuxsuite/android-4.9-clang-android.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-mainline-clang-12.yml
+++ b/.github/workflows/android-mainline-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name defconfigs --json-out builds.json tuxsuite/android-mainline-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name allconfigs --json-out builds.json tuxsuite/android-mainline-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-mainline-clang-13.yml
+++ b/.github/workflows/android-mainline-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name defconfigs --json-out builds.json tuxsuite/android-mainline-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name allconfigs --json-out builds.json tuxsuite/android-mainline-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-mainline-clang-14.yml
+++ b/.github/workflows/android-mainline-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name defconfigs --json-out builds.json tuxsuite/android-mainline-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name allconfigs --json-out builds.json tuxsuite/android-mainline-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-mainline-clang-15.yml
+++ b/.github/workflows/android-mainline-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name defconfigs --json-out builds.json tuxsuite/android-mainline-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name allconfigs --json-out builds.json tuxsuite/android-mainline-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-mainline-clang-16.yml
+++ b/.github/workflows/android-mainline-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name defconfigs --json-out builds.json tuxsuite/android-mainline-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name allconfigs --json-out builds.json tuxsuite/android-mainline-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-mainline-clang-android.yml
+++ b/.github/workflows/android-mainline-clang-android.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name defconfigs --json-out builds.json tuxsuite/android-mainline-clang-android.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name allconfigs --json-out builds.json tuxsuite/android-mainline-clang-android.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.10-clang-12.yml
+++ b/.github/workflows/android12-5.10-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.10-clang-13.yml
+++ b/.github/workflows/android12-5.10-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.10-clang-14.yml
+++ b/.github/workflows/android12-5.10-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.10-clang-15.yml
+++ b/.github/workflows/android12-5.10-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.10-clang-16.yml
+++ b/.github/workflows/android12-5.10-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.10-clang-android.yml
+++ b/.github/workflows/android12-5.10-clang-android.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-android.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-android.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.4-clang-12.yml
+++ b/.github/workflows/android12-5.4-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.4-clang-13.yml
+++ b/.github/workflows/android12-5.4-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.4-clang-14.yml
+++ b/.github/workflows/android12-5.4-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.4-clang-15.yml
+++ b/.github/workflows/android12-5.4-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.4-clang-16.yml
+++ b/.github/workflows/android12-5.4-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.4-clang-android.yml
+++ b/.github/workflows/android12-5.4-clang-android.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-android.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-android.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.10-clang-12.yml
+++ b/.github/workflows/android13-5.10-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.10-clang-13.yml
+++ b/.github/workflows/android13-5.10-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.10-clang-14.yml
+++ b/.github/workflows/android13-5.10-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.10-clang-15.yml
+++ b/.github/workflows/android13-5.10-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.10-clang-16.yml
+++ b/.github/workflows/android13-5.10-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.10-clang-android.yml
+++ b/.github/workflows/android13-5.10-clang-android.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-android.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-android.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.15-clang-12.yml
+++ b/.github/workflows/android13-5.15-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.15-clang-13.yml
+++ b/.github/workflows/android13-5.15-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.15-clang-14.yml
+++ b/.github/workflows/android13-5.15-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.15-clang-15.yml
+++ b/.github/workflows/android13-5.15-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.15-clang-16.yml
+++ b/.github/workflows/android13-5.15-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.15-clang-android.yml
+++ b/.github/workflows/android13-5.15-clang-android.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-android.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-android.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android14-5.15-clang-12.yml
+++ b/.github/workflows/android14-5.15-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name defconfigs --json-out builds.json tuxsuite/android14-5.15-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name allconfigs --json-out builds.json tuxsuite/android14-5.15-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android14-5.15-clang-13.yml
+++ b/.github/workflows/android14-5.15-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name defconfigs --json-out builds.json tuxsuite/android14-5.15-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name allconfigs --json-out builds.json tuxsuite/android14-5.15-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android14-5.15-clang-14.yml
+++ b/.github/workflows/android14-5.15-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name defconfigs --json-out builds.json tuxsuite/android14-5.15-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name allconfigs --json-out builds.json tuxsuite/android14-5.15-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android14-5.15-clang-15.yml
+++ b/.github/workflows/android14-5.15-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name defconfigs --json-out builds.json tuxsuite/android14-5.15-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name allconfigs --json-out builds.json tuxsuite/android14-5.15-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android14-5.15-clang-16.yml
+++ b/.github/workflows/android14-5.15-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name defconfigs --json-out builds.json tuxsuite/android14-5.15-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name allconfigs --json-out builds.json tuxsuite/android14-5.15-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android14-5.15-clang-android.yml
+++ b/.github/workflows/android14-5.15-clang-android.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name defconfigs --json-out builds.json tuxsuite/android14-5.15-clang-android.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -105,6 +106,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name allconfigs --json-out builds.json tuxsuite/android14-5.15-clang-android.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-clang-11.yml
+++ b/.github/workflows/arm64-clang-11.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name defconfigs --json-out builds.json --patch-series patches/arm64 tuxsuite/arm64-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -63,6 +64,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name allconfigs --json-out builds.json --patch-series patches/arm64 tuxsuite/arm64-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-clang-12.yml
+++ b/.github/workflows/arm64-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name defconfigs --json-out builds.json --patch-series patches/arm64 tuxsuite/arm64-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -63,6 +64,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name allconfigs --json-out builds.json --patch-series patches/arm64 tuxsuite/arm64-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-clang-13.yml
+++ b/.github/workflows/arm64-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name defconfigs --json-out builds.json --patch-series patches/arm64 tuxsuite/arm64-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -84,6 +85,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name allconfigs --json-out builds.json --patch-series patches/arm64 tuxsuite/arm64-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-clang-14.yml
+++ b/.github/workflows/arm64-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name defconfigs --json-out builds.json --patch-series patches/arm64 tuxsuite/arm64-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -84,6 +85,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name allconfigs --json-out builds.json --patch-series patches/arm64 tuxsuite/arm64-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-clang-15.yml
+++ b/.github/workflows/arm64-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name defconfigs --json-out builds.json --patch-series patches/arm64 tuxsuite/arm64-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -84,6 +85,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name allconfigs --json-out builds.json --patch-series patches/arm64 tuxsuite/arm64-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-clang-16.yml
+++ b/.github/workflows/arm64-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name defconfigs --json-out builds.json --patch-series patches/arm64 tuxsuite/arm64-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -84,6 +85,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name allconfigs --json-out builds.json --patch-series patches/arm64 tuxsuite/arm64-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-fixes-clang-11.yml
+++ b/.github/workflows/arm64-fixes-clang-11.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name defconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -63,6 +64,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name allconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-fixes-clang-12.yml
+++ b/.github/workflows/arm64-fixes-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name defconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -63,6 +64,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name allconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-fixes-clang-13.yml
+++ b/.github/workflows/arm64-fixes-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name defconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -84,6 +85,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name allconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-fixes-clang-14.yml
+++ b/.github/workflows/arm64-fixes-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name defconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -84,6 +85,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name allconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-fixes-clang-15.yml
+++ b/.github/workflows/arm64-fixes-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name defconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -84,6 +85,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name allconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-fixes-clang-16.yml
+++ b/.github/workflows/arm64-fixes-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name defconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -84,6 +85,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name allconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.10-clang-12.yml
+++ b/.github/workflows/chromeos-5.10-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.10 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.10-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.10-clang-13.yml
+++ b/.github/workflows/chromeos-5.10-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.10 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.10-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.10-clang-14.yml
+++ b/.github/workflows/chromeos-5.10-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.10 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.10-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.10-clang-15.yml
+++ b/.github/workflows/chromeos-5.10-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.10 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.10-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.10-clang-16.yml
+++ b/.github/workflows/chromeos-5.10-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.10 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.10-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.15-clang-12.yml
+++ b/.github/workflows/chromeos-5.15-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.15 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.15-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.15-clang-13.yml
+++ b/.github/workflows/chromeos-5.15-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.15 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.15-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.15-clang-14.yml
+++ b/.github/workflows/chromeos-5.15-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.15 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.15-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.15-clang-15.yml
+++ b/.github/workflows/chromeos-5.15-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.15 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.15-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.15-clang-16.yml
+++ b/.github/workflows/chromeos-5.15-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.15 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.15-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/mainline-clang-11.yml
+++ b/.github/workflows/mainline-clang-11.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -588,6 +589,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name distribution_configs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -898,6 +900,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/mainline-clang-12.yml
+++ b/.github/workflows/mainline-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -609,6 +610,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name distribution_configs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -919,6 +921,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/mainline-clang-13.yml
+++ b/.github/workflows/mainline-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -630,6 +631,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name distribution_configs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -961,6 +963,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -672,6 +673,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name distribution_configs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1045,6 +1047,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -672,6 +673,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name distribution_configs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1045,6 +1047,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -714,6 +715,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name distribution_configs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1087,6 +1089,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/next-clang-11.yml
+++ b/.github/workflows/next-clang-11.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -588,6 +589,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name distribution_configs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -898,6 +900,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/next-clang-12.yml
+++ b/.github/workflows/next-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -609,6 +610,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name distribution_configs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -919,6 +921,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/next-clang-13.yml
+++ b/.github/workflows/next-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -651,6 +652,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name distribution_configs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -982,6 +984,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -693,6 +694,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name distribution_configs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1066,6 +1068,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -693,6 +694,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name distribution_configs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1066,6 +1068,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -777,6 +778,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name distribution_configs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1150,6 +1152,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/next-clang-android.yml
+++ b/.github/workflows/next-clang-android.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-android.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -315,6 +316,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/next tuxsuite/next-clang-android.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/stable-clang-11.yml
+++ b/.github/workflows/stable-clang-11.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.19.y --job-name defconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -588,6 +589,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.19.y --job-name distribution_configs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -898,6 +900,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.19.y --job-name allconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/stable-clang-12.yml
+++ b/.github/workflows/stable-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.19.y --job-name defconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -630,6 +631,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.19.y --job-name distribution_configs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -940,6 +942,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.19.y --job-name allconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.19.y --job-name defconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -651,6 +652,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.19.y --job-name distribution_configs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -982,6 +984,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.19.y --job-name allconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.19.y --job-name defconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -714,6 +715,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.19.y --job-name distribution_configs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1087,6 +1089,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.19.y --job-name allconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.19.y --job-name defconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -714,6 +715,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.19.y --job-name distribution_configs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1087,6 +1089,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.19.y --job-name allconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/stable-clang-16.yml
+++ b/.github/workflows/stable-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.19.y --job-name defconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -693,6 +694,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.19.y --job-name distribution_configs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1066,6 +1068,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.19.y --job-name allconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/tip-clang-11.yml
+++ b/.github/workflows/tip-clang-11.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/tip-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -84,6 +85,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/tip-clang-11.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/tip-clang-12.yml
+++ b/.github/workflows/tip-clang-12.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/tip-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -84,6 +85,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/tip-clang-12.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/tip-clang-13.yml
+++ b/.github/workflows/tip-clang-13.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/tip-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -84,6 +85,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/tip-clang-13.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/tip-clang-14.yml
+++ b/.github/workflows/tip-clang-14.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/tip-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -84,6 +85,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/tip-clang-14.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/tip-clang-15.yml
+++ b/.github/workflows/tip-clang-15.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/tip-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -84,6 +85,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/tip-clang-15.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/tip-clang-16.yml
+++ b/.github/workflows/tip-clang-16.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/tip-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -84,6 +85,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/tip-clang-16.tux.yml || true
+      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/generate_workflow.py
+++ b/generate_workflow.py
@@ -104,7 +104,8 @@ def tuxsuite_setups(job_name, tuxsuite_yml, repo, ref):
                 },
                 {
                     "name": "tuxsuite",
-                    "run": "tuxsuite plan --git-repo {} --git-ref {} --job-name {} --json-out builds.json {}{} || true".format(repo, ref, job_name, patch_series, tuxsuite_yml)
+                    "run": "tuxsuite plan --git-repo {} --git-ref {} --job-name {} --json-out builds.json {}{} || true".format(repo, ref, job_name, patch_series, tuxsuite_yml),
+                    "timeout-minutes": 480
                 },
                 {
                     "name": "save output",


### PR DESCRIPTION
By default, GitHub Actions limits each step in a workflow to 360
minutes, which would normally be enough but if an all*config build gets
preempted and has to restart, it is possible for the 'tuxsuite plan'
command to exceed 360 minutes. Increase it by two more hours up to a
total of eight hours to see if that is enough to avoid job timeouts.
