### PR TITLE
Replace Exception with more specific RuntimeError

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -43,9 +43,9 @@ def update_llvm_tot_version():
                                 text=True).stdout
 
     if not (match := re.search(r'set\(LLVM_VERSION_MAJOR (\d+)', cmakelists)):
-        raise Exception('Could not find LLVM_VERSION_MAJOR?')
+        raise RuntimeError('Could not find LLVM_VERSION_MAJOR?')
     if not (llvm_version_tot := Path('LLVM_TOT_VERSION')).exists():
-        raise Exception('Not in the right folder?')
+        raise RuntimeError('Not in the right folder?')
     llvm_version_tot.write_text(f"{match.group(1)}\n", encoding='utf-8')
 
 

--- a/scripts/parse-debian-clang.py
+++ b/scripts/parse-debian-clang.py
@@ -33,7 +33,7 @@ if not (version_string := args.version_string):
 # This will get us the checkout date and the hash
 clang_regex = r'\+\+([0-9]+)\+([a-z0-9]+)-'
 if not (match := re.search(clang_regex, version_string)):
-    raise Exception('date and hash could not be found?')
+    raise RuntimeError('date and hash could not be found?')
 clang_date, clang_hash = match.groups()
 
 # Convert clang date string into a datetime object for easy calculations
@@ -42,7 +42,7 @@ now_utc = datetime.datetime.now(datetime.timezone.utc)
 delta = now_utc - clang_utc
 
 if args.check and delta.days >= 5:
-    raise Exception(f"Clang has not been updated for {delta}!")
+    raise RuntimeError(f"Clang has not been updated for {delta}!")
 
 if args.print_info:
     print(

--- a/utils.py
+++ b/utils.py
@@ -109,7 +109,7 @@ def get_cbl_name():
         return unique_defconfigs[base_config]
     if "defconfig" in base_config:
         return "x86" if arch == "i386" else arch
-    raise Exception("unknown CBL name")
+    raise RuntimeError("unknown CBL name")
 
 
 def _read_builds():
@@ -118,7 +118,7 @@ def _read_builds():
         builds = "mock.builds.json"
     try:
         if pathlib.Path(builds).stat().st_size == 0:
-            raise Exception(f"{builds} is zero sized?")
+            raise RuntimeError(f"{builds} is zero sized?")
         with open(builds, encoding='utf-8') as file:
             builds = json.load(file)
     except FileNotFoundError as err:
@@ -165,7 +165,7 @@ def get_repo_ref(config, tree_name):
     for tree in config["trees"]:
         if tree["name"] == tree_name:
             return tree["git_repo"], tree["git_ref"]
-    raise Exception(f"Could not find git repo and ref for {tree_name}?")
+    raise RuntimeError(f"Could not find git repo and ref for {tree_name}?")
 
 
 def get_llvm_versions(config, tree_name):


### PR DESCRIPTION
Recent versions of pylint complain:

  W0719: Raising too general exception: Exception (broad-exception-raised)

This does not truly matter since we do not expect these exceptions to be
caught but it is a simple change to make the linter happy. Use the more
specific but still accurate RuntimeError exception, which is used for
generic problems at runtime.
