### PR TITLE
Enable KCSAN on stable

### DIFF
--- a/.github/workflows/5.15-clang-17.yml
+++ b/.github/workflows/5.15-clang-17.yml
@@ -642,6 +642,27 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _c7262a13ef30a0795dee277fa1409fed:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 17
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _1949b87b1748e3a21a7b1d27e116cff9:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/stable-clang-17.yml
+++ b/.github/workflows/stable-clang-17.yml
@@ -705,6 +705,27 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _c7262a13ef30a0795dee277fa1409fed:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 17
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _1949b87b1748e3a21a7b1d27e116cff9:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/generator.yml
+++ b/generator.yml
@@ -531,8 +531,7 @@ builds:
   - {<< : *x86_64_cfi,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_cfi_lto,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_kasan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
-  # x86_64_kcsan: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1704)
-  # - {<< : *x86_64_kcsan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_kcsan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_ubsan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_allmod,     << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_allmod_lto, << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
@@ -596,8 +595,7 @@ builds:
   - {<< : *x86_64_lto_full,   << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_thin,   << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_kasan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
-  # x86_64_kcsan: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1704)
-  # - {<< : *x86_64_kcsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_kcsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_ubsan,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_allmod,     << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_allmod_lto, << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}

--- a/tuxsuite/5.15-clang-17.tux.yml
+++ b/tuxsuite/5.15-clang-17.tux.yml
@@ -301,6 +301,18 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - defconfig
+    - CONFIG_KCSAN=y
+    - CONFIG_KCSAN_KUNIT_TEST=y
+    - CONFIG_KUNIT=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-nightly
+    kconfig:
+    - defconfig
     - CONFIG_UBSAN=y
     targets:
     - kernel

--- a/tuxsuite/stable-clang-17.tux.yml
+++ b/tuxsuite/stable-clang-17.tux.yml
@@ -331,6 +331,18 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - defconfig
+    - CONFIG_KCSAN=y
+    - CONFIG_KCSAN_KUNIT_TEST=y
+    - CONFIG_KUNIT=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-nightly
+    kconfig:
+    - defconfig
     - CONFIG_UBSAN=y
     targets:
     - kernel


### PR DESCRIPTION
The change for tip of tree LLVM has been backported to both of these
trees now so it is safe to re-enable these.

Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/424
