### PR TITLE
Add powerpc allmodconfig build on linux-next

### DIFF
--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -1243,6 +1243,27 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _516fac05d5416a9f78740a10f02ebe3f:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n
+    env:
+      ARCH: powerpc
+      LLVM_VERSION: 15
+      BOOT: 0
+      CONFIG: allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _5173235a7c271979a177be1eb5cb40b0:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -1327,6 +1327,27 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _746c6cc9d865631749721e0b69fa26e8:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n
+    env:
+      ARCH: powerpc
+      LLVM_VERSION: 16
+      BOOT: 0
+      CONFIG: allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _fbc0af0db8490a9977f5e99915bf441a:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs

--- a/.github/workflows/next-clang-17.yml
+++ b/.github/workflows/next-clang-17.yml
@@ -1327,6 +1327,27 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _fba586c9a687192e653123eeeab7d2e3:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n
+    env:
+      ARCH: powerpc
+      LLVM_VERSION: 17
+      BOOT: 0
+      CONFIG: allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _6ee344b20402930df88a0227d01bbe27:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs

--- a/generator.yml
+++ b/generator.yml
@@ -309,6 +309,7 @@ configs:
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
   - &ppc64le_fedora    {config: [*ppc64le-fedora-config-url, CONFIG_BPF_PRELOAD=n],                            kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel}
   - &ppc64le_suse      {config: *ppc64le-suse-config-url,                                                      kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel}
+  - &ppc64_allmod      {config: [allmodconfig, CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y, CONFIG_WERROR=n],                                     << : *powerpc64-triple,     << : *default}
   - &riscv             {config: defconfig,                                                                     kernel_image: Image,        << : *riscv-triple,         << : *kernel}
   - &riscv_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                               kernel_image: Image,        << : *riscv-triple,         << : *default}
   #                                         https://github.com/ClangBuiltLinux/linux/issues/1143
@@ -477,6 +478,7 @@ builds:
   - {<< : *ppc64le,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *ppc64le_fedora,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *ppc64le_suse,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *ppc64_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *riscv_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *riscv_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -946,6 +948,7 @@ builds:
   - {<< : *ppc64le,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *ppc64le_fedora,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *ppc64le_suse,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *ppc64_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *riscv_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *riscv_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -1409,6 +1412,7 @@ builds:
   - {<< : *ppc64le,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *ppc64le_fedora,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *ppc64le_suse,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
+  - {<< : *ppc64_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *riscv_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *riscv_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}

--- a/tuxsuite/next-clang-15.tux.yml
+++ b/tuxsuite/next-clang-15.tux.yml
@@ -547,6 +547,17 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: powerpc
+    toolchain: clang-15
+    kconfig:
+    - allmodconfig
+    - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
+    - CONFIG_WERROR=n
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
   - target_arch: riscv
     toolchain: clang-15
     kconfig:

--- a/tuxsuite/next-clang-16.tux.yml
+++ b/tuxsuite/next-clang-16.tux.yml
@@ -589,6 +589,17 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: powerpc
+    toolchain: clang-16
+    kconfig:
+    - allmodconfig
+    - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
+    - CONFIG_WERROR=n
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
   - target_arch: riscv
     toolchain: clang-16
     kconfig:

--- a/tuxsuite/next-clang-17.tux.yml
+++ b/tuxsuite/next-clang-17.tux.yml
@@ -589,6 +589,17 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: powerpc
+    toolchain: clang-nightly
+    kconfig:
+    - allmodconfig
+    - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
+    - CONFIG_WERROR=n
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
   - target_arch: riscv
     toolchain: clang-nightly
     kconfig:


### PR DESCRIPTION
In order to use ld.lld (and by extension, LLVM=1) with allmodconfig
(which is big endian), we need to build with the ELFv2 ABI, as ld.lld
does not have support for the ELFv1 ABI. This is now possible on -next,
so wire up this build to make sure it stays green.

This adds 15 more builds per week:

```
diff --git a/tmp/estimate-builds.txt b/tmp/.psub.GnbBewMeWv
index 24a4a39..ad40946 100644
--- a/tmp/estimate-builds.txt
+++ b/tmp/.psub.GnbBewMeWv
@@ -1,4 +1,4 @@
-Total builds per week: 8148
+Total builds per week: 8163

   - tree: mainline
     total: 2900
@@ -12,11 +12,11 @@ Total builds per week: 8148
     - clang-11: 520

   - tree: next
-    total: 2150
+    total: 2165
     breakdown:
-    - clang-17: 320
-    - clang-16: 320
-    - clang-15: 300
+    - clang-17: 325
+    - clang-16: 325
+    - clang-15: 305
     - clang-14: 285
     - clang-13: 285
     - clang-12: 265
```
