### PR TITLE
Disable x86_64 allyesconfig builds on stable

### DIFF
--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -1306,25 +1306,4 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2761279f511773a7e0d3689117cf5c33:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
-    env:
-      ARCH: x86_64
-      LLVM_VERSION: 15
-      BOOT: 0
-      CONFIG: allyesconfig
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
 

--- a/.github/workflows/stable-clang-16.yml
+++ b/.github/workflows/stable-clang-16.yml
@@ -1390,25 +1390,4 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _cc92db58f57103904b162bb3cb351329:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
-    env:
-      ARCH: x86_64
-      LLVM_VERSION: 16
-      BOOT: 0
-      CONFIG: allyesconfig
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
 

--- a/.github/workflows/stable-clang-17.yml
+++ b/.github/workflows/stable-clang-17.yml
@@ -1390,25 +1390,4 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _73a72aae81b42c7ef0b0bd18add14c1f:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_allconfigs
-    name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
-    env:
-      ARCH: x86_64
-      LLVM_VERSION: 17
-      BOOT: 0
-      CONFIG: allyesconfig
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
 

--- a/generator.yml
+++ b/generator.yml
@@ -570,7 +570,8 @@ builds:
   - {<< : *x86_64_allmod,     << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_allmod_lto, << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_allno,      << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
-  - {<< : *x86_64_allyes,     << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
+  # x86_64 allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
+  # - {<< : *x86_64_allyes,     << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *x86_64_alpine,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_arch,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_fedora,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -1040,7 +1041,8 @@ builds:
   - {<< : *x86_64_allmod,     << : *stable,           << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *x86_64_allmod_lto, << : *stable,           << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *x86_64_allno,      << : *stable,           << : *llvm_full,       boot: false, << : *llvm_latest}
-  - {<< : *x86_64_allyes,     << : *stable,           << : *llvm_full,       boot: false, << : *llvm_latest}
+  # x86_64 allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
+  # - {<< : *x86_64_allyes,     << : *stable,           << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *x86_64_alpine,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_arch,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_fedora,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -1498,7 +1500,8 @@ builds:
   - {<< : *x86_64_allmod,     << : *stable,           << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *x86_64_allmod_lto, << : *stable,           << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *x86_64_allno,      << : *stable,           << : *llvm_full,       boot: false, << : *llvm_15}
-  - {<< : *x86_64_allyes,     << : *stable,           << : *llvm_full,       boot: false, << : *llvm_15}
+  # x86_64 allyesconfig disabled: https://github.com/ClangBuiltLinux/linux/issues/1768
+  # - {<< : *x86_64_allyes,     << : *stable,           << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *x86_64_alpine,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *x86_64_arch,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *x86_64_fedora,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_15}

--- a/tuxsuite/stable-clang-15.tux.yml
+++ b/tuxsuite/stable-clang-15.tux.yml
@@ -575,12 +575,4 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: x86_64
-    toolchain: clang-15
-    kconfig: allyesconfig
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
 

--- a/tuxsuite/stable-clang-16.tux.yml
+++ b/tuxsuite/stable-clang-16.tux.yml
@@ -617,12 +617,4 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: x86_64
-    toolchain: clang-16
-    kconfig: allyesconfig
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
 

--- a/tuxsuite/stable-clang-17.tux.yml
+++ b/tuxsuite/stable-clang-17.tux.yml
@@ -617,12 +617,4 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: x86_64
-    toolchain: clang-nightly
-    kconfig: allyesconfig
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
 


### PR DESCRIPTION
The build time performance regression from call depth tracking is not
fixed in this branch, causing the builds to timeout. Until that series
can be backported, disable these builds to keep the CI green.

Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/539
