### PR TITLE
Adjust location of raised timeout in GitHub Actions workflow files

### DIFF
--- a/.github/workflows/4.14-clang-13.yml
+++ b/.github/workflows/4.14-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.14.y --job-name defconfigs --json-out builds.json tuxsuite/4.14-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.14-clang-14.yml
+++ b/.github/workflows/4.14-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.14.y --job-name defconfigs --json-out builds.json tuxsuite/4.14-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.14-clang-15.yml
+++ b/.github/workflows/4.14-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.14.y --job-name defconfigs --json-out builds.json tuxsuite/4.14-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.14-clang-16.yml
+++ b/.github/workflows/4.14-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.14.y --job-name defconfigs --json-out builds.json tuxsuite/4.14-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.19-clang-13.yml
+++ b/.github/workflows/4.19-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.19.y --job-name defconfigs --json-out builds.json tuxsuite/4.19-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.19-clang-14.yml
+++ b/.github/workflows/4.19-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.19.y --job-name defconfigs --json-out builds.json tuxsuite/4.19-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.19-clang-15.yml
+++ b/.github/workflows/4.19-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.19.y --job-name defconfigs --json-out builds.json tuxsuite/4.19-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.19-clang-16.yml
+++ b/.github/workflows/4.19-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.19.y --job-name defconfigs --json-out builds.json tuxsuite/4.19-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.9-clang-13.yml
+++ b/.github/workflows/4.9-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.9.y --job-name defconfigs --json-out builds.json tuxsuite/4.9-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.9-clang-14.yml
+++ b/.github/workflows/4.9-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.9.y --job-name defconfigs --json-out builds.json tuxsuite/4.9-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.9-clang-15.yml
+++ b/.github/workflows/4.9-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.9.y --job-name defconfigs --json-out builds.json tuxsuite/4.9-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/4.9-clang-16.yml
+++ b/.github/workflows/4.9-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-4.9.y --job-name defconfigs --json-out builds.json tuxsuite/4.9-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.10-clang-11.yml
+++ b/.github/workflows/5.10-clang-11.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name defconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -291,11 +291,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name allconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.10-clang-12.yml
+++ b/.github/workflows/5.10-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name defconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -333,11 +333,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name allconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.10-clang-13.yml
+++ b/.github/workflows/5.10-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name defconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -354,11 +354,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name allconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.10-clang-14.yml
+++ b/.github/workflows/5.10-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name defconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -354,11 +354,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name allconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.10-clang-15.yml
+++ b/.github/workflows/5.10-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name defconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -354,11 +354,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name allconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.10-clang-16.yml
+++ b/.github/workflows/5.10-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name defconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -354,11 +354,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.10.y --job-name allconfigs --json-out builds.json --patch-series patches/5.10 tuxsuite/5.10-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name defconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -564,11 +564,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name distribution_configs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -896,11 +896,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name allconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name defconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -627,11 +627,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name distribution_configs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -959,11 +959,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name allconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name defconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -690,11 +690,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name distribution_configs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1064,11 +1064,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name allconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name defconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -690,11 +690,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name distribution_configs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1064,11 +1064,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name allconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name defconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -690,11 +690,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name distribution_configs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1064,11 +1064,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name allconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.15-clang-16.yml
+++ b/.github/workflows/5.15-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name defconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -669,11 +669,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name distribution_configs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1043,11 +1043,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.15.y --job-name allconfigs --json-out builds.json --patch-series patches/5.15 tuxsuite/5.15-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.4-clang-13.yml
+++ b/.github/workflows/5.4-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.4.y --job-name defconfigs --json-out builds.json tuxsuite/5.4-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.4-clang-14.yml
+++ b/.github/workflows/5.4-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.4.y --job-name defconfigs --json-out builds.json tuxsuite/5.4-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.4-clang-15.yml
+++ b/.github/workflows/5.4-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.4.y --job-name defconfigs --json-out builds.json tuxsuite/5.4-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/5.4-clang-16.yml
+++ b/.github/workflows/5.4-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-5.4.y --job-name defconfigs --json-out builds.json tuxsuite/5.4-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.14-clang-12.yml
+++ b/.github/workflows/android-4.14-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.14-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.14-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.14-clang-13.yml
+++ b/.github/workflows/android-4.14-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.14-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.14-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.14-clang-14.yml
+++ b/.github/workflows/android-4.14-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.14-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.14-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.14-clang-15.yml
+++ b/.github/workflows/android-4.14-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.14-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.14-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.14-clang-16.yml
+++ b/.github/workflows/android-4.14-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.14-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.14-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.14-clang-android.yml
+++ b/.github/workflows/android-4.14-clang-android.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.14-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.14-clang-android.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.19-clang-12.yml
+++ b/.github/workflows/android-4.19-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.19-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.19-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.19-clang-13.yml
+++ b/.github/workflows/android-4.19-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.19-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.19-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.19-clang-14.yml
+++ b/.github/workflows/android-4.19-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.19-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.19-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.19-clang-15.yml
+++ b/.github/workflows/android-4.19-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.19-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.19-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.19-clang-16.yml
+++ b/.github/workflows/android-4.19-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.19-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.19-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.19-clang-android.yml
+++ b/.github/workflows/android-4.19-clang-android.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.19-stable --job-name defconfigs --json-out builds.json tuxsuite/android-4.19-clang-android.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.9-clang-12.yml
+++ b/.github/workflows/android-4.9-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.9-q --job-name defconfigs --json-out builds.json tuxsuite/android-4.9-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.9-clang-13.yml
+++ b/.github/workflows/android-4.9-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.9-q --job-name defconfigs --json-out builds.json tuxsuite/android-4.9-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.9-clang-14.yml
+++ b/.github/workflows/android-4.9-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.9-q --job-name defconfigs --json-out builds.json tuxsuite/android-4.9-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.9-clang-15.yml
+++ b/.github/workflows/android-4.9-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.9-q --job-name defconfigs --json-out builds.json tuxsuite/android-4.9-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.9-clang-16.yml
+++ b/.github/workflows/android-4.9-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.9-q --job-name defconfigs --json-out builds.json tuxsuite/android-4.9-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-4.9-clang-android.yml
+++ b/.github/workflows/android-4.9-clang-android.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-4.9-q --job-name defconfigs --json-out builds.json tuxsuite/android-4.9-clang-android.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-mainline-clang-12.yml
+++ b/.github/workflows/android-mainline-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name defconfigs --json-out builds.json tuxsuite/android-mainline-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name allconfigs --json-out builds.json tuxsuite/android-mainline-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-mainline-clang-13.yml
+++ b/.github/workflows/android-mainline-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name defconfigs --json-out builds.json tuxsuite/android-mainline-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name allconfigs --json-out builds.json tuxsuite/android-mainline-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-mainline-clang-14.yml
+++ b/.github/workflows/android-mainline-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name defconfigs --json-out builds.json tuxsuite/android-mainline-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name allconfigs --json-out builds.json tuxsuite/android-mainline-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-mainline-clang-15.yml
+++ b/.github/workflows/android-mainline-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name defconfigs --json-out builds.json tuxsuite/android-mainline-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name allconfigs --json-out builds.json tuxsuite/android-mainline-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-mainline-clang-16.yml
+++ b/.github/workflows/android-mainline-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name defconfigs --json-out builds.json tuxsuite/android-mainline-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name allconfigs --json-out builds.json tuxsuite/android-mainline-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android-mainline-clang-android.yml
+++ b/.github/workflows/android-mainline-clang-android.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name defconfigs --json-out builds.json tuxsuite/android-mainline-clang-android.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android-mainline --job-name allconfigs --json-out builds.json tuxsuite/android-mainline-clang-android.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.10-clang-12.yml
+++ b/.github/workflows/android12-5.10-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.10-clang-13.yml
+++ b/.github/workflows/android12-5.10-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.10-clang-14.yml
+++ b/.github/workflows/android12-5.10-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.10-clang-15.yml
+++ b/.github/workflows/android12-5.10-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.10-clang-16.yml
+++ b/.github/workflows/android12-5.10-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.10-clang-android.yml
+++ b/.github/workflows/android12-5.10-clang-android.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-android.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.10 tuxsuite/android12-5.10-clang-android.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.4-clang-12.yml
+++ b/.github/workflows/android12-5.4-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.4-clang-13.yml
+++ b/.github/workflows/android12-5.4-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.4-clang-14.yml
+++ b/.github/workflows/android12-5.4-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.4-clang-15.yml
+++ b/.github/workflows/android12-5.4-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.4-clang-16.yml
+++ b/.github/workflows/android12-5.4-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android12-5.4-clang-android.yml
+++ b/.github/workflows/android12-5.4-clang-android.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name defconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-android.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android12-5.4 --job-name allconfigs --json-out builds.json --patch-series patches/android12-5.4 tuxsuite/android12-5.4-clang-android.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.10-clang-12.yml
+++ b/.github/workflows/android13-5.10-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.10-clang-13.yml
+++ b/.github/workflows/android13-5.10-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.10-clang-14.yml
+++ b/.github/workflows/android13-5.10-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.10-clang-15.yml
+++ b/.github/workflows/android13-5.10-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.10-clang-16.yml
+++ b/.github/workflows/android13-5.10-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.10-clang-android.yml
+++ b/.github/workflows/android13-5.10-clang-android.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-android.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.10 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.10 tuxsuite/android13-5.10-clang-android.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.15-clang-12.yml
+++ b/.github/workflows/android13-5.15-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.15-clang-13.yml
+++ b/.github/workflows/android13-5.15-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.15-clang-14.yml
+++ b/.github/workflows/android13-5.15-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.15-clang-15.yml
+++ b/.github/workflows/android13-5.15-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.15-clang-16.yml
+++ b/.github/workflows/android13-5.15-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android13-5.15-clang-android.yml
+++ b/.github/workflows/android13-5.15-clang-android.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name defconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-android.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android13-5.15 --job-name allconfigs --json-out builds.json --patch-series patches/android13-5.15 tuxsuite/android13-5.15-clang-android.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android14-5.15-clang-12.yml
+++ b/.github/workflows/android14-5.15-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name defconfigs --json-out builds.json tuxsuite/android14-5.15-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name allconfigs --json-out builds.json tuxsuite/android14-5.15-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android14-5.15-clang-13.yml
+++ b/.github/workflows/android14-5.15-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name defconfigs --json-out builds.json tuxsuite/android14-5.15-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name allconfigs --json-out builds.json tuxsuite/android14-5.15-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android14-5.15-clang-14.yml
+++ b/.github/workflows/android14-5.15-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name defconfigs --json-out builds.json tuxsuite/android14-5.15-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name allconfigs --json-out builds.json tuxsuite/android14-5.15-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android14-5.15-clang-15.yml
+++ b/.github/workflows/android14-5.15-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name defconfigs --json-out builds.json tuxsuite/android14-5.15-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name allconfigs --json-out builds.json tuxsuite/android14-5.15-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android14-5.15-clang-16.yml
+++ b/.github/workflows/android14-5.15-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name defconfigs --json-out builds.json tuxsuite/android14-5.15-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name allconfigs --json-out builds.json tuxsuite/android14-5.15-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/android14-5.15-clang-android.yml
+++ b/.github/workflows/android14-5.15-clang-android.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name defconfigs --json-out builds.json tuxsuite/android14-5.15-clang-android.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -102,11 +102,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://android.googlesource.com/kernel/common.git --git-ref android14-5.15 --job-name allconfigs --json-out builds.json tuxsuite/android14-5.15-clang-android.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-clang-11.yml
+++ b/.github/workflows/arm64-clang-11.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name defconfigs --json-out builds.json tuxsuite/arm64-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -60,11 +60,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name allconfigs --json-out builds.json tuxsuite/arm64-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-clang-12.yml
+++ b/.github/workflows/arm64-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name defconfigs --json-out builds.json tuxsuite/arm64-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -60,11 +60,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name allconfigs --json-out builds.json tuxsuite/arm64-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-clang-13.yml
+++ b/.github/workflows/arm64-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name defconfigs --json-out builds.json tuxsuite/arm64-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -81,11 +81,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name allconfigs --json-out builds.json tuxsuite/arm64-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-clang-14.yml
+++ b/.github/workflows/arm64-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name defconfigs --json-out builds.json tuxsuite/arm64-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -81,11 +81,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name allconfigs --json-out builds.json tuxsuite/arm64-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-clang-15.yml
+++ b/.github/workflows/arm64-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name defconfigs --json-out builds.json tuxsuite/arm64-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -81,11 +81,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name allconfigs --json-out builds.json tuxsuite/arm64-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-clang-16.yml
+++ b/.github/workflows/arm64-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name defconfigs --json-out builds.json tuxsuite/arm64-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -81,11 +81,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/core --job-name allconfigs --json-out builds.json tuxsuite/arm64-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-fixes-clang-11.yml
+++ b/.github/workflows/arm64-fixes-clang-11.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name defconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -60,11 +60,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name allconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-fixes-clang-12.yml
+++ b/.github/workflows/arm64-fixes-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name defconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -60,11 +60,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name allconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-fixes-clang-13.yml
+++ b/.github/workflows/arm64-fixes-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name defconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -81,11 +81,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name allconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-fixes-clang-14.yml
+++ b/.github/workflows/arm64-fixes-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name defconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -81,11 +81,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name allconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-fixes-clang-15.yml
+++ b/.github/workflows/arm64-fixes-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name defconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -81,11 +81,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name allconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/arm64-fixes-clang-16.yml
+++ b/.github/workflows/arm64-fixes-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name defconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -81,11 +81,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --git-ref for-next/fixes --job-name allconfigs --json-out builds.json tuxsuite/arm64-fixes-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.10-clang-12.yml
+++ b/.github/workflows/chromeos-5.10-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.10 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.10-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.10-clang-13.yml
+++ b/.github/workflows/chromeos-5.10-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.10 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.10-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.10-clang-14.yml
+++ b/.github/workflows/chromeos-5.10-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.10 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.10-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.10-clang-15.yml
+++ b/.github/workflows/chromeos-5.10-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.10 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.10-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.10-clang-16.yml
+++ b/.github/workflows/chromeos-5.10-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.10 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.10-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.15-clang-12.yml
+++ b/.github/workflows/chromeos-5.15-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.15 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.15-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.15-clang-13.yml
+++ b/.github/workflows/chromeos-5.15-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.15 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.15-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.15-clang-14.yml
+++ b/.github/workflows/chromeos-5.15-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.15 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.15-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.15-clang-15.yml
+++ b/.github/workflows/chromeos-5.15-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.15 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.15-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/chromeos-5.15-clang-16.yml
+++ b/.github/workflows/chromeos-5.15-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --git-ref chromeos-5.15 --job-name defconfigs --json-out builds.json tuxsuite/chromeos-5.15-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/mainline-clang-11.yml
+++ b/.github/workflows/mainline-clang-11.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -585,11 +585,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name distribution_configs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -917,11 +917,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/mainline-clang-12.yml
+++ b/.github/workflows/mainline-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -606,11 +606,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name distribution_configs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -938,11 +938,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/mainline-clang-13.yml
+++ b/.github/workflows/mainline-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -627,11 +627,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name distribution_configs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -959,11 +959,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -627,11 +627,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name distribution_configs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -959,11 +959,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -669,11 +669,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name distribution_configs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1043,11 +1043,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name defconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -711,11 +711,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name distribution_configs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1085,11 +1085,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --git-ref master --job-name allconfigs --json-out builds.json --patch-series patches/mainline tuxsuite/mainline-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/next-clang-11.yml
+++ b/.github/workflows/next-clang-11.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/next-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -585,11 +585,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name distribution_configs --json-out builds.json tuxsuite/next-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -917,11 +917,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/next-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/next-clang-12.yml
+++ b/.github/workflows/next-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/next-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -606,11 +606,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name distribution_configs --json-out builds.json tuxsuite/next-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -938,11 +938,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/next-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/next-clang-13.yml
+++ b/.github/workflows/next-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/next-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -648,11 +648,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name distribution_configs --json-out builds.json tuxsuite/next-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -980,11 +980,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/next-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/next-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -648,11 +648,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name distribution_configs --json-out builds.json tuxsuite/next-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -980,11 +980,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/next-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/next-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -690,11 +690,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name distribution_configs --json-out builds.json tuxsuite/next-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1064,11 +1064,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/next-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/next-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -774,11 +774,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name distribution_configs --json-out builds.json tuxsuite/next-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1148,11 +1148,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/next-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/next-clang-android.yml
+++ b/.github/workflows/next-clang-android.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/next-clang-android.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -312,11 +312,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/next-clang-android.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/stable-clang-11.yml
+++ b/.github/workflows/stable-clang-11.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-6.0.y --job-name defconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -585,11 +585,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-6.0.y --job-name distribution_configs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -917,11 +917,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-6.0.y --job-name allconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/stable-clang-12.yml
+++ b/.github/workflows/stable-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-6.0.y --job-name defconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -606,11 +606,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-6.0.y --job-name distribution_configs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -938,11 +938,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-6.0.y --job-name allconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-6.0.y --job-name defconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -627,11 +627,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-6.0.y --job-name distribution_configs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -959,11 +959,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-6.0.y --job-name allconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-6.0.y --job-name defconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -690,11 +690,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-6.0.y --job-name distribution_configs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1064,11 +1064,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-6.0.y --job-name allconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-6.0.y --job-name defconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -690,11 +690,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-6.0.y --job-name distribution_configs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1064,11 +1064,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-6.0.y --job-name allconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/stable-clang-16.yml
+++ b/.github/workflows/stable-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-6.0.y --job-name defconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -669,11 +669,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-6.0.y --job-name distribution_configs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -1043,11 +1043,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --git-ref linux-6.0.y --job-name allconfigs --json-out builds.json --patch-series patches/stable tuxsuite/stable-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/tip-clang-11.yml
+++ b/.github/workflows/tip-clang-11.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/tip-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -81,11 +81,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/tip-clang-11.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/tip-clang-12.yml
+++ b/.github/workflows/tip-clang-12.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/tip-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -81,11 +81,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/tip-clang-12.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/tip-clang-13.yml
+++ b/.github/workflows/tip-clang-13.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/tip-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -81,11 +81,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/tip-clang-13.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/tip-clang-14.yml
+++ b/.github/workflows/tip-clang-14.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/tip-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -81,11 +81,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/tip-clang-14.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/tip-clang-15.yml
+++ b/.github/workflows/tip-clang-15.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/tip-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -81,11 +81,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/tip-clang-15.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/tip-clang-16.yml
+++ b/.github/workflows/tip-clang-16.yml
@@ -22,11 +22,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name defconfigs --json-out builds.json tuxsuite/tip-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:
@@ -81,11 +81,11 @@ jobs:
     container: tuxsuite/tuxsuite
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
+    timeout-minutes: 480
     steps:
     - uses: actions/checkout@v3
     - name: tuxsuite
       run: tuxsuite plan --git-repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --git-ref master --job-name allconfigs --json-out builds.json tuxsuite/tip-clang-16.tux.yml || true
-      timeout-minutes: 480
     - name: save output
       uses: actions/upload-artifact@v3
       with:

--- a/generate_workflow.py
+++ b/generate_workflow.py
@@ -98,6 +98,7 @@ def tuxsuite_setups(job_name, tuxsuite_yml, repo, ref):
             "env": {
                 "TUXSUITE_TOKEN": "${{ secrets.TUXSUITE_TOKEN }}"
             },
+            "timeout-minutes": 480,
             "steps": [
                 {
                     "uses": "actions/checkout@v3"
@@ -105,7 +106,6 @@ def tuxsuite_setups(job_name, tuxsuite_yml, repo, ref):
                 {
                     "name": "tuxsuite",
                     "run": f"tuxsuite plan --git-repo {repo} --git-ref {ref} --job-name {job_name} --json-out builds.json {patch_series}{tuxsuite_yml} || true",
-                    "timeout-minutes": 480
                 },
                 {
                     "name": "save output",


### PR DESCRIPTION
The eight hour timeout needs to be set in the job scope, rather than the
step scope, otherwise the entire job will be killed by its default six
hour timeout.
