### PR TITLE
Disable s390 builds with LLVM < 13 on 5.10

### DIFF
--- a/.github/workflows/5.10-clang-11.yml
+++ b/.github/workflows/5.10-clang-11.yml
@@ -243,27 +243,6 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3b0c273122a784488dcfee7a6a9016b9:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=11 defconfig
-    env:
-      ARCH: s390
-      LLVM_VERSION: 11
-      BOOT: 1
-      CONFIG: defconfig
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _73f8d728902a8cc9c807d77d1aaaedaf:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/5.10-clang-12.yml
+++ b/.github/workflows/5.10-clang-12.yml
@@ -285,27 +285,6 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ff91e27f2eb0b39e3180ac5e04cf04a1:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=12 defconfig
-    env:
-      ARCH: s390
-      LLVM_VERSION: 12
-      BOOT: 1
-      CONFIG: defconfig
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _d49633cca166398690b1f3ecad135a14:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/generator.yml
+++ b/generator.yml
@@ -2126,7 +2126,6 @@ builds:
   # https://github.com/ClangBuiltLinux/linux/issues/1023
   # https://github.com/ClangBuiltLinux/linux/issues/1143
   - {<< : *riscv_no_efi,      << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  << : *llvm_12}
-  - {<< : *s390,              << : *stable-5_10,      << : *clang,           boot: true,  << : *llvm_12}
   - {<< : *x86_64,            << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *x86_64_allmod,     << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_12}
   - {<< : *x86_64_allno,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_12}
@@ -2457,7 +2456,6 @@ builds:
   # https://github.com/ClangBuiltLinux/linux/issues/1023
   # https://github.com/ClangBuiltLinux/linux/issues/1143
   - {<< : *riscv_no_efi,      << : *stable-5_10,      << : *riscv_llvm_full, boot: true,  << : *llvm_11}
-  - {<< : *s390,              << : *stable-5_10,      << : *clang,           boot: true,  << : *llvm_11}
   - {<< : *x86_64,            << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *x86_64_allmod,     << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_11}
   - {<< : *x86_64_allno,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_11}

--- a/tuxsuite/5.10-clang-11.tux.yml
+++ b/tuxsuite/5.10-clang-11.tux.yml
@@ -106,13 +106,6 @@ jobs:
       LD: riscv64-linux-gnu-ld
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: s390
-    toolchain: clang-11
-    kconfig: defconfig
-    targets:
-    - kernel
-    make_variables:
-      LLVM_IAS: 0
   - target_arch: x86_64
     toolchain: clang-11
     kconfig: defconfig

--- a/tuxsuite/5.10-clang-12.tux.yml
+++ b/tuxsuite/5.10-clang-12.tux.yml
@@ -127,13 +127,6 @@ jobs:
       LD: riscv64-linux-gnu-ld
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: s390
-    toolchain: clang-12
-    kconfig: defconfig
-    targets:
-    - kernel
-    make_variables:
-      LLVM_IAS: 0
   - target_arch: x86_64
     toolchain: clang-12
     kconfig: defconfig


### PR DESCRIPTION
Commit 82d3edb50a11 ("s390/cpum_sf: add READ_ONCE() semantics to compare
and swap loops") was applied to 5.10, where it started causing build
breakage with LLVM 11 and 12:

```
  arch/s390/kernel/perf_cpum_sf.c:1234:3: error: inline asm error: This value type register class is not natively supported!
                  "       cdsg    %[old],%[new],%[ptr]\n"
                  ^
  warning: Compiler has made implicit assumption that TypeSize is not scalable. This may or may not lead to broken code.
```

The construct that is used in the inline assembly was only supported in
LLVM starting with the 13.0.0 release, even though it has been supported
in GCC for a while. This was the catalyst for commit e2bc3e91d91e
("scripts/min-tool-version.sh: Raise minimum clang version to 13.0.0 for
s390").

The min-tool-version.sh infrastructure does not exist in 5.10 and it may
be undesirable to backport it. Do what was done in #150 and #161 and
disable LLVM 11 and 12 builds on stable-5.10. This does not lose us much
coverage, as we were only testing one configuration on these branches.
