### PR TITLE
Re-enable OpenSUSE's RISC-V configuration

### DIFF
--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -785,6 +785,27 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _f3c18ac5c3e0b8debf3a492c76062fe9:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_distribution_configs
+    name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 11
+      BOOT: 1
+      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_distribution_configs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _acc5128ffcbc8107ba480ce551919ee8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -848,6 +848,27 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _6bae59ef4c989f6e25ce342bf9dcf3e0:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_distribution_configs
+    name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 12
+      BOOT: 1
+      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_distribution_configs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _ca7469095b0b6a043817e9b4281b32ef:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/mainline-clang-11.yml
+++ b/.github/workflows/mainline-clang-11.yml
@@ -806,6 +806,27 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _f3c18ac5c3e0b8debf3a492c76062fe9:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_distribution_configs
+    name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 11
+      BOOT: 1
+      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_distribution_configs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _acc5128ffcbc8107ba480ce551919ee8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/mainline-clang-12.yml
+++ b/.github/workflows/mainline-clang-12.yml
@@ -827,6 +827,27 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _6bae59ef4c989f6e25ce342bf9dcf3e0:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_distribution_configs
+    name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 12
+      BOOT: 1
+      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_distribution_configs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _ca7469095b0b6a043817e9b4281b32ef:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/next-clang-11.yml
+++ b/.github/workflows/next-clang-11.yml
@@ -806,6 +806,27 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _f3c18ac5c3e0b8debf3a492c76062fe9:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_distribution_configs
+    name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 11
+      BOOT: 1
+      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_distribution_configs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _acc5128ffcbc8107ba480ce551919ee8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/next-clang-12.yml
+++ b/.github/workflows/next-clang-12.yml
@@ -827,6 +827,27 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _6bae59ef4c989f6e25ce342bf9dcf3e0:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_distribution_configs
+    name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 12
+      BOOT: 1
+      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_distribution_configs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _ca7469095b0b6a043817e9b4281b32ef:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/stable-clang-11.yml
+++ b/.github/workflows/stable-clang-11.yml
@@ -806,6 +806,27 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _f3c18ac5c3e0b8debf3a492c76062fe9:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_distribution_configs
+    name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 11
+      BOOT: 1
+      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_distribution_configs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _acc5128ffcbc8107ba480ce551919ee8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/stable-clang-12.yml
+++ b/.github/workflows/stable-clang-12.yml
@@ -848,6 +848,27 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _6bae59ef4c989f6e25ce342bf9dcf3e0:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_distribution_configs
+    name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 12
+      BOOT: 1
+      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_distribution_configs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _ca7469095b0b6a043817e9b4281b32ef:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/generator.yml
+++ b/generator.yml
@@ -1935,8 +1935,7 @@ builds:
   - {<< : *riscv,             << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *riscv_allmod,      << : *mainline,         << : *llvm,            boot: false, << : *llvm_12}
   - {<< : *riscv_alpine,      << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
-  # OpenSUSE RISC-V config: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1719)
-  # - {<< : *riscv_suse,        << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *riscv_suse,        << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *um,                << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
@@ -1996,8 +1995,7 @@ builds:
   - {<< : *riscv,             << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *riscv_allmod,      << : *next,             << : *llvm,            boot: false, << : *llvm_12}
   - {<< : *riscv_alpine,      << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
-  # OpenSUSE RISC-V config: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1719)
-  # - {<< : *riscv_suse,        << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *riscv_suse,        << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *um,                << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
@@ -2056,8 +2054,7 @@ builds:
   - {<< : *riscv,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *riscv_allmod,      << : *stable,           << : *llvm,            boot: false, << : *llvm_12}
   - {<< : *riscv_alpine,      << : *stable,           << : *llvm,            boot: true,  << : *llvm_12}
-  # OpenSUSE RISC-V config: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1719)
-  # - {<< : *riscv_suse,        << : *stable,           << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *riscv_suse,        << : *stable,           << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *um,                << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *x86_64,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *x86_64_lto_full,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_12}
@@ -2116,8 +2113,7 @@ builds:
   - {<< : *riscv,             << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_12}
   - {<< : *riscv_alpine,      << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
-  # OpenSUSE RISC-V config: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1719)
-  # - {<< : *riscv_suse,        << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *riscv_suse,        << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *x86_64,            << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *x86_64_lto_full,   << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *x86_64_lto_thin,   << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
@@ -2266,8 +2262,7 @@ builds:
   - {<< : *riscv,             << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *riscv_allmod,      << : *mainline,         << : *llvm,            boot: false, << : *llvm_11}
   - {<< : *riscv_alpine,      << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
-  # OpenSUSE RISC-V config: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1719)
-  # - {<< : *riscv_suse,        << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *riscv_suse,        << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *um,                << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
@@ -2327,8 +2322,7 @@ builds:
   - {<< : *riscv,             << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *riscv_allmod,      << : *next,             << : *llvm,            boot: false, << : *llvm_11}
   - {<< : *riscv_alpine,      << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
-  # OpenSUSE RISC-V config: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1719)
-  # - {<< : *riscv_suse,        << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *riscv_suse,        << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *um,                << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
@@ -2388,8 +2382,7 @@ builds:
   - {<< : *riscv,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *riscv_allmod,      << : *stable,           << : *llvm,            boot: false, << : *llvm_11}
   - {<< : *riscv_alpine,      << : *stable,           << : *llvm,            boot: true,  << : *llvm_11}
-  # OpenSUSE RISC-V config: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1719)
-  # - {<< : *riscv_suse,        << : *stable,           << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *riscv_suse,        << : *stable,           << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *um,                << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *x86_64,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *x86_64_lto_full,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_11}
@@ -2448,8 +2441,7 @@ builds:
   - {<< : *riscv,             << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_11}
   - {<< : *riscv_alpine,      << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
-  # OpenSUSE RISC-V config: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1719)
-  # - {<< : *riscv_suse,        << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
+  - {<< : *riscv_suse,        << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *x86_64,            << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *x86_64_lto_full,   << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *x86_64_lto_thin,   << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}

--- a/tuxsuite/5.15-clang-11.tux.yml
+++ b/tuxsuite/5.15-clang-11.tux.yml
@@ -351,6 +351,15 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
+  - target_arch: riscv
+    toolchain: clang-11
+    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 0
   - target_arch: x86_64
     toolchain: clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64

--- a/tuxsuite/5.15-clang-12.tux.yml
+++ b/tuxsuite/5.15-clang-12.tux.yml
@@ -382,6 +382,15 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
+  - target_arch: riscv
+    toolchain: clang-12
+    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 0
   - target_arch: x86_64
     toolchain: clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64

--- a/tuxsuite/mainline-clang-11.tux.yml
+++ b/tuxsuite/mainline-clang-11.tux.yml
@@ -359,6 +359,15 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
+  - target_arch: riscv
+    toolchain: clang-11
+    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 0
   - target_arch: x86_64
     toolchain: clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64

--- a/tuxsuite/mainline-clang-12.tux.yml
+++ b/tuxsuite/mainline-clang-12.tux.yml
@@ -370,6 +370,15 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
+  - target_arch: riscv
+    toolchain: clang-12
+    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 0
   - target_arch: x86_64
     toolchain: clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64

--- a/tuxsuite/next-clang-11.tux.yml
+++ b/tuxsuite/next-clang-11.tux.yml
@@ -359,6 +359,15 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
+  - target_arch: riscv
+    toolchain: clang-11
+    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 0
   - target_arch: x86_64
     toolchain: clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64

--- a/tuxsuite/next-clang-12.tux.yml
+++ b/tuxsuite/next-clang-12.tux.yml
@@ -370,6 +370,15 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
+  - target_arch: riscv
+    toolchain: clang-12
+    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 0
   - target_arch: x86_64
     toolchain: clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64

--- a/tuxsuite/stable-clang-11.tux.yml
+++ b/tuxsuite/stable-clang-11.tux.yml
@@ -359,6 +359,15 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
+  - target_arch: riscv
+    toolchain: clang-11
+    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 0
   - target_arch: x86_64
     toolchain: clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64

--- a/tuxsuite/stable-clang-12.tux.yml
+++ b/tuxsuite/stable-clang-12.tux.yml
@@ -379,6 +379,15 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
+  - target_arch: riscv
+    toolchain: clang-12
+    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 0
   - target_arch: x86_64
     toolchain: clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64


### PR DESCRIPTION
The build failures for which this configuration was disabled have been
resolved in all of these trees.

Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/445
