### PR TITLE
Disable ppc44x_defconfig builds on stable

### DIFF
--- a/.github/workflows/stable-clang-12.yml
+++ b/.github/workflows/stable-clang-12.yml
@@ -390,27 +390,6 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _f19fa50ec541ef4ddce215421e645da8:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 ppc44x_defconfig
-    env:
-      ARCH: powerpc
-      LLVM_VERSION: 12
-      BOOT: 1
-      CONFIG: ppc44x_defconfig
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _38b22cfae74996dcecea1459e2f4a5d1:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -411,27 +411,6 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _48a57be25b36aba020e19ff27fcc54a4:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 ppc44x_defconfig
-    env:
-      ARCH: powerpc
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: ppc44x_defconfig
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _d84b97b9a88aa671856abd90b21a3707:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -432,27 +432,6 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _21120d396d88027038271a19c433b2ea:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 ppc44x_defconfig
-    env:
-      ARCH: powerpc
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: ppc44x_defconfig
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _880d0c92bac14cafd5355697d2940454:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -432,27 +432,6 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _73089fb85e10cf8cd08daf2f08ef949c:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 ppc44x_defconfig
-    env:
-      ARCH: powerpc
-      LLVM_VERSION: 15
-      BOOT: 1
-      CONFIG: ppc44x_defconfig
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _7b977da0b866baaa39c0fe5c0379b628:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/stable-clang-16.yml
+++ b/.github/workflows/stable-clang-16.yml
@@ -432,27 +432,6 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _f190a79c7006ff76669571b6c508bebe:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 ppc44x_defconfig
-    env:
-      ARCH: powerpc
-      LLVM_VERSION: 16
-      BOOT: 1
-      CONFIG: ppc44x_defconfig
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _68adb70db01be3b72adae71e171ec517:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/generator.yml
+++ b/generator.yml
@@ -512,7 +512,8 @@ builds:
   - {<< : *i386_suse,         << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *mips,              << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *mipsel,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *ppc32,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_tot}
+  # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)
+  # - {<< : *ppc32,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_tot}
   - {<< : *ppc64,             << : *stable,           << : *ppc64_llvm,      boot: true,  << : *llvm_tot}
   - {<< : *ppc64le,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *ppc64le_fedora,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -904,7 +905,8 @@ builds:
   - {<< : *i386_suse,         << : *stable,           << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *mips,              << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *mipsel,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *ppc32,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_latest}
+  # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)
+  # - {<< : *ppc32,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_latest}
   - {<< : *ppc64,             << : *stable,           << : *ppc64_llvm,      boot: true,  << : *llvm_latest}
   - {<< : *ppc64le,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *ppc64le_fedora,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -1294,7 +1296,8 @@ builds:
   - {<< : *i386_suse,         << : *stable,           << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *mips,              << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *mipsel,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *ppc32,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_14}
+  # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)
+  # - {<< : *ppc32,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_14}
   - {<< : *ppc64,             << : *stable,           << : *ppc64_llvm,      boot: true,  << : *llvm_14}
   - {<< : *ppc64le,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *ppc64le_fedora,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_14}
@@ -1674,7 +1677,8 @@ builds:
   - {<< : *i386_suse,         << : *stable,           << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *mips,              << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *mipsel,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *ppc32,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_13}
+  # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)
+  # - {<< : *ppc32,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_13}
   - {<< : *ppc64,             << : *stable,           << : *ppc64_llvm,      boot: true,  << : *llvm_13}
   - {<< : *ppc64le,           << : *stable,           << : *llvm,            boot: true,  << : *llvm_13}
   - {<< : *ppc64le_fedora,    << : *stable,           << : *clang,           boot: true,  << : *llvm_13}
@@ -2046,7 +2050,8 @@ builds:
   - {<< : *i386_suse,         << : *stable,           << : *llvm_full,       boot: false, << : *llvm_12}
   - {<< : *mips,              << : *stable,           << : *mips_llvm_full,  boot: true,  << : *llvm_12}
   - {<< : *mipsel,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_12}
-  - {<< : *ppc32,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_12}
+  # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)
+  # - {<< : *ppc32,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *ppc64,             << : *stable,           << : *ppc64_llvm,      boot: true,  << : *llvm_12}
   - {<< : *ppc64le,           << : *stable,           << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *ppc64le_fedora,    << : *stable,           << : *clang,           boot: true,  << : *llvm_12}

--- a/tuxsuite/stable-clang-12.tux.yml
+++ b/tuxsuite/stable-clang-12.tux.yml
@@ -180,15 +180,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: clang-12
-    kconfig: ppc44x_defconfig
-    targets:
-    - kernel
-    kernel_image: uImage
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: powerpc
-    toolchain: clang-12
     kconfig:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y

--- a/tuxsuite/stable-clang-13.tux.yml
+++ b/tuxsuite/stable-clang-13.tux.yml
@@ -189,15 +189,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: clang-13
-    kconfig: ppc44x_defconfig
-    targets:
-    - kernel
-    kernel_image: uImage
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: powerpc
-    toolchain: clang-13
     kconfig:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y

--- a/tuxsuite/stable-clang-14.tux.yml
+++ b/tuxsuite/stable-clang-14.tux.yml
@@ -200,15 +200,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: clang-14
-    kconfig: ppc44x_defconfig
-    targets:
-    - kernel
-    kernel_image: uImage
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: powerpc
-    toolchain: clang-14
     kconfig:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y

--- a/tuxsuite/stable-clang-15.tux.yml
+++ b/tuxsuite/stable-clang-15.tux.yml
@@ -200,15 +200,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: clang-15
-    kconfig: ppc44x_defconfig
-    targets:
-    - kernel
-    kernel_image: uImage
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: powerpc
-    toolchain: clang-15
     kconfig:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y

--- a/tuxsuite/stable-clang-16.tux.yml
+++ b/tuxsuite/stable-clang-16.tux.yml
@@ -200,15 +200,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig: ppc44x_defconfig
-    targets:
-    - kernel
-    kernel_image: uImage
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: powerpc
-    toolchain: clang-nightly
     kconfig:
     - pseries_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y


### PR DESCRIPTION
Same as commit 4ea2e8d ("generator.yml: Disable ppc44x_defconfig builds
on mainline and -next") but for stable. This should have been done as
part of the latest stable bump.

Link: https://github.com/ClangBuiltLinux/linux/issues/1679
