### PR TITLE
check_logs.py: Print logs if build result is not a pass

### DIFF
--- a/check_logs.py
+++ b/check_logs.py
@@ -100,7 +100,7 @@ def fetch_logs(build):
 def check_log(build):
     warnings_count = build["warnings_count"]
     errors_count = build["errors_count"]
-    if warnings_count + errors_count > 0:
+    if warnings_count + errors_count > 0 or build["result"] != "pass":
         print_yellow(f"{warnings_count} warnings, {errors_count} errors")
         fetch_logs(build)
 


### PR DESCRIPTION
There are times where there could be build errors not caught by
tuxsuite's regex (like linker errors without "Error" in the string).

Print build.log if the result of the build is not a "pass".

Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/540
