### PR TITLE
Add more checks for potential TuxSuite problems

### DIFF
--- a/check_logs.py
+++ b/check_logs.py
@@ -247,6 +247,9 @@ def run_boot(build):
 
 
 def boot_test(build):
+    if build["result"] == "unknown":
+        print_red("unknown build result, skipping boot")
+        sys.exit(1)
     if build["result"] == "fail":
         print_red("fatal build errors encountered during build, skipping boot")
         sys.exit(1)

--- a/check_logs.py
+++ b/check_logs.py
@@ -81,6 +81,10 @@ def verify_build():
         print_red("Build is not finished on TuxSuite's side!")
         sys.exit(1)
 
+    if "Build Timed Out" in build["status_message"]:
+        print_red(build["status_message"])
+        sys.exit(1)
+
     if build["status_message"] == "Unable to apply kernel patch":
         print_red(
             "Patch failed to apply to current kernel tree, does it need to be removed or updated?"

--- a/check_logs.py
+++ b/check_logs.py
@@ -63,7 +63,7 @@ def verify_build():
     retries = 0
     max_retries = 9
     while retries < max_retries:
-        if build["result"] == "fail" or build["result"] == "pass":
+        if build["tuxbuild_status"] == "complete":
             break
 
         if retries:
@@ -78,7 +78,7 @@ def verify_build():
     print(json.dumps(build, indent=4))
 
     if retries == max_retries:
-        print_red("status.json did not give a pass/fail result!")
+        print_red("Build is not finished on TuxSuite's side!")
         sys.exit(1)
 
     if build["status_message"] == "Unable to apply kernel patch":

--- a/utils.py
+++ b/utils.py
@@ -118,7 +118,7 @@ def _read_builds():
         builds = "mock.builds.json"
     try:
         if pathlib.Path(builds).stat().st_size == 0:
-            raise Exception("%s is zero sized?" % (builds))
+            raise Exception(f"{builds} is zero sized?")
         with open(builds) as f:
             builds = json.load(f)
     except FileNotFoundError as e:

--- a/utils.py
+++ b/utils.py
@@ -117,6 +117,8 @@ def _read_builds():
     if os.environ.get("MOCK"):
         builds = "mock.builds.json"
     try:
+        if pathlib.Path(builds).stat().st_size == 0:
+            raise Exception("%s is zero sized?" % (builds))
         with open(builds) as f:
             builds = json.load(f)
     except FileNotFoundError as e:


### PR DESCRIPTION
This PR adds some more explicit checks for situations that we have hit in TuxSuite, such as an empty builds.json or unfinished builds, which will help making triaging failures quicker.
