### PR TITLE
patches: mainline: Add fix for host1x -Wuninitialized warning

### DIFF
--- a/patches/mainline/b9930311641cf2ed905a84aabe27e8f3868aee4a.patch
+++ b/patches/mainline/b9930311641cf2ed905a84aabe27e8f3868aee4a.patch
@@ -1,0 +1,52 @@
+From b9930311641cf2ed905a84aabe27e8f3868aee4a Mon Sep 17 00:00:00 2001
+From: Arnd Bergmann <arnd@arndb.de>
+Date: Fri, 27 Jan 2023 23:14:00 +0100
+Subject: [PATCH] gpu: host1x: Fix uninitialized variable use
+
+The error handling for platform_get_irq() failing no longer works after
+a recent change, clang now points this out with a warning:
+
+drivers/gpu/host1x/dev.c:520:6: error: variable 'syncpt_irq' is uninitialized when used here [-Werror,-Wuninitialized]
+        if (syncpt_irq < 0)
+            ^~~~~~~~~~
+
+Fix this by removing the variable and checking the correct error status.
+
+Fixes: 625d4ffb438c ("gpu: host1x: Rewrite syncpoint interrupt handling")
+Signed-off-by: Arnd Bergmann <arnd@arndb.de>
+Reviewed-by: Nathan Chancellor <nathan@kernel.org>
+Reviewed-by: Mikko Perttunen <mperttunen@nvidia.com>
+Reported-by: "kernelci.org bot" <bot@kernelci.org>
+Reviewed-by: Nick Desaulniers <ndesaulniers@google.com>
+Signed-off-by: Thierry Reding <treding@nvidia.com>
+Link: https://gitlab.freedesktop.org/drm/tegra/-/commit/b9930311641cf2ed905a84aabe27e8f3868aee4a
+---
+ drivers/gpu/host1x/dev.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/host1x/dev.c b/drivers/gpu/host1x/dev.c
+index 4872d183d8604..aae2efeef5032 100644
+--- a/drivers/gpu/host1x/dev.c
++++ b/drivers/gpu/host1x/dev.c
+@@ -487,7 +487,6 @@ static int host1x_get_resets(struct host1x *host)
+ static int host1x_probe(struct platform_device *pdev)
+ {
+ 	struct host1x *host;
+-	int syncpt_irq;
+ 	int err;
+ 
+ 	host = devm_kzalloc(&pdev->dev, sizeof(*host), GFP_KERNEL);
+@@ -517,8 +516,8 @@ static int host1x_probe(struct platform_device *pdev)
+ 	}
+ 
+ 	host->syncpt_irq = platform_get_irq(pdev, 0);
+-	if (syncpt_irq < 0)
+-		return syncpt_irq;
++	if (host->syncpt_irq < 0)
++		return host->syncpt_irq;
+ 
+ 	mutex_init(&host->devices_lock);
+ 	INIT_LIST_HEAD(&host->devices);
+-- 
+GitLab
+

--- a/patches/mainline/series
+++ b/patches/mainline/series
@@ -1,1 +1,2 @@
+b9930311641cf2ed905a84aabe27e8f3868aee4a.patch
 v4_20230217_elver_kasan_emit_different_calls_for_instrumentable_memintrinsics.patch


### PR DESCRIPTION
There was apparently a snafu with sending this change along with the one
it fixes. Apply the change in the meantime.

Link: https://lore.kernel.org/Y%2FeULFO4jbivQ679@dev-arch.thelio-3990X/
