### PR TITLE
Turn x86_64 allyesconfig builds back on

### DIFF
--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -1306,4 +1306,25 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _2761279f511773a7e0d3689117cf5c33:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 15
+      BOOT: 0
+      CONFIG: allyesconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
 

--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -1390,4 +1390,25 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _cc92db58f57103904b162bb3cb351329:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 16
+      BOOT: 0
+      CONFIG: allyesconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
 

--- a/.github/workflows/mainline-clang-17.yml
+++ b/.github/workflows/mainline-clang-17.yml
@@ -1390,4 +1390,25 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _73a72aae81b42c7ef0b0bd18add14c1f:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 17
+      BOOT: 0
+      CONFIG: allyesconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
 

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -1348,4 +1348,25 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _2761279f511773a7e0d3689117cf5c33:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 15
+      BOOT: 0
+      CONFIG: allyesconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
 

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -1432,4 +1432,25 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _cc92db58f57103904b162bb3cb351329:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 16
+      BOOT: 0
+      CONFIG: allyesconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
 

--- a/.github/workflows/next-clang-17.yml
+++ b/.github/workflows/next-clang-17.yml
@@ -1432,4 +1432,25 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _73a72aae81b42c7ef0b0bd18add14c1f:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 17
+      BOOT: 0
+      CONFIG: allyesconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
 

--- a/.github/workflows/tip-clang-15.yml
+++ b/.github/workflows/tip-clang-15.yml
@@ -134,4 +134,25 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _2761279f511773a7e0d3689117cf5c33:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 15
+      BOOT: 0
+      CONFIG: allyesconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
 

--- a/.github/workflows/tip-clang-16.yml
+++ b/.github/workflows/tip-clang-16.yml
@@ -134,4 +134,25 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _cc92db58f57103904b162bb3cb351329:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 16
+      BOOT: 0
+      CONFIG: allyesconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
 

--- a/.github/workflows/tip-clang-17.yml
+++ b/.github/workflows/tip-clang-17.yml
@@ -134,4 +134,25 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _73a72aae81b42c7ef0b0bd18add14c1f:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 17
+      BOOT: 0
+      CONFIG: allyesconfig
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
 

--- a/generator.yml
+++ b/generator.yml
@@ -428,8 +428,7 @@ builds:
   - {<< : *x86_64_allmod,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_allmod_lto, << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_allno,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
-  # x86_64 allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
-  # - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_alpine,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_arch,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_fedora,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -499,8 +498,7 @@ builds:
   - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
-  # x86_64 allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
-  # - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_gcov,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_alpine,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_arch,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -815,8 +813,7 @@ builds:
   - {<< : *x86_64,            << : *tip,              << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_allmod,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_allno,      << : *tip,              << : *llvm_full,       boot: false, << : *llvm_tot}
-  # -tip allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
-  # - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_tot}
   ###########
   #  ARM64  #
   ###########
@@ -898,8 +895,7 @@ builds:
   - {<< : *x86_64_allmod,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *x86_64_allmod_lto, << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *x86_64_allno,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
-  # x86_64 allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
-  # - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *x86_64_alpine,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_arch,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_fedora,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -969,8 +965,7 @@ builds:
   - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
-  # x86_64 allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
-  # - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *x86_64_gcov,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_alpine,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_arch,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -1285,8 +1280,7 @@ builds:
   - {<< : *x86_64,            << : *tip,              << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_allmod,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *x86_64_allno,      << : *tip,              << : *llvm_full,       boot: false, << : *llvm_latest}
-  # -tip allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
-  # - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_latest}
   ###########
   #  ARM64  #
   ###########
@@ -1364,8 +1358,7 @@ builds:
   - {<< : *x86_64_allmod,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *x86_64_allmod_lto, << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *x86_64_allno,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_15}
-  # x86_64 allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
-  # - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_15}
+  - {<< : *x86_64_allyes,     << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *x86_64_alpine,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *x86_64_arch,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *x86_64_fedora,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
@@ -1431,8 +1424,7 @@ builds:
   - {<< : *x86_64_allmod,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *x86_64_allmod_lto, << : *next,             << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *x86_64_allno,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_15}
-  # x86_64 allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
-  # - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_15}
+  - {<< : *x86_64_allyes,     << : *next,             << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *x86_64_gcov,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *x86_64_alpine,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *x86_64_arch,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
@@ -1739,8 +1731,7 @@ builds:
   - {<< : *x86_64,            << : *tip,              << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *x86_64_allmod,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *x86_64_allno,      << : *tip,              << : *llvm_full,       boot: false, << : *llvm_15}
-  # -tip allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
-  # - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_15}
+  - {<< : *x86_64_allyes,     << : *tip,              << : *llvm_full,       boot: false, << : *llvm_15}
   ###########
   #  ARM64  #
   ###########

--- a/tuxsuite/mainline-clang-15.tux.yml
+++ b/tuxsuite/mainline-clang-15.tux.yml
@@ -575,4 +575,12 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-15
+    kconfig: allyesconfig
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
 

--- a/tuxsuite/mainline-clang-16.tux.yml
+++ b/tuxsuite/mainline-clang-16.tux.yml
@@ -617,4 +617,12 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-16
+    kconfig: allyesconfig
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
 

--- a/tuxsuite/mainline-clang-17.tux.yml
+++ b/tuxsuite/mainline-clang-17.tux.yml
@@ -617,4 +617,12 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-nightly
+    kconfig: allyesconfig
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
 

--- a/tuxsuite/next-clang-15.tux.yml
+++ b/tuxsuite/next-clang-15.tux.yml
@@ -597,4 +597,12 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-15
+    kconfig: allyesconfig
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
 

--- a/tuxsuite/next-clang-16.tux.yml
+++ b/tuxsuite/next-clang-16.tux.yml
@@ -639,4 +639,12 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-16
+    kconfig: allyesconfig
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
 

--- a/tuxsuite/next-clang-17.tux.yml
+++ b/tuxsuite/next-clang-17.tux.yml
@@ -639,4 +639,12 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-nightly
+    kconfig: allyesconfig
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
 

--- a/tuxsuite/tip-clang-15.tux.yml
+++ b/tuxsuite/tip-clang-15.tux.yml
@@ -46,4 +46,12 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-15
+    kconfig: allyesconfig
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
 

--- a/tuxsuite/tip-clang-16.tux.yml
+++ b/tuxsuite/tip-clang-16.tux.yml
@@ -46,4 +46,12 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-16
+    kconfig: allyesconfig
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
 

--- a/tuxsuite/tip-clang-17.tux.yml
+++ b/tuxsuite/tip-clang-17.tux.yml
@@ -46,4 +46,12 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-nightly
+    kconfig: allyesconfig
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
 


### PR DESCRIPTION
These were disabled due to a build time regression, which has since been
resolved in all of these trees. This increases the number of builds
slightly:

```diff
diff --git a/tmp/estimate-builds.txt b/tmp/.psub.3vT4MBu4zi
index ad40946..38964c1 100644
--- a/tmp/estimate-builds.txt
+++ b/tmp/.psub.3vT4MBu4zi
@@ -1,22 +1,22 @@
-Total builds per week: 8163
+Total builds per week: 8218

   - tree: mainline
-    total: 2900
+    total: 2925
     breakdown:
-    - clang-17: 630
-    - clang-16: 630
-    - clang-15: 295
+    - clang-17: 640
+    - clang-16: 640
+    - clang-15: 300
     - clang-14: 280
     - clang-13: 280
     - clang-12: 265
     - clang-11: 520

   - tree: next
-    total: 2165
+    total: 2180
     breakdown:
-    - clang-17: 325
-    - clang-16: 325
-    - clang-15: 305
+    - clang-17: 330
+    - clang-16: 330
+    - clang-15: 310
     - clang-14: 285
     - clang-13: 285
     - clang-12: 265
@@ -67,6 +67,17 @@ Total builds per week: 8163
     - clang-12: 22
     - clang-11: 20

+  - tree: tip
+    total: 175
+    breakdown:
+    - clang-17: 25
+    - clang-16: 25
+    - clang-15: 25
+    - clang-14: 25
+    - clang-13: 25
+    - clang-12: 25
+    - clang-11: 25
+
   - tree: arm64
     total: 165
     breakdown:
@@ -89,17 +100,6 @@ Total builds per week: 8163
     - clang-12: 20
     - clang-11: 20

-  - tree: tip
-    total: 160
-    breakdown:
-    - clang-17: 20
-    - clang-16: 20
-    - clang-15: 20
-    - clang-14: 25
-    - clang-13: 25
-    - clang-12: 25
-    - clang-11: 25
-
   - tree: android-mainline
     total: 76
     breakdown:
```
