### PR TITLE
Adjust x86_64 allyesconfig builds

### DIFF
--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -1306,25 +1306,4 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2761279f511773a7e0d3689117cf5c33:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
-    env:
-      ARCH: x86_64
-      LLVM_VERSION: 15
-      BOOT: 0
-      CONFIG: allyesconfig
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
 

--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -1390,25 +1390,4 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _cc92db58f57103904b162bb3cb351329:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
-    env:
-      ARCH: x86_64
-      LLVM_VERSION: 16
-      BOOT: 0
-      CONFIG: allyesconfig
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
 

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -1327,25 +1327,4 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2761279f511773a7e0d3689117cf5c33:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
-    env:
-      ARCH: x86_64
-      LLVM_VERSION: 15
-      BOOT: 0
-      CONFIG: allyesconfig
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
 

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -1411,25 +1411,4 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _cc92db58f57103904b162bb3cb351329:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
-    env:
-      ARCH: x86_64
-      LLVM_VERSION: 16
-      BOOT: 0
-      CONFIG: allyesconfig
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
 

--- a/.github/workflows/tip-clang-11.yml
+++ b/.github/workflows/tip-clang-11.yml
@@ -134,4 +134,25 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _f93dc26c868cb14278bd57d172f7b70e:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 11
+      BOOT: 0
+      CONFIG: allyesconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
 

--- a/.github/workflows/tip-clang-12.yml
+++ b/.github/workflows/tip-clang-12.yml
@@ -134,4 +134,25 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _2dff3a82fb364654e103e70b4b546e45:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 12
+      BOOT: 0
+      CONFIG: allyesconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
 

--- a/.github/workflows/tip-clang-13.yml
+++ b/.github/workflows/tip-clang-13.yml
@@ -134,4 +134,25 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _02922017f2cb19d45aba8492132c7804:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 13
+      BOOT: 0
+      CONFIG: allyesconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
 

--- a/.github/workflows/tip-clang-14.yml
+++ b/.github/workflows/tip-clang-14.yml
@@ -134,4 +134,25 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _fb32e519cea6f2c116bd013eec8409de:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 14
+      BOOT: 0
+      CONFIG: allyesconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
 

--- a/generator.yml
+++ b/generator.yml
@@ -400,7 +400,8 @@ builds:
   - {<< : *x86_64_allmod,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_allmod_lto, << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_allno,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
-  - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  # x86_64 allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
+  # - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_alpine,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_arch,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_fedora,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -469,7 +470,8 @@ builds:
   - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
-  - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  # x86_64 allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
+  # - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_gcov,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_alpine,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_arch,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -801,7 +803,8 @@ builds:
   - {<< : *x86_64_allmod,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *x86_64_allmod_lto, << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *x86_64_allno,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
-  - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  # x86_64 allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
+  # - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *x86_64_alpine,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_arch,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_fedora,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -866,7 +869,8 @@ builds:
   - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
-  - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  # x86_64 allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
+  # - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *x86_64_gcov,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_alpine,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_arch,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}

--- a/generator.yml
+++ b/generator.yml
@@ -1496,8 +1496,7 @@ builds:
   - {<< : *x86_64,            << : *tip,              << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *x86_64_allmod,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *x86_64_allno,      << : *tip,              << : *llvm_full,       boot: false, << : *llvm_14}
-  # -tip allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
-  # - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_14}
+  - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_14}
   ###########
   #  ARM64  #
   ###########
@@ -1874,8 +1873,7 @@ builds:
   - {<< : *x86_64,            << : *tip,              << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *x86_64_allmod,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *x86_64_allno,      << : *tip,              << : *llvm_full,       boot: false, << : *llvm_13}
-  # -tip allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
-  # - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_13}
+  - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_13}
   ###########
   #  ARM64  #
   ###########
@@ -2205,8 +2203,7 @@ builds:
   - {<< : *x86_64,            << : *tip,              << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *x86_64_allmod,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_12}
   - {<< : *x86_64_allno,      << : *tip,              << : *llvm_full,       boot: false, << : *llvm_12}
-  # -tip allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
-  # - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_12}
+  - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_12}
   ###########
   #  ARM64  #
   ###########
@@ -2495,8 +2492,7 @@ builds:
   - {<< : *x86_64,            << : *tip,              << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *x86_64_allmod,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_11}
   - {<< : *x86_64_allno,      << : *tip,              << : *llvm_full,       boot: false, << : *llvm_11}
-  # -tip allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
-  # - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_11}
+  - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_11}
   ###########
   #  ARM64  #
   ###########

--- a/tuxsuite/mainline-clang-15.tux.yml
+++ b/tuxsuite/mainline-clang-15.tux.yml
@@ -572,12 +572,4 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: x86_64
-    toolchain: clang-15
-    kconfig: allyesconfig
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
 

--- a/tuxsuite/mainline-clang-16.tux.yml
+++ b/tuxsuite/mainline-clang-16.tux.yml
@@ -614,12 +614,4 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: x86_64
-    toolchain: clang-nightly
-    kconfig: allyesconfig
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
 

--- a/tuxsuite/next-clang-15.tux.yml
+++ b/tuxsuite/next-clang-15.tux.yml
@@ -583,12 +583,4 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: x86_64
-    toolchain: clang-15
-    kconfig: allyesconfig
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
 

--- a/tuxsuite/next-clang-16.tux.yml
+++ b/tuxsuite/next-clang-16.tux.yml
@@ -625,12 +625,4 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: x86_64
-    toolchain: clang-nightly
-    kconfig: allyesconfig
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
 

--- a/tuxsuite/tip-clang-11.tux.yml
+++ b/tuxsuite/tip-clang-11.tux.yml
@@ -43,4 +43,12 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-11
+    kconfig: allyesconfig
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
 

--- a/tuxsuite/tip-clang-12.tux.yml
+++ b/tuxsuite/tip-clang-12.tux.yml
@@ -43,4 +43,12 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-12
+    kconfig: allyesconfig
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
 

--- a/tuxsuite/tip-clang-13.tux.yml
+++ b/tuxsuite/tip-clang-13.tux.yml
@@ -43,4 +43,12 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-13
+    kconfig: allyesconfig
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
 

--- a/tuxsuite/tip-clang-14.tux.yml
+++ b/tuxsuite/tip-clang-14.tux.yml
@@ -43,4 +43,12 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-14
+    kconfig: allyesconfig
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
 


### PR DESCRIPTION
This adjusts mainline and -next to disable x86_64 allyesconfig to match -tip, while turning on x86_64 allyesconfig for -tip, as I do not believe the issue is reproducible there.
