### PR TITLE
drop triples

### DIFF
--- a/generator.yml
+++ b/generator.yml
@@ -234,19 +234,6 @@ architectures:
   - &riscv-arch   riscv
   - &s390-arch    s390
   - &um-arch      um
-triples:
-  - &arm-triple         {CROSS_COMPILE: arm-linux-gnueabi-,    ARCH: *arm-arch}
-  - &arm64-triple       {CROSS_COMPILE: aarch64-linux-gnu-,    ARCH: *arm64-arch}
-  - &hexagon-triple     {CROSS_COMPILE: hexagon-linux-musl-,   ARCH: *hexagon-arch}
-  - &i386-triple        {CROSS_COMPILE: "",                    ARCH: *i386-arch}
-  - &mips-triple        {CROSS_COMPILE: mips-linux-gnu-,       ARCH: *mips-arch}
-  - &mipsel-triple      {CROSS_COMPILE: mipsel-linux-gnu-,     ARCH: *mips-arch}
-  - &powerpc-triple     {CROSS_COMPILE: powerpc-linux-gnu-,    ARCH: *powerpc-arch}
-  - &powerpc64-triple   {CROSS_COMPILE: powerpc64-linux-gnu,   ARCH: *powerpc-arch}
-  - &powerpc64le-triple {CROSS_COMPILE: powerpc64le-linux-gnu, ARCH: *powerpc-arch}
-  - &riscv-triple       {CROSS_COMPILE: riscv64-linux-gnu,     ARCH: *riscv-arch}
-  - &s390-triple        {CROSS_COMPILE: s390x-linux-gnu,       ARCH: *s390-arch}
-  - &um-triple          {CROSS_COMPILE: "",                    ARCH: *um-arch}
 targets:
   - &default     {targets: [default]}
   - &kernel      {targets: [kernel]}
@@ -258,90 +245,90 @@ kasan_configs:
   - &arm64-kasan-configs    {config: [defconfig, CONFIG_FTRACE=y, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y]}
   - &arm64-kasan-sw-configs {config: [defconfig, CONFIG_FTRACE=y, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_SW_TAGS=y, CONFIG_KUNIT=y]}
 configs:
-  #                     config:                                                                                image target (optional)     [triples:] (Optional: x86)  targets to build
-  - &arm32_v5          {config: multi_v5_defconfig,                                                                                        << : *arm-triple,           << : *kernel_dtbs}
-  - &arm32_v6          {config: aspeed_g5_defconfig,                                                                                       << : *arm-triple,           << : *kernel_dtbs}
-  - &arm32_v7          {config: multi_v7_defconfig,                                                                                        << : *arm-triple,           << : *kernel}
-  - &arm32_v7_t        {config: [multi_v7_defconfig, CONFIG_THUMB2_KERNEL=y],                                                              << : *arm-triple,           << : *kernel}
-  - &arm32_imx         {config: imx_v4_v5_defconfig,                                                                                       << : *arm-triple,           << : *default}
-  - &arm32_omap        {config: omap2plus_defconfig,                                                                                       << : *arm-triple,           << : *default}
-  - &arm32_lpae_fp     {config: [multi_v7_defconfig, CONFIG_ARM_LPAE=y, CONFIG_UNWINDER_FRAME_POINTER=y],                                  << : *arm-triple,           << : *kernel}
-  - &arm32_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                                                           << : *arm-triple,           << : *default}
-  - &arm32_allno       {config: allnoconfig,                                                                                               << : *arm-triple,           << : *default}
-  - &arm32_allyes      {config: [allyesconfig, CONFIG_WERROR=n],                                                                           << : *arm-triple,           << : *default}
-  - &arm32_alpine      {config: *arm32-alpine-config-url,                                                                                  << : *arm-triple,           << : *kernel}
+  #                     config:                                                                                image target (optional)    [ARCH:] (Optional: x86)  targets to build
+  - &arm32_v5          {config: multi_v5_defconfig,                                                                                        ARCH: *arm-arch,        << : *kernel_dtbs}
+  - &arm32_v6          {config: aspeed_g5_defconfig,                                                                                       ARCH: *arm-arch,        << : *kernel_dtbs}
+  - &arm32_v7          {config: multi_v7_defconfig,                                                                                        ARCH: *arm-arch,        << : *kernel}
+  - &arm32_v7_t        {config: [multi_v7_defconfig, CONFIG_THUMB2_KERNEL=y],                                                              ARCH: *arm-arch,        << : *kernel}
+  - &arm32_imx         {config: imx_v4_v5_defconfig,                                                                                       ARCH: *arm-arch,        << : *default}
+  - &arm32_omap        {config: omap2plus_defconfig,                                                                                       ARCH: *arm-arch,        << : *default}
+  - &arm32_lpae_fp     {config: [multi_v7_defconfig, CONFIG_ARM_LPAE=y, CONFIG_UNWINDER_FRAME_POINTER=y],                                  ARCH: *arm-arch,        << : *kernel}
+  - &arm32_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                                                           ARCH: *arm-arch,        << : *default}
+  - &arm32_allno       {config: allnoconfig,                                                                                               ARCH: *arm-arch,        << : *default}
+  - &arm32_allyes      {config: [allyesconfig, CONFIG_WERROR=n],                                                                           ARCH: *arm-arch,        << : *default}
+  - &arm32_alpine      {config: *arm32-alpine-config-url,                                                                                  ARCH: *arm-arch,        << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
-  - &arm32_fedora      {config: [*arm32-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                          << : *arm-triple,           << : *kernel}
-  - &arm32_suse        {config: *arm32-suse-config-url,                                                                                    << : *arm-triple,           << : *kernel}
-  - &arm64             {config: defconfig,                                                                                                 << : *arm64-triple,         << : *kernel}
+  - &arm32_fedora      {config: [*arm32-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                          ARCH: *arm-arch,        << : *kernel}
+  - &arm32_suse        {config: *arm32-suse-config-url,                                                                                    ARCH: *arm-arch,        << : *kernel}
+  - &arm64             {config: defconfig,                                                                                                 ARCH: *arm64-arch,      << : *kernel}
   #                                         https://github.com/ClangBuiltLinux/linux/issues/595
-  - &arm64_no_vdso32   {config: [defconfig, CONFIG_COMPAT_VDSO=n],                                                                         << : *arm64-triple,         << : *kernel}
-  - &arm64be           {config: [defconfig, CONFIG_CPU_BIG_ENDIAN=y],                                                                      << : *arm64-triple,         << : *kernel}
-  - &arm64_cros        {<< : *arm64-cros-configs,                                                                                          << : *arm64-triple,         << : *kernel}
-  - &arm64_lto_full    {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                      << : *arm64-triple,         << : *kernel}
-  - &arm64_lto_thin    {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                      << : *arm64-triple,         << : *kernel}
-  - &arm64_cfi         {config: [defconfig, CONFIG_CFI_CLANG=y],                                                                           << : *arm64-triple,         << : *kernel}
-  - &arm64_cfi_lto     {config: [defconfig, CONFIG_CFI_CLANG=y, CONFIG_LTO_CLANG_THIN=y],                                                  << : *arm64-triple,         << : *kernel}
-  - &arm64_kasan       {<< : *arm64-kasan-configs,                                                                                         << : *arm64-triple,         << : *kernel}
-  - &arm64_kasan_sw    {<< : *arm64-kasan-sw-configs,                                                                                      << : *arm64-triple,         << : *kernel}
-  - &arm64_ubsan       {config: [defconfig, CONFIG_UBSAN=y],                                                                               << : *arm64-triple,         << : *kernel}
-  - &arm64_gki         {config: gki_defconfig,                                                                                             << : *arm64-triple,         << : *kernel}
-  - &arm64_cut         {config: cuttlefish_defconfig,                                                                                      << : *arm64-triple,         << : *kernel}
-  - &arm64_allmod      {config: allmodconfig,                                                                                              << : *arm64-triple,         << : *default}
-  - &arm64_allmod_lto  {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_LTO_CLANG_THIN=y],                             << : *arm64-triple,         << : *default}
-  - &arm64_allno       {config: allnoconfig,                                                                                               << : *arm64-triple,         << : *default}
-  - &arm64_allyes      {config: allyesconfig,                                                                                              << : *arm64-triple,         << : *default}
-  - &arm64_alpine      {config: *arm64-alpine-config-url,                                                                                  << : *arm64-triple,         << : *kernel}
+  - &arm64_no_vdso32   {config: [defconfig, CONFIG_COMPAT_VDSO=n],                                                                         ARCH: *arm64-arch,      << : *kernel}
+  - &arm64be           {config: [defconfig, CONFIG_CPU_BIG_ENDIAN=y],                                                                      ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_cros        {<< : *arm64-cros-configs,                                                                                          ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_lto_full    {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                      ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_lto_thin    {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                      ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_cfi         {config: [defconfig, CONFIG_CFI_CLANG=y],                                                                           ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_cfi_lto     {config: [defconfig, CONFIG_CFI_CLANG=y, CONFIG_LTO_CLANG_THIN=y],                                                  ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_kasan       {<< : *arm64-kasan-configs,                                                                                         ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_kasan_sw    {<< : *arm64-kasan-sw-configs,                                                                                      ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_ubsan       {config: [defconfig, CONFIG_UBSAN=y],                                                                               ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_gki         {config: gki_defconfig,                                                                                             ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_cut         {config: cuttlefish_defconfig,                                                                                      ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_allmod      {config: allmodconfig,                                                                                              ARCH: *arm64-arch,      << : *default}
+  - &arm64_allmod_lto  {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_LTO_CLANG_THIN=y],                             ARCH: *arm64-arch,      << : *default}
+  - &arm64_allno       {config: allnoconfig,                                                                                               ARCH: *arm64-arch,      << : *default}
+  - &arm64_allyes      {config: allyesconfig,                                                                                              ARCH: *arm64-arch,      << : *default}
+  - &arm64_alpine      {config: *arm64-alpine-config-url,                                                                                  ARCH: *arm64-arch,      << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
-  - &arm64_fedora      {config: [*arm64-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                          << : *arm64-triple,         << : *kernel}
+  - &arm64_fedora      {config: [*arm64-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                          ARCH: *arm64-arch,      << : *kernel}
   # CONFIG_DEBUG_INFO_BTF disabled for certain SUSE configs due to pahole issue: https://lore.kernel.org/r/20210506205622.3663956-1-kafai@fb.com/
-  - &arm64_suse        {config: [*arm64-suse-config-url, CONFIG_DEBUG_INFO_BTF=n],                                                         << : *arm64-triple,         << : *kernel}
-  - &hexagon           {config: defconfig,                                                                                                 << : *hexagon-triple,       << : *default}
-  - &hexagon_allmod    {config: [allmodconfig, CONFIG_WERROR=n],                                                                           << : *hexagon-triple,       << : *default}
-  - &i386              {config: defconfig,                                                                                                 << : *i386-triple,          << : *kernel}
-  - &i386_suse         {config: *i386-suse-config-url,                                                                                     << : *i386-triple,          << : *default}
-  - &mips              {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y, CONFIG_CPU_BIG_ENDIAN=y],           kernel_image: vmlinux,      << : *mips-triple,          << : *kernel}
-  - &mipsel            {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y],                                    kernel_image: vmlinux,      << : *mipsel-triple,        << : *kernel}
-  - &ppc32             {config: ppc44x_defconfig,                                                              kernel_image: uImage,       << : *powerpc-triple,       << : *kernel}
+  - &arm64_suse        {config: [*arm64-suse-config-url, CONFIG_DEBUG_INFO_BTF=n],                                                         ARCH: *arm64-arch,      << : *kernel}
+  - &hexagon           {config: defconfig,                                                                                                 ARCH: *hexagon-arch,    << : *default}
+  - &hexagon_allmod    {config: [allmodconfig, CONFIG_WERROR=n],                                                                           ARCH: *hexagon-arch,    << : *default}
+  - &i386              {config: defconfig,                                                                                                 ARCH: *i386-arch,       << : *kernel}
+  - &i386_suse         {config: *i386-suse-config-url,                                                                                     ARCH: *i386-arch,       << : *default}
+  - &mips              {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y, CONFIG_CPU_BIG_ENDIAN=y],           kernel_image: vmlinux,      ARCH: *mips-arch,       << : *kernel}
+  - &mipsel            {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y],                                    kernel_image: vmlinux,      ARCH: *mips-arch,       << : *kernel}
+  - &ppc32             {config: ppc44x_defconfig,                                                              kernel_image: uImage,       ARCH: *powerpc-arch,    << : *kernel}
   # Disable -Werror for pseries_defconfig for now: https://github.com/ClangBuiltLinux/linux/issues/1445
-  - &ppc64             {config: [pseries_defconfig, CONFIG_PPC_DISABLE_WERROR=y],                              kernel_image: vmlinux,      << : *powerpc64-triple,     << : *kernel}
-  - &ppc64le           {config: powernv_defconfig,                                                             kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel}
+  - &ppc64             {config: [pseries_defconfig, CONFIG_PPC_DISABLE_WERROR=y],                              kernel_image: vmlinux,      ARCH: *powerpc-arch,    << : *kernel}
+  - &ppc64le           {config: powernv_defconfig,                                                             kernel_image: zImage.epapr, ARCH: *powerpc-arch,    << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
-  - &ppc64le_fedora    {config: [*ppc64le-fedora-config-url, CONFIG_BPF_PRELOAD=n],                            kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel}
-  - &ppc64le_suse      {config: *ppc64le-suse-config-url,                                                      kernel_image: zImage.epapr, << : *powerpc64le-triple,   << : *kernel}
-  - &ppc64_allmod      {config: [allmodconfig, CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y, CONFIG_WERROR=n],                                     << : *powerpc64-triple,     << : *default}
-  - &riscv             {config: defconfig,                                                                     kernel_image: Image,        << : *riscv-triple,         << : *kernel}
-  - &riscv_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                               kernel_image: Image,        << : *riscv-triple,         << : *default}
+  - &ppc64le_fedora    {config: [*ppc64le-fedora-config-url, CONFIG_BPF_PRELOAD=n],                            kernel_image: zImage.epapr, ARCH: *powerpc-arch,    << : *kernel}
+  - &ppc64le_suse      {config: *ppc64le-suse-config-url,                                                      kernel_image: zImage.epapr, ARCH: *powerpc-arch,    << : *kernel}
+  - &ppc64_allmod      {config: [allmodconfig, CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y, CONFIG_WERROR=n],                                     ARCH: *powerpc-arch,    << : *default}
+  - &riscv             {config: defconfig,                                                                     kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
+  - &riscv_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                               kernel_image: Image,        ARCH: *riscv-arch,      << : *default}
   #                                         https://github.com/ClangBuiltLinux/linux/issues/1143
-  - &riscv_no_efi      {config: [defconfig, CONFIG_EFI=n],                                                     kernel_image: Image,        << : *riscv-triple,         << : *kernel}
-  - &riscv_alpine      {config: *riscv-alpine-config-url,                                                      kernel_image: Image,        << : *riscv-triple,         << : *kernel}
-  - &riscv_suse        {config: *riscv-suse-config-url,                                                        kernel_image: Image,        << : *riscv-triple,         << : *kernel}
-  - &s390              {config: defconfig,                                                                                                 << : *s390-triple,          << : *kernel}
-  - &s390_kasan        {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],            << : *s390-triple,          << : *kernel}
+  - &riscv_no_efi      {config: [defconfig, CONFIG_EFI=n],                                                     kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
+  - &riscv_alpine      {config: *riscv-alpine-config-url,                                                      kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
+  - &riscv_suse        {config: *riscv-suse-config-url,                                                        kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
+  - &s390              {config: defconfig,                                                                                                 ARCH: *s390-arch,       << : *kernel}
+  - &s390_kasan        {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],            ARCH: *s390-arch,       << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
-  - &s390_fedora       {config: [*s390-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                           << : *s390-triple,          << : *kernel}
-  - &s390_suse         {config: *s390-suse-config-url,                                                                                     << : *s390-triple,          << : *kernel}
-  - &um                {config: defconfig,                                                                                                 << : *um-triple,            << : *kernel}
-  - &x86_64            {config: defconfig,                                                                                                                             << : *kernel}
-  - &x86_64_lto_full   {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                                                  << : *kernel}
-  - &x86_64_lto_thin   {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                                                  << : *kernel}
-  - &x86_64_cfi        {config: [defconfig, CONFIG_CFI_CLANG=y],                                                                                                       << : *kernel}
-  - &x86_64_cfi_lto    {config: [defconfig, CONFIG_CFI_CLANG=y, CONFIG_LTO_CLANG_THIN=y],                                                                              << : *kernel}
-  - &x86_64_cros       {<< : *x86_64-cros-configs,                                                                                                                     << : *kernel}
-  - &x86_64_gki        {config: gki_defconfig,                                                                                                                         << : *kernel}
-  - &x86_64_cut        {config: x86_64_cuttlefish_defconfig,                                                                                                           << : *kernel}
-  - &x86_64_allmod     {config: allmodconfig,                                                                                                                          << : *default}
-  - &x86_64_allmod_lto {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_LTO_CLANG_THIN=y],                                                         << : *default}
-  - &x86_64_allno      {config: allnoconfig,                                                                                                                           << : *default}
-  - &x86_64_allyes     {config: allyesconfig,                                                                                                                          << : *default}
-  - &x86_64_gcov       {config: [defconfig, CONFIG_GCOV_KERNEL=y, CONFIG_GCOV_PROFILE_ALL=y],                                                                          << : *kernel}
-  - &x86_64_kasan      {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],                                        << : *kernel}
-  - &x86_64_kcsan      {config: [defconfig, CONFIG_KCSAN=y, CONFIG_KCSAN_KUNIT_TEST=y, CONFIG_KUNIT=y],                                                                << : *kernel}
-  - &x86_64_ubsan      {config: [defconfig, CONFIG_UBSAN=y],                                                                                                           << : *kernel}
-  - &x86_64_alpine     {config: *x86_64-alpine-config-url,                                                                                                             << : *kernel}
-  - &x86_64_arch       {config: *x86_64-arch-config-url,                                                                                                               << : *kernel}
-  - &x86_64_fedora     {config: *x86_64-fedora-config-url,                                                                                                             << : *kernel}
-  - &x86_64_suse       {config: *x86_64-suse-config-url,                                                                                                               << : *kernel}
+  - &s390_fedora       {config: [*s390-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                           ARCH: *s390-arch,       << : *kernel}
+  - &s390_suse         {config: *s390-suse-config-url,                                                                                     ARCH: *s390-arch,       << : *kernel}
+  - &um                {config: defconfig,                                                                                                 ARCH: *um-arch,         << : *kernel}
+  - &x86_64            {config: defconfig,                                                                                                                         << : *kernel}
+  - &x86_64_lto_full   {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                                              << : *kernel}
+  - &x86_64_lto_thin   {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                                              << : *kernel}
+  - &x86_64_cfi        {config: [defconfig, CONFIG_CFI_CLANG=y],                                                                                                   << : *kernel}
+  - &x86_64_cfi_lto    {config: [defconfig, CONFIG_CFI_CLANG=y, CONFIG_LTO_CLANG_THIN=y],                                                                          << : *kernel}
+  - &x86_64_cros       {<< : *x86_64-cros-configs,                                                                                                                 << : *kernel}
+  - &x86_64_gki        {config: gki_defconfig,                                                                                                                     << : *kernel}
+  - &x86_64_cut        {config: x86_64_cuttlefish_defconfig,                                                                                                       << : *kernel}
+  - &x86_64_allmod     {config: allmodconfig,                                                                                                                      << : *default}
+  - &x86_64_allmod_lto {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_LTO_CLANG_THIN=y],                                                     << : *default}
+  - &x86_64_allno      {config: allnoconfig,                                                                                                                       << : *default}
+  - &x86_64_allyes     {config: allyesconfig,                                                                                                                      << : *default}
+  - &x86_64_gcov       {config: [defconfig, CONFIG_GCOV_KERNEL=y, CONFIG_GCOV_PROFILE_ALL=y],                                                                      << : *kernel}
+  - &x86_64_kasan      {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],                                    << : *kernel}
+  - &x86_64_kcsan      {config: [defconfig, CONFIG_KCSAN=y, CONFIG_KCSAN_KUNIT_TEST=y, CONFIG_KUNIT=y],                                                            << : *kernel}
+  - &x86_64_ubsan      {config: [defconfig, CONFIG_UBSAN=y],                                                                                                       << : *kernel}
+  - &x86_64_alpine     {config: *x86_64-alpine-config-url,                                                                                                         << : *kernel}
+  - &x86_64_arch       {config: *x86_64-arch-config-url,                                                                                                           << : *kernel}
+  - &x86_64_fedora     {config: *x86_64-fedora-config-url,                                                                                                         << : *kernel}
+  - &x86_64_suse       {config: *x86_64-suse-config-url,                                                                                                           << : *kernel}
 tiers:
   # Generic tiers       LLVM=1       LLVM_IAS=1        Make variables to pass to TuxSuite
   - &llvm_full          {llvm: true,  llvm_ias: true,  make_variables: {LLVM: 1, LLVM_IAS: 1}}


### PR DESCRIPTION
https://lore.kernel.org/llvm/20230401170117.1580840-1-masahiroy@kernel.org/ reminded me that we probably don't need to set CROSS_COMPILE any more. Nathan confirmed that tuxsuite doesn't allow setting this, and that these triples aren't consumed or emitted by generate.py.