### PR TITLE
Add ruff.toml and clean up warnings

### DIFF
--- a/check_logs.py
+++ b/check_logs.py
@@ -144,9 +144,8 @@ def check_built_config(build):
     # Build dictionary of CONFIG_NAME: y/m/n ("is not set" translates to 'n').
     configs = {}
     with open(".config", encoding='utf-8') as file:
-        for line in file:
-            line = line.strip()
-            if len(line) == 0:
+        for rawline in file:
+            if not (line := rawline.strip()):
                 continue
 
             name = None

--- a/generate.py
+++ b/generate.py
@@ -22,7 +22,7 @@ def parse_args(trees):
                         help='Fail if generating yml files results in a diff')
     parser.add_argument(
         'trees',
-        choices=trees + ['all'],
+        choices=[*trees, 'all'],
         default='all',
         help='The trees to generate yml files for (default: all)',
         metavar='TREES',

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,3 +1,4 @@
+# https://beta.ruff.rs/docs/rules/
 select = [
     'A', # flake8-builtins
     'ARG', # flake8-unused-arguments

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,27 @@
+select = [
+    'A', # flake8-builtins
+    'ARG', # flake8-unused-arguments
+    'B', # flake8-bugbear
+    'C4', # flake8-comprehensions
+    'E', # pycodestyle
+    'F', # pyflakes
+    'PIE', # flake8-pie
+    'PL', # pylint
+    'RET', # flake8-return
+    'RUF', # ruff
+    'SIM', # flake8-simplify
+    'SLF', # flake8-self
+    'UP', # pyupgrade
+    'W', # pycodestyle
+]
+ignore = [
+    'E501', # line-too-long
+    'PLR0911', # too-many-return-statments
+    'PLR0912', # too-many-branches
+    'PLR0913', # too-many-arguments
+    'PLR0915', # too-many-statements
+    'PLR2004', # magic-value-comparison
+]
+target-version = 'py38'
+# Separate repo used as a submodule, ignore it
+extend-exclude = ['boot-utils']


### PR DESCRIPTION
[`ruff`](https://github.com/charliermarsh/ruff) is a fast Python linter written in Rust. Add a `ruff.toml` file to turn on several classes of warnings that are useful and fix them up.
