### PR TITLE
patches: android13-5.10: Add upstream series for pahole 1.24 compatability

### DIFF
--- a/patches/android13-5.10/pahole-1.24.patch
+++ b/patches/android13-5.10/pahole-1.24.patch
@@ -1,0 +1,334 @@
+From bbaea0f1cd33d702d053d5bdaf6d6dec3932894c Mon Sep 17 00:00:00 2001
+From: Ilya Leoshkevich <iii@linux.ibm.com>
+Date: Wed, 19 Oct 2022 10:56:00 +0200
+Subject: [PATCH 1/5] bpf: Generate BTF_KIND_FLOAT when linking vmlinux
+
+commit db16c1fe92d7ba7d39061faef897842baee2c887  upstream.
+
+[backported for dependency only extra_paholeopt variable setup and
+usage, we don't want floats generated in 5.10]
+
+pahole v1.21 supports the --btf_gen_floats flag, which makes it
+generate the information about the floating-point types [1].
+
+Adjust link-vmlinux.sh to pass this flag to pahole in case it's
+supported, which is determined using a simple version check.
+
+[1] https://lore.kernel.org/dwarves/YHRiXNX1JUF2Az0A@kernel.org/
+
+Signed-off-by: Ilya Leoshkevich <iii@linux.ibm.com>
+Signed-off-by: Andrii Nakryiko <andrii@kernel.org>
+Acked-by: Andrii Nakryiko <andrii@kernel.org>
+Link: https://lore.kernel.org/bpf/20210413190043.21918-1-iii@linux.ibm.com
+Signed-off-by: Jiri Olsa <jolsa@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ scripts/link-vmlinux.sh | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/scripts/link-vmlinux.sh b/scripts/link-vmlinux.sh
+index d0b44bee9286..cdfccbfed452 100755
+--- a/scripts/link-vmlinux.sh
++++ b/scripts/link-vmlinux.sh
+@@ -146,6 +146,7 @@ vmlinux_link()
+ gen_btf()
+ {
+ 	local pahole_ver
++	local extra_paholeopt=
+ 
+ 	if ! [ -x "$(command -v ${PAHOLE})" ]; then
+ 		echo >&2 "BTF: ${1}: pahole (${PAHOLE}) is not available"
+@@ -161,7 +162,7 @@ gen_btf()
+ 	vmlinux_link ${1}
+ 
+ 	info "BTF" ${2}
+-	LLVM_OBJCOPY=${OBJCOPY} ${PAHOLE} -J ${1}
++	LLVM_OBJCOPY=${OBJCOPY} ${PAHOLE} -J ${extra_paholeopt} ${1}
+ 
+ 	# Create ${2} which contains just .BTF section but no symbols. Add
+ 	# SHF_ALLOC because .BTF will be part of the vmlinux image. --strip-all
+-- 
+2.38.1
+
+
+From 06481cd9f7f692088bce03244f8cf132018f2fc6 Mon Sep 17 00:00:00 2001
+From: Javier Martinez Canillas <javierm@redhat.com>
+Date: Wed, 19 Oct 2022 10:56:01 +0200
+Subject: [PATCH 2/5] kbuild: Quote OBJCOPY var to avoid a pahole call break
+ the build
+
+commit ff2e6efda0d5c51b33e2bcc0b0b981ac0a0ef214 upstream.
+
+[backported for dependency, skipped Makefile.modfinal change,
+because module BTF is not supported in 5.10]
+
+The ccache tool can be used to speed up cross-compilation, by calling the
+compiler and binutils through ccache. For example, following should work:
+
+    $ export ARCH=arm64 CROSS_COMPILE="ccache aarch64-linux-gnu-"
+
+    $ make M=drivers/gpu/drm/rockchip/
+
+but pahole fails to extract the BTF info from DWARF, breaking the build:
+
+      CC [M]  drivers/gpu/drm/rockchip//rockchipdrm.mod.o
+      LD [M]  drivers/gpu/drm/rockchip//rockchipdrm.ko
+      BTF [M] drivers/gpu/drm/rockchip//rockchipdrm.ko
+    aarch64-linux-gnu-objcopy: invalid option -- 'J'
+    Usage: aarch64-linux-gnu-objcopy [option(s)] in-file [out-file]
+     Copies a binary file, possibly transforming it in the process
+    ...
+    make[1]: *** [scripts/Makefile.modpost:156: __modpost] Error 2
+    make: *** [Makefile:1866: modules] Error 2
+
+this fails because OBJCOPY is set to "ccache aarch64-linux-gnu-copy" and
+later pahole is executed with the following command line:
+
+    LLVM_OBJCOPY=$(OBJCOPY) $(PAHOLE) -J --btf_base vmlinux $@
+
+which gets expanded to:
+
+    LLVM_OBJCOPY=ccache aarch64-linux-gnu-objcopy pahole -J ...
+
+instead of:
+
+    LLVM_OBJCOPY="ccache aarch64-linux-gnu-objcopy" pahole -J ...
+
+Fixes: 5f9ae91f7c0d ("kbuild: Build kernel module BTFs if BTF is enabled and pahole supports it")
+Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>
+Signed-off-by: Andrii Nakryiko <andrii@kernel.org>
+Acked-by: Andrii Nakryiko <andrii@kernel.org>
+Acked-by: Arnaldo Carvalho de Melo <acme@redhat.com>
+Link: https://lore.kernel.org/bpf/20210526215228.3729875-1-javierm@redhat.com
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ scripts/link-vmlinux.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/link-vmlinux.sh b/scripts/link-vmlinux.sh
+index cdfccbfed452..72bf14df6903 100755
+--- a/scripts/link-vmlinux.sh
++++ b/scripts/link-vmlinux.sh
+@@ -162,7 +162,7 @@ gen_btf()
+ 	vmlinux_link ${1}
+ 
+ 	info "BTF" ${2}
+-	LLVM_OBJCOPY=${OBJCOPY} ${PAHOLE} -J ${extra_paholeopt} ${1}
++	LLVM_OBJCOPY="${OBJCOPY}" ${PAHOLE} -J ${extra_paholeopt} ${1}
+ 
+ 	# Create ${2} which contains just .BTF section but no symbols. Add
+ 	# SHF_ALLOC because .BTF will be part of the vmlinux image. --strip-all
+-- 
+2.38.1
+
+
+From f5f413cb3e8af235c5d310bea9942424fb242c2c Mon Sep 17 00:00:00 2001
+From: Andrii Nakryiko <andrii@kernel.org>
+Date: Wed, 19 Oct 2022 10:56:02 +0200
+Subject: [PATCH 3/5] kbuild: skip per-CPU BTF generation for pahole
+ v1.18-v1.21
+
+commit a0b8200d06ad6450c179407baa5f0f52f8cfcc97 upstream.
+
+[small context changes due to missing floats support in 5.10]
+
+Commit "mm/page_alloc: convert per-cpu list protection to local_lock" will
+introduce a zero-sized per-CPU variable, which causes pahole to generate
+invalid BTF.  Only pahole versions 1.18 through 1.21 are impacted, as
+before 1.18 pahole doesn't know anything about per-CPU variables, and 1.22
+contains the proper fix for the issue.
+
+Luckily, pahole 1.18 got --skip_encoding_btf_vars option disabling BTF
+generation for per-CPU variables in anticipation of some unanticipated
+problems.  So use this escape hatch to disable per-CPU var BTF info on
+those problematic pahole versions.  Users relying on availability of
+per-CPU var BTFs would need to upgrade to pahole 1.22+, but everyone won't
+notice any regressions.
+
+Link: https://lkml.kernel.org/r/20210530002536.3193829-1-andrii@kernel.org
+Signed-off-by: Andrii Nakryiko <andrii@kernel.org>
+Acked-by: Mel Gorman <mgorman@techsingularity.net>
+Cc: Arnaldo Carvalho de Melo <acme@redhat.com>
+Cc: Hao Luo <haoluo@google.com>
+Cc: Michal Suchanek <msuchanek@suse.de>
+Cc: Jiri Olsa <jolsa@kernel.org>
+Signed-off-by: Andrew Morton <akpm@linux-foundation.org>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+Signed-off-by: Jiri Olsa <jolsa@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ scripts/link-vmlinux.sh | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/scripts/link-vmlinux.sh b/scripts/link-vmlinux.sh
+index 72bf14df6903..bbb22be4c8f1 100755
+--- a/scripts/link-vmlinux.sh
++++ b/scripts/link-vmlinux.sh
+@@ -161,6 +161,11 @@ gen_btf()
+ 
+ 	vmlinux_link ${1}
+ 
++	if [ "${pahole_ver}" -ge "118" ] && [ "${pahole_ver}" -le "121" ]; then
++		# pahole 1.18 through 1.21 can't handle zero-sized per-CPU vars
++		extra_paholeopt="${extra_paholeopt} --skip_encoding_btf_vars"
++	fi
++
+ 	info "BTF" ${2}
+ 	LLVM_OBJCOPY="${OBJCOPY}" ${PAHOLE} -J ${extra_paholeopt} ${1}
+ 
+-- 
+2.38.1
+
+
+From c5006abb80e276896ff7237300a6d447708c7924 Mon Sep 17 00:00:00 2001
+From: Jiri Olsa <jolsa@redhat.com>
+Date: Wed, 19 Oct 2022 10:56:03 +0200
+Subject: [PATCH 4/5] kbuild: Unify options for BTF generation for vmlinux and
+ modules
+
+commit 9741e07ece7c247dd65e1aa01e16b683f01c05a8 upstream.
+
+[skipped --btf_gen_floats option in pahole-flags.sh, skipped
+Makefile.modfinal change, because there's no BTF kmod support,
+squashing in 'exit 0' change from merge commit fc02cb2b37fe]
+
+Using new PAHOLE_FLAGS variable to pass extra arguments to
+pahole for both vmlinux and modules BTF data generation.
+
+Adding new scripts/pahole-flags.sh script that detect and
+prints pahole options.
+
+[ fixed issues found by kernel test robot ]
+
+Signed-off-by: Jiri Olsa <jolsa@kernel.org>
+Signed-off-by: Andrii Nakryiko <andrii@kernel.org>
+Acked-by: Andrii Nakryiko <andrii@kernel.org>
+Link: https://lore.kernel.org/bpf/20211029125729.70002-1-jolsa@kernel.org
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ Makefile                |  3 +++
+ scripts/link-vmlinux.sh |  8 +-------
+ scripts/pahole-flags.sh | 17 +++++++++++++++++
+ 3 files changed, 21 insertions(+), 7 deletions(-)
+ create mode 100755 scripts/pahole-flags.sh
+
+diff --git a/Makefile b/Makefile
+index 5c7075d3b2f6..0ecf8333cc17 100644
+--- a/Makefile
++++ b/Makefile
+@@ -465,6 +465,8 @@ LZ4		= lz4c
+ XZ		= xz
+ ZSTD		= zstd
+ 
++PAHOLE_FLAGS	= $(shell PAHOLE=$(PAHOLE) $(srctree)/scripts/pahole-flags.sh)
++
+ CHECKFLAGS     := -D__linux__ -Dlinux -D__STDC__ -Dunix -D__unix__ \
+ 		  -Wbitwise -Wno-return-void -Wno-unknown-attribute $(CF)
+ NOSTDINC_FLAGS :=
+@@ -518,6 +520,7 @@ export KBUILD_CFLAGS CFLAGS_KERNEL CFLAGS_MODULE
+ export KBUILD_AFLAGS AFLAGS_KERNEL AFLAGS_MODULE
+ export KBUILD_AFLAGS_MODULE KBUILD_CFLAGS_MODULE KBUILD_LDFLAGS_MODULE
+ export KBUILD_AFLAGS_KERNEL KBUILD_CFLAGS_KERNEL
++export PAHOLE_FLAGS
+ 
+ # Files to ignore in find ... statements
+ 
+diff --git a/scripts/link-vmlinux.sh b/scripts/link-vmlinux.sh
+index bbb22be4c8f1..acd07a70a2f4 100755
+--- a/scripts/link-vmlinux.sh
++++ b/scripts/link-vmlinux.sh
+@@ -146,7 +146,6 @@ vmlinux_link()
+ gen_btf()
+ {
+ 	local pahole_ver
+-	local extra_paholeopt=
+ 
+ 	if ! [ -x "$(command -v ${PAHOLE})" ]; then
+ 		echo >&2 "BTF: ${1}: pahole (${PAHOLE}) is not available"
+@@ -161,13 +160,8 @@ gen_btf()
+ 
+ 	vmlinux_link ${1}
+ 
+-	if [ "${pahole_ver}" -ge "118" ] && [ "${pahole_ver}" -le "121" ]; then
+-		# pahole 1.18 through 1.21 can't handle zero-sized per-CPU vars
+-		extra_paholeopt="${extra_paholeopt} --skip_encoding_btf_vars"
+-	fi
+-
+ 	info "BTF" ${2}
+-	LLVM_OBJCOPY="${OBJCOPY}" ${PAHOLE} -J ${extra_paholeopt} ${1}
++	LLVM_OBJCOPY="${OBJCOPY}" ${PAHOLE} -J ${PAHOLE_FLAGS} ${1}
+ 
+ 	# Create ${2} which contains just .BTF section but no symbols. Add
+ 	# SHF_ALLOC because .BTF will be part of the vmlinux image. --strip-all
+diff --git a/scripts/pahole-flags.sh b/scripts/pahole-flags.sh
+new file mode 100755
+index 000000000000..27445cb72974
+--- /dev/null
++++ b/scripts/pahole-flags.sh
+@@ -0,0 +1,17 @@
++#!/bin/sh
++# SPDX-License-Identifier: GPL-2.0
++
++extra_paholeopt=
++
++if ! [ -x "$(command -v ${PAHOLE})" ]; then
++	exit 0
++fi
++
++pahole_ver=$(${PAHOLE} --version | sed -E 's/v([0-9]+)\.([0-9]+)/\1\2/')
++
++if [ "${pahole_ver}" -ge "118" ] && [ "${pahole_ver}" -le "121" ]; then
++	# pahole 1.18 through 1.21 can't handle zero-sized per-CPU vars
++	extra_paholeopt="${extra_paholeopt} --skip_encoding_btf_vars"
++fi
++
++echo ${extra_paholeopt}
+-- 
+2.38.1
+
+
+From ecad3312111798d84dac1ce6a853e0ac9de8d505 Mon Sep 17 00:00:00 2001
+From: Martin Rodriguez Reboredo <yakoyoku@gmail.com>
+Date: Wed, 19 Oct 2022 10:56:04 +0200
+Subject: [PATCH 5/5] kbuild: Add skip_encoding_btf_enum64 option to pahole
+
+New pahole (version 1.24) generates by default new BTF_KIND_ENUM64 BTF tag,
+which is not supported by stable kernel.
+
+As a result the kernel with CONFIG_DEBUG_INFO_BTF option will fail to
+compile with following error:
+
+  BTFIDS  vmlinux
+FAILED: load BTF from vmlinux: Invalid argument
+
+New pahole provides --skip_encoding_btf_enum64 option to skip BTF_KIND_ENUM64
+generation and produce BTF supported by stable kernel.
+
+Adding this option to scripts/pahole-flags.sh.
+
+This change does not have equivalent commit in linus tree, because linus tree
+has support for BTF_KIND_ENUM64 tag, so it does not need to be disabled.
+
+Signed-off-by: Martin Rodriguez Reboredo <yakoyoku@gmail.com>
+Signed-off-by: Jiri Olsa <jolsa@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ scripts/pahole-flags.sh | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/scripts/pahole-flags.sh b/scripts/pahole-flags.sh
+index 27445cb72974..8c82173e42e5 100755
+--- a/scripts/pahole-flags.sh
++++ b/scripts/pahole-flags.sh
+@@ -14,4 +14,8 @@ if [ "${pahole_ver}" -ge "118" ] && [ "${pahole_ver}" -le "121" ]; then
+ 	extra_paholeopt="${extra_paholeopt} --skip_encoding_btf_vars"
+ fi
+ 
++if [ "${pahole_ver}" -ge "124" ]; then
++	extra_paholeopt="${extra_paholeopt} --skip_encoding_btf_enum64"
++fi
++
+ echo ${extra_paholeopt}
+-- 
+2.38.1
+

--- a/patches/android13-5.10/series
+++ b/patches/android13-5.10/series
@@ -1,1 +1,2 @@
 0001-ARM-NWFPE-avoid-compiler-generated-__aeabi_uldivmod.patch
+pahole-1.24.patch


### PR DESCRIPTION
android13-5.10 enables BTF generation via pahole. TuxMake's version of
pahole was recently bumped to the latest (1.24) as part of an overall
update to Debian testing, which generates `BTF_KIND_ENUM64` by default,
even though 5.10 does not have support for it, resulting in the
following failure:

```
    FAILED: load BTF from vmlinux: Unknown error -22
```

This is resolved in upstream 5.10 with a series to disable generating
these BTF types but that may take some time to get merged into the
Android trees due to release times lines so apply the series via
tuxsuite for the time being.
