### PR TITLE
Initial stab at front end cache checks

### DIFF
--- a/.github/workflows/4.14-clang-13.yml
+++ b/.github/workflows/4.14-clang-13.yml
@@ -16,8 +16,32 @@ name: 4.14 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/4.14-clang-14.yml
+++ b/.github/workflows/4.14-clang-14.yml
@@ -16,8 +16,32 @@ name: 4.14 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/4.14-clang-15.yml
+++ b/.github/workflows/4.14-clang-15.yml
@@ -16,8 +16,32 @@ name: 4.14 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/4.14-clang-16.yml
+++ b/.github/workflows/4.14-clang-16.yml
@@ -16,8 +16,32 @@ name: 4.14 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/4.14-clang-17.yml
+++ b/.github/workflows/4.14-clang-17.yml
@@ -16,8 +16,32 @@ name: 4.14 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/4.19-clang-13.yml
+++ b/.github/workflows/4.19-clang-13.yml
@@ -16,8 +16,32 @@ name: 4.19 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/4.19-clang-14.yml
+++ b/.github/workflows/4.19-clang-14.yml
@@ -16,8 +16,32 @@ name: 4.19 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/4.19-clang-15.yml
+++ b/.github/workflows/4.19-clang-15.yml
@@ -16,8 +16,32 @@ name: 4.19 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/4.19-clang-16.yml
+++ b/.github/workflows/4.19-clang-16.yml
@@ -16,8 +16,32 @@ name: 4.19 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/4.19-clang-17.yml
+++ b/.github/workflows/4.19-clang-17.yml
@@ -16,8 +16,32 @@ name: 4.19 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.10-clang-11.yml
+++ b/.github/workflows/5.10-clang-11.yml
@@ -16,8 +16,32 @@ name: 5.10 (clang-11)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -264,8 +288,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.10-clang-12.yml
+++ b/.github/workflows/5.10-clang-12.yml
@@ -16,8 +16,32 @@ name: 5.10 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -306,8 +330,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.10-clang-13.yml
+++ b/.github/workflows/5.10-clang-13.yml
@@ -16,8 +16,32 @@ name: 5.10 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -348,8 +372,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.10-clang-14.yml
+++ b/.github/workflows/5.10-clang-14.yml
@@ -16,8 +16,32 @@ name: 5.10 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -348,8 +372,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.10-clang-15.yml
+++ b/.github/workflows/5.10-clang-15.yml
@@ -16,8 +16,32 @@ name: 5.10 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -348,8 +372,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.10-clang-16.yml
+++ b/.github/workflows/5.10-clang-16.yml
@@ -16,8 +16,32 @@ name: 5.10 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -348,8 +372,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.10-clang-17.yml
+++ b/.github/workflows/5.10-clang-17.yml
@@ -16,8 +16,32 @@ name: 5.10 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -348,8 +372,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -16,8 +16,32 @@ name: 5.15 (clang-11)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -558,8 +582,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -890,8 +938,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -16,8 +16,32 @@ name: 5.15 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -621,8 +645,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -953,8 +1001,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -16,8 +16,32 @@ name: 5.15 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -684,8 +708,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -1058,8 +1106,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -16,8 +16,32 @@ name: 5.15 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -684,8 +708,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -1058,8 +1106,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -16,8 +16,32 @@ name: 5.15 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -684,8 +708,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -1058,8 +1106,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.15-clang-16.yml
+++ b/.github/workflows/5.15-clang-16.yml
@@ -16,8 +16,32 @@ name: 5.15 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -684,8 +708,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -1058,8 +1106,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.15-clang-17.yml
+++ b/.github/workflows/5.15-clang-17.yml
@@ -16,8 +16,32 @@ name: 5.15 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -684,8 +708,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -1058,8 +1106,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.4-clang-13.yml
+++ b/.github/workflows/5.4-clang-13.yml
@@ -16,8 +16,32 @@ name: 5.4 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.4-clang-14.yml
+++ b/.github/workflows/5.4-clang-14.yml
@@ -16,8 +16,32 @@ name: 5.4 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.4-clang-15.yml
+++ b/.github/workflows/5.4-clang-15.yml
@@ -16,8 +16,32 @@ name: 5.4 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.4-clang-16.yml
+++ b/.github/workflows/5.4-clang-16.yml
@@ -16,8 +16,32 @@ name: 5.4 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/5.4-clang-17.yml
+++ b/.github/workflows/5.4-clang-17.yml
@@ -16,8 +16,32 @@ name: 5.4 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-4.14-clang-12.yml
+++ b/.github/workflows/android-4.14-clang-12.yml
@@ -16,8 +16,32 @@ name: android-4.14 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-4.14-clang-13.yml
+++ b/.github/workflows/android-4.14-clang-13.yml
@@ -16,8 +16,32 @@ name: android-4.14 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-4.14-clang-14.yml
+++ b/.github/workflows/android-4.14-clang-14.yml
@@ -16,8 +16,32 @@ name: android-4.14 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-4.14-clang-15.yml
+++ b/.github/workflows/android-4.14-clang-15.yml
@@ -16,8 +16,32 @@ name: android-4.14 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-4.14-clang-16.yml
+++ b/.github/workflows/android-4.14-clang-16.yml
@@ -16,8 +16,32 @@ name: android-4.14 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-4.14-clang-17.yml
+++ b/.github/workflows/android-4.14-clang-17.yml
@@ -16,8 +16,32 @@ name: android-4.14 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-4.14-clang-android.yml
+++ b/.github/workflows/android-4.14-clang-android.yml
@@ -16,8 +16,32 @@ name: android-4.14 (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-android
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-4.19-clang-12.yml
+++ b/.github/workflows/android-4.19-clang-12.yml
@@ -16,8 +16,32 @@ name: android-4.19 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-4.19-clang-13.yml
+++ b/.github/workflows/android-4.19-clang-13.yml
@@ -16,8 +16,32 @@ name: android-4.19 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-4.19-clang-14.yml
+++ b/.github/workflows/android-4.19-clang-14.yml
@@ -16,8 +16,32 @@ name: android-4.19 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-4.19-clang-15.yml
+++ b/.github/workflows/android-4.19-clang-15.yml
@@ -16,8 +16,32 @@ name: android-4.19 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-4.19-clang-16.yml
+++ b/.github/workflows/android-4.19-clang-16.yml
@@ -16,8 +16,32 @@ name: android-4.19 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-4.19-clang-17.yml
+++ b/.github/workflows/android-4.19-clang-17.yml
@@ -16,8 +16,32 @@ name: android-4.19 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-4.19-clang-android.yml
+++ b/.github/workflows/android-4.19-clang-android.yml
@@ -16,8 +16,32 @@ name: android-4.19 (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-android
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-mainline-clang-12.yml
+++ b/.github/workflows/android-mainline-clang-12.yml
@@ -16,8 +16,32 @@ name: android-mainline (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-mainline-clang-13.yml
+++ b/.github/workflows/android-mainline-clang-13.yml
@@ -16,8 +16,32 @@ name: android-mainline (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-mainline-clang-14.yml
+++ b/.github/workflows/android-mainline-clang-14.yml
@@ -16,8 +16,32 @@ name: android-mainline (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-mainline-clang-15.yml
+++ b/.github/workflows/android-mainline-clang-15.yml
@@ -16,8 +16,32 @@ name: android-mainline (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-mainline-clang-16.yml
+++ b/.github/workflows/android-mainline-clang-16.yml
@@ -16,8 +16,32 @@ name: android-mainline (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-mainline-clang-17.yml
+++ b/.github/workflows/android-mainline-clang-17.yml
@@ -16,8 +16,32 @@ name: android-mainline (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android-mainline-clang-android.yml
+++ b/.github/workflows/android-mainline-clang-android.yml
@@ -16,8 +16,32 @@ name: android-mainline (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-android
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-android
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android12-5.10-clang-12.yml
+++ b/.github/workflows/android12-5.10-clang-12.yml
@@ -16,8 +16,32 @@ name: android12-5.10 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android12-5.10-clang-13.yml
+++ b/.github/workflows/android12-5.10-clang-13.yml
@@ -16,8 +16,32 @@ name: android12-5.10 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android12-5.10-clang-14.yml
+++ b/.github/workflows/android12-5.10-clang-14.yml
@@ -16,8 +16,32 @@ name: android12-5.10 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android12-5.10-clang-15.yml
+++ b/.github/workflows/android12-5.10-clang-15.yml
@@ -16,8 +16,32 @@ name: android12-5.10 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android12-5.10-clang-16.yml
+++ b/.github/workflows/android12-5.10-clang-16.yml
@@ -16,8 +16,32 @@ name: android12-5.10 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android12-5.10-clang-17.yml
+++ b/.github/workflows/android12-5.10-clang-17.yml
@@ -16,8 +16,32 @@ name: android12-5.10 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android12-5.10-clang-android.yml
+++ b/.github/workflows/android12-5.10-clang-android.yml
@@ -16,8 +16,32 @@ name: android12-5.10 (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-android
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-android
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android12-5.4-clang-12.yml
+++ b/.github/workflows/android12-5.4-clang-12.yml
@@ -16,8 +16,32 @@ name: android12-5.4 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android12-5.4-clang-13.yml
+++ b/.github/workflows/android12-5.4-clang-13.yml
@@ -16,8 +16,32 @@ name: android12-5.4 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android12-5.4-clang-14.yml
+++ b/.github/workflows/android12-5.4-clang-14.yml
@@ -16,8 +16,32 @@ name: android12-5.4 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android12-5.4-clang-15.yml
+++ b/.github/workflows/android12-5.4-clang-15.yml
@@ -16,8 +16,32 @@ name: android12-5.4 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android12-5.4-clang-16.yml
+++ b/.github/workflows/android12-5.4-clang-16.yml
@@ -16,8 +16,32 @@ name: android12-5.4 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android12-5.4-clang-17.yml
+++ b/.github/workflows/android12-5.4-clang-17.yml
@@ -16,8 +16,32 @@ name: android12-5.4 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android12-5.4-clang-android.yml
+++ b/.github/workflows/android12-5.4-clang-android.yml
@@ -16,8 +16,32 @@ name: android12-5.4 (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-android
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-android
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android13-5.10-clang-12.yml
+++ b/.github/workflows/android13-5.10-clang-12.yml
@@ -16,8 +16,32 @@ name: android13-5.10 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android13-5.10-clang-13.yml
+++ b/.github/workflows/android13-5.10-clang-13.yml
@@ -16,8 +16,32 @@ name: android13-5.10 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android13-5.10-clang-14.yml
+++ b/.github/workflows/android13-5.10-clang-14.yml
@@ -16,8 +16,32 @@ name: android13-5.10 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android13-5.10-clang-15.yml
+++ b/.github/workflows/android13-5.10-clang-15.yml
@@ -16,8 +16,32 @@ name: android13-5.10 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android13-5.10-clang-16.yml
+++ b/.github/workflows/android13-5.10-clang-16.yml
@@ -16,8 +16,32 @@ name: android13-5.10 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android13-5.10-clang-17.yml
+++ b/.github/workflows/android13-5.10-clang-17.yml
@@ -16,8 +16,32 @@ name: android13-5.10 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android13-5.10-clang-android.yml
+++ b/.github/workflows/android13-5.10-clang-android.yml
@@ -16,8 +16,32 @@ name: android13-5.10 (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-android
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-android
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android13-5.15-clang-12.yml
+++ b/.github/workflows/android13-5.15-clang-12.yml
@@ -16,8 +16,32 @@ name: android13-5.15 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android13-5.15-clang-13.yml
+++ b/.github/workflows/android13-5.15-clang-13.yml
@@ -16,8 +16,32 @@ name: android13-5.15 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android13-5.15-clang-14.yml
+++ b/.github/workflows/android13-5.15-clang-14.yml
@@ -16,8 +16,32 @@ name: android13-5.15 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android13-5.15-clang-15.yml
+++ b/.github/workflows/android13-5.15-clang-15.yml
@@ -16,8 +16,32 @@ name: android13-5.15 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android13-5.15-clang-16.yml
+++ b/.github/workflows/android13-5.15-clang-16.yml
@@ -16,8 +16,32 @@ name: android13-5.15 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android13-5.15-clang-17.yml
+++ b/.github/workflows/android13-5.15-clang-17.yml
@@ -16,8 +16,32 @@ name: android13-5.15 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android13-5.15-clang-android.yml
+++ b/.github/workflows/android13-5.15-clang-android.yml
@@ -16,8 +16,32 @@ name: android13-5.15 (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-android
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-android
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android14-5.15-clang-12.yml
+++ b/.github/workflows/android14-5.15-clang-12.yml
@@ -16,8 +16,32 @@ name: android14-5.15 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android14-5.15-clang-13.yml
+++ b/.github/workflows/android14-5.15-clang-13.yml
@@ -16,8 +16,32 @@ name: android14-5.15 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android14-5.15-clang-14.yml
+++ b/.github/workflows/android14-5.15-clang-14.yml
@@ -16,8 +16,32 @@ name: android14-5.15 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android14-5.15-clang-15.yml
+++ b/.github/workflows/android14-5.15-clang-15.yml
@@ -16,8 +16,32 @@ name: android14-5.15 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android14-5.15-clang-16.yml
+++ b/.github/workflows/android14-5.15-clang-16.yml
@@ -16,8 +16,32 @@ name: android14-5.15 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android14-5.15-clang-17.yml
+++ b/.github/workflows/android14-5.15-clang-17.yml
@@ -16,8 +16,32 @@ name: android14-5.15 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android14-5.15-clang-android.yml
+++ b/.github/workflows/android14-5.15-clang-android.yml
@@ -16,8 +16,32 @@ name: android14-5.15 (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-android
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-android
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android14-6.1-clang-12.yml
+++ b/.github/workflows/android14-6.1-clang-12.yml
@@ -16,8 +16,32 @@ name: android14-6.1 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android14-6.1-clang-13.yml
+++ b/.github/workflows/android14-6.1-clang-13.yml
@@ -16,8 +16,32 @@ name: android14-6.1 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android14-6.1-clang-14.yml
+++ b/.github/workflows/android14-6.1-clang-14.yml
@@ -16,8 +16,32 @@ name: android14-6.1 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android14-6.1-clang-15.yml
+++ b/.github/workflows/android14-6.1-clang-15.yml
@@ -16,8 +16,32 @@ name: android14-6.1 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android14-6.1-clang-16.yml
+++ b/.github/workflows/android14-6.1-clang-16.yml
@@ -16,8 +16,32 @@ name: android14-6.1 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/android14-6.1-clang-17.yml
+++ b/.github/workflows/android14-6.1-clang-17.yml
@@ -16,8 +16,32 @@ name: android14-6.1 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -96,8 +120,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/arm64-clang-11.yml
+++ b/.github/workflows/arm64-clang-11.yml
@@ -16,8 +16,32 @@ name: arm64 (clang-11)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -54,8 +78,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/arm64-clang-12.yml
+++ b/.github/workflows/arm64-clang-12.yml
@@ -16,8 +16,32 @@ name: arm64 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -54,8 +78,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/arm64-clang-13.yml
+++ b/.github/workflows/arm64-clang-13.yml
@@ -16,8 +16,32 @@ name: arm64 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -75,8 +99,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/arm64-clang-14.yml
+++ b/.github/workflows/arm64-clang-14.yml
@@ -16,8 +16,32 @@ name: arm64 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -75,8 +99,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/arm64-clang-15.yml
+++ b/.github/workflows/arm64-clang-15.yml
@@ -16,8 +16,32 @@ name: arm64 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -75,8 +99,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/arm64-clang-16.yml
+++ b/.github/workflows/arm64-clang-16.yml
@@ -16,8 +16,32 @@ name: arm64 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -75,8 +99,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/arm64-clang-17.yml
+++ b/.github/workflows/arm64-clang-17.yml
@@ -16,8 +16,32 @@ name: arm64 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -75,8 +99,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/arm64-fixes-clang-11.yml
+++ b/.github/workflows/arm64-fixes-clang-11.yml
@@ -16,8 +16,32 @@ name: arm64-fixes (clang-11)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -54,8 +78,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/arm64-fixes-clang-12.yml
+++ b/.github/workflows/arm64-fixes-clang-12.yml
@@ -16,8 +16,32 @@ name: arm64-fixes (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -54,8 +78,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/arm64-fixes-clang-13.yml
+++ b/.github/workflows/arm64-fixes-clang-13.yml
@@ -16,8 +16,32 @@ name: arm64-fixes (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -75,8 +99,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/arm64-fixes-clang-14.yml
+++ b/.github/workflows/arm64-fixes-clang-14.yml
@@ -16,8 +16,32 @@ name: arm64-fixes (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -75,8 +99,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/arm64-fixes-clang-15.yml
+++ b/.github/workflows/arm64-fixes-clang-15.yml
@@ -16,8 +16,32 @@ name: arm64-fixes (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -75,8 +99,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/arm64-fixes-clang-16.yml
+++ b/.github/workflows/arm64-fixes-clang-16.yml
@@ -16,8 +16,32 @@ name: arm64-fixes (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -75,8 +99,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/arm64-fixes-clang-17.yml
+++ b/.github/workflows/arm64-fixes-clang-17.yml
@@ -16,8 +16,32 @@ name: arm64-fixes (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -75,8 +99,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/chromeos-5.10-clang-12.yml
+++ b/.github/workflows/chromeos-5.10-clang-12.yml
@@ -16,8 +16,32 @@ name: chromeos-5.10 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/chromeos-5.10-clang-13.yml
+++ b/.github/workflows/chromeos-5.10-clang-13.yml
@@ -16,8 +16,32 @@ name: chromeos-5.10 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/chromeos-5.10-clang-14.yml
+++ b/.github/workflows/chromeos-5.10-clang-14.yml
@@ -16,8 +16,32 @@ name: chromeos-5.10 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/chromeos-5.10-clang-15.yml
+++ b/.github/workflows/chromeos-5.10-clang-15.yml
@@ -16,8 +16,32 @@ name: chromeos-5.10 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/chromeos-5.10-clang-16.yml
+++ b/.github/workflows/chromeos-5.10-clang-16.yml
@@ -16,8 +16,32 @@ name: chromeos-5.10 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/chromeos-5.10-clang-17.yml
+++ b/.github/workflows/chromeos-5.10-clang-17.yml
@@ -16,8 +16,32 @@ name: chromeos-5.10 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/chromeos-5.15-clang-12.yml
+++ b/.github/workflows/chromeos-5.15-clang-12.yml
@@ -16,8 +16,32 @@ name: chromeos-5.15 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/chromeos-5.15-clang-13.yml
+++ b/.github/workflows/chromeos-5.15-clang-13.yml
@@ -16,8 +16,32 @@ name: chromeos-5.15 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/chromeos-5.15-clang-14.yml
+++ b/.github/workflows/chromeos-5.15-clang-14.yml
@@ -16,8 +16,32 @@ name: chromeos-5.15 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/chromeos-5.15-clang-15.yml
+++ b/.github/workflows/chromeos-5.15-clang-15.yml
@@ -16,8 +16,32 @@ name: chromeos-5.15 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/chromeos-5.15-clang-16.yml
+++ b/.github/workflows/chromeos-5.15-clang-16.yml
@@ -16,8 +16,32 @@ name: chromeos-5.15 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/chromeos-5.15-clang-17.yml
+++ b/.github/workflows/chromeos-5.15-clang-17.yml
@@ -16,8 +16,32 @@ name: chromeos-5.15 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/mainline-clang-11.yml
+++ b/.github/workflows/mainline-clang-11.yml
@@ -16,8 +16,32 @@ name: mainline (clang-11)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -579,8 +603,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -911,8 +959,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/mainline-clang-12.yml
+++ b/.github/workflows/mainline-clang-12.yml
@@ -16,8 +16,32 @@ name: mainline (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -600,8 +624,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -932,8 +980,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/mainline-clang-13.yml
+++ b/.github/workflows/mainline-clang-13.yml
@@ -16,8 +16,32 @@ name: mainline (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -621,8 +645,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -953,8 +1001,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -16,8 +16,32 @@ name: mainline (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -621,8 +645,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -953,8 +1001,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -16,8 +16,32 @@ name: mainline (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -663,8 +687,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -1037,8 +1085,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -16,8 +16,32 @@ name: mainline (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -747,8 +771,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -1121,8 +1169,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/mainline-clang-17.yml
+++ b/.github/workflows/mainline-clang-17.yml
@@ -16,8 +16,32 @@ name: mainline (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -747,8 +771,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -1121,8 +1169,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/next-clang-11.yml
+++ b/.github/workflows/next-clang-11.yml
@@ -16,8 +16,32 @@ name: next (clang-11)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -579,8 +603,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -911,8 +959,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/next-clang-12.yml
+++ b/.github/workflows/next-clang-12.yml
@@ -16,8 +16,32 @@ name: next (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -600,8 +624,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -932,8 +980,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/next-clang-13.yml
+++ b/.github/workflows/next-clang-13.yml
@@ -16,8 +16,32 @@ name: next (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -642,8 +666,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -974,8 +1022,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -16,8 +16,32 @@ name: next (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -642,8 +666,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -974,8 +1022,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -16,8 +16,32 @@ name: next (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -684,8 +708,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -1058,8 +1106,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -16,8 +16,32 @@ name: next (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -768,8 +792,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -1142,8 +1190,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/next-clang-17.yml
+++ b/.github/workflows/next-clang-17.yml
@@ -16,8 +16,32 @@ name: next (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -768,8 +792,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -1142,8 +1190,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/next-clang-android.yml
+++ b/.github/workflows/next-clang-android.yml
@@ -16,8 +16,32 @@ name: next (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-android
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -306,8 +330,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-android
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/stable-clang-11.yml
+++ b/.github/workflows/stable-clang-11.yml
@@ -16,8 +16,32 @@ name: stable (clang-11)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -579,8 +603,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -911,8 +959,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/stable-clang-12.yml
+++ b/.github/workflows/stable-clang-12.yml
@@ -16,8 +16,32 @@ name: stable (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -600,8 +624,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -932,8 +980,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -16,8 +16,32 @@ name: stable (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -621,8 +645,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -953,8 +1001,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -16,8 +16,32 @@ name: stable (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -621,8 +645,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -953,8 +1001,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -16,8 +16,32 @@ name: stable (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -663,8 +687,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -1037,8 +1085,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/stable-clang-16.yml
+++ b/.github/workflows/stable-clang-16.yml
@@ -16,8 +16,32 @@ name: stable (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -747,8 +771,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -1121,8 +1169,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/stable-clang-17.yml
+++ b/.github/workflows/stable-clang-17.yml
@@ -16,8 +16,32 @@ name: stable (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -747,8 +771,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_distribution_configs:
+    name: cache check (distribution_configs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_distribution_configs:
     name: TuxSuite (distribution_configs)
+    needs: cache_check_distribution_configs
+    if: ${{ needs.cache_check_distribution_configs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -1121,8 +1169,32 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/tip-clang-11.yml
+++ b/.github/workflows/tip-clang-11.yml
@@ -16,8 +16,32 @@ name: tip (clang-11)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -75,8 +99,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-11
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/tip-clang-12.yml
+++ b/.github/workflows/tip-clang-12.yml
@@ -16,8 +16,32 @@ name: tip (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -75,8 +99,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-12
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/tip-clang-13.yml
+++ b/.github/workflows/tip-clang-13.yml
@@ -16,8 +16,32 @@ name: tip (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -75,8 +99,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-13
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/tip-clang-14.yml
+++ b/.github/workflows/tip-clang-14.yml
@@ -16,8 +16,32 @@ name: tip (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -75,8 +99,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-14
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/tip-clang-15.yml
+++ b/.github/workflows/tip-clang-15.yml
@@ -16,8 +16,32 @@ name: tip (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -75,8 +99,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-15
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/tip-clang-16.yml
+++ b/.github/workflows/tip-clang-16.yml
@@ -16,8 +16,32 @@ name: tip (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -75,8 +99,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-16
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/.github/workflows/tip-clang-17.yml
+++ b/.github/workflows/tip-clang-17.yml
@@ -16,8 +16,32 @@ name: tip (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  cache_check_defconfigs:
+    name: cache check (defconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_defconfigs:
     name: TuxSuite (defconfigs)
+    needs: cache_check_defconfigs
+    if: ${{ needs.cache_check_defconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:
@@ -75,8 +99,32 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  cache_check_allconfigs:
+    name: cache check (allconfigs)
+    runs-on: ubuntu-latest
+    container: tuxmake/clang-nightly
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v3
+    - name: Should build run?
+      id: should_run
+      run: |
+        if python3 should_run.py || { ret=$?; ( exit $ret ) }; then
+          echo "should_run=true" >>$GITHUB_OUTPUT
+        else
+            case $ret in
+              2) echo "should_run=false" >>$GITHUB_OUTPUT ;;
+              *) exit 1 ;;
+            esac
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
+    needs: cache_check_allconfigs
+    if: ${{ needs.cache_check_allconfigs.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
     env:

--- a/should_run.py
+++ b/should_run.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import yaml
+
+import utils
+
+if 'GITHUB_ACTIONS' not in os.environ:
+    raise RuntimeError('Not running on GitHub Actions?')
+
+if 'GITHUB_TOKEN' not in os.environ:
+    raise RuntimeError('No GITHUB_TOKEN was specified?')
+
+github = {
+    'actor': os.environ['GITHUB_ACTOR'],
+    'event_name': os.environ['GITHUB_EVENT_NAME'],
+    'job': os.environ['GITHUB_JOB'],
+    'token': os.environ['GITHUB_TOKEN'],
+    'repository': os.environ['GITHUB_REPOSITORY'],
+    'repository_owner': os.environ['GITHUB_REPOSITORY_OWNER'],
+    'workflow_ref': os.environ['GITHUB_WORKFLOW_REF'],
+    'workspace': Path(os.environ['GITHUB_WORKSPACE']),
+}
+
+if github['repository_owner'] != 'ClangBuiltLinux':
+    raise RuntimeError('Not running in ClangBuiltLinux repo, exiting...')
+# A workflow dispatch means we want the workflow to run because it is being
+# called manually, do not bother checking anything further in this case.
+if github['event_name'] == 'workflow_dispatch':
+    print(
+        'Workflow was called manually, exiting with return code 0 to run tuxsuite...',
+    )
+    sys.exit(0)
+
+# Input: <owner>/<repo>/.github/workflows/<workflow>.yml@refs/heads/<branch>
+# Output: <owner>/<repo>/.github/workflows/<workflow>.yml
+workflow_path = Path(github['workflow_ref'].split('@', 1)[0])
+workflow_stem = workflow_path.stem
+# branch name is <workflow>-<job>, so that it is entirely unique for updating
+branch = f"{workflow_stem}-{github['job']}"
+
+# Configure git
+repo = Path(github['workspace'], github['workspace'].name)
+git_configs = {
+    'safe.directory': repo,
+    'user.name': f"{github['actor']} via GitHub Actions",
+    'user.email': f"{github['actor']}@users.noreply.github.com",
+}
+for key, val in git_configs.items():
+    subprocess.run(['git', 'config', '--global', key, val], check=True)
+
+# Clone repository
+subprocess.run(
+    ['git', 'clone', f"https://github.com/{github['repository']}", repo],
+    check=True)
+
+# Down out of band to avoid leaking GITHUB_TOKEN, the push will fail later
+# if this does not work, so check=False.
+new_remote = f"https://{github['actor']}:{github['token']}@github.com/{github['repository']}"
+subprocess.run(['git', 'remote', 'set-url', 'origin', new_remote],
+               check=False,
+               cwd=repo)
+
+# If there is no branch in the repository for the current workflow, create one
+try:
+    subprocess.run(['git', 'checkout', branch], check=True, cwd=repo)
+except subprocess.CalledProcessError:
+    subprocess.run(['git', 'checkout', '--orphan', branch],
+                   check=True,
+                   cwd=repo)
+    subprocess.run(['git', 'rm', '-fr', '.'], check=True, cwd=repo)
+
+# Get compiler string
+compiler = subprocess.run(['clang', '--version'],
+                          capture_output=True,
+                          check=True,
+                          text=True).stdout.splitlines()[0]
+
+# Get current sha of remote
+# Input: <tree>-clang-<num>
+# Output: <tree>
+# Have to split then join because tree could have a hyphen
+# pylint: disable-next=invalid-name ??
+tree_name = '-'.join(workflow_stem.split('-')[0:-2])
+with Path(github['workspace'], 'generator.yml').open(encoding='utf-8') as file:
+    config = yaml.safe_load(file)
+url, ref = utils.get_repo_ref(config, tree_name)
+ls_rem = subprocess.run(['git', 'ls-remote', url, ref],
+                        capture_output=True,
+                        check=True,
+                        text=True)
+# Input: <sha>\tref/heads/<ref>
+# Output: <sha>
+sha = ls_rem.stdout.split('\t', 1)[0]
+
+info_json = Path(repo, 'last_run_info.json')
+new_run_info = {
+    'compiler': compiler,
+    'sha': sha,
+}
+
+# If the file already exists...
+if info_json.exists():
+    with info_json.open(encoding='utf-8') as file:
+        old_run_info = json.load(file)
+    # compare the two, writing to disk and breaking as soon as there is a
+    # difference
+    for key in old_run_info:
+        if old_run_info[key] != new_run_info[key]:
+            with info_json.open('w', encoding='utf-8') as file:
+                json.dump(new_run_info, file, indent=4, sort_keys=True)
+            break
+else:
+    # Otherwise, create and write to the file
+    with info_json.open('w', encoding='utf-8') as file:
+        json.dump(new_run_info, file, indent=4, sort_keys=True)
+
+subprocess.run(['git', 'add', info_json.name], check=True, cwd=repo)
+status = subprocess.run(['git', 'status', '--porcelain', '-u'],
+                        capture_output=True,
+                        check=True,
+                        cwd=repo,
+                        text=True)
+if not status.stdout:  # No changes, we do not need to run
+    print(
+        f"I: No changes to {info_json.name} detected, exiting with return code 2 to skip running tuxsuite...",
+    )
+    sys.exit(2)
+
+subprocess.run(['git', 'commit', '-m', f"{branch}: Update last_run_info.json"],
+               check=True,
+               cwd=repo)
+subprocess.run(['git', 'push', 'origin', f"HEAD:{branch}"],
+               check=True,
+               cwd=repo)
+print('I: Exiting with return code 0 to run tuxsuite...')


### PR DESCRIPTION
NOTE: This is currently based on #519 for ease of development, I will rebase this on main once that PR is merged.

There are times where neither the kernel revision nor the compiler have
changed since the last run, which means there is little point running the
build because it is unlikely anything would change (except due to
flakiness with GitHub Actions, more on that later). While tuxsuite does
have compiler caching enabled, it still relies on spinning up all the
build machines, letting the cache work, then firing off the boot tests,
which can be expensive.

By caching the compiler string and the kernel revision, it is possible
to avoid even spinning up the tuxsuite jobs if nothing has changed.
`should_run.py` takes care of this by exiting:

    * 0 if the build should run (something changed or there was no
      previous results)
    * 1 for any internal assertion failure
    * 2 if nothing changed from the previous run

If there is any internal assertion failure, the cache step fails,
failing the whole workflow, so that those situations can be properly
dealt with. The script should never do this, but it is possible there
are things I have not considered happening yet.

To avoid contention with pushing and pulling, each `should_run.py` job
gets its own branch. While this will result in a lot of branches, they
should not cause too many issues because they will just contain the JSON
file with the last run info.

`should_run.py` does not try to account for flakiness on the GitHub
Actions or TuxSuite side, so it is possible that a previous build will
fail due to flakiness and not be retried on the next cron if nothing
changes since then. To attempt to account for a situation where we
re-run a known flaky build, the script gets out of the way when the
GitHub Actions event is `workflow_dispatch`, meaning a workflow was
manually run. Additionally, if the previous run was only flaky during
the QEMU boots (rather than during the TuxSuite stage), they can
generally just be re-run right away, since the kernels do not need to be
rebuilt. I do not think this will happen too often but if it does, we
can try to come up with a better heuristic.

Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/308
