### PR TITLE
Disable RISC-V gki_defconfig with llvm_android for now

### DIFF
--- a/.github/workflows/android-mainline-clang-android.yml
+++ b/.github/workflows/android-mainline-clang-android.yml
@@ -75,27 +75,6 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _a84110171ba256e7841d0a1808611e52:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+64-bit.config+gki.config
-    env:
-      ARCH: riscv
-      LLVM_VERSION: android
-      BOOT: 1
-      CONFIG: gki_defconfig+64-bit.config+gki.config
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _e8eaa6c4609c31891f40230b3aa2339f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/generator.yml
+++ b/generator.yml
@@ -3383,7 +3383,8 @@ builds:
   - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, << : *llvm_android}
   - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
   - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
-  - {<< : *riscv_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
+  # riscv_gki disabled until tuxsuite properly supports it: https://github.com/ClangBuiltLinux/continuous-integration2/issues/556
+  # - {<< : *riscv_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
   - {<< : *arm32_allmod,      << : *android14-5_15,   << : *llvm_full,       boot: false, << : *llvm_android}
   - {<< : *arm32_v7_t,        << : *android14-5_15,   << : *llvm_full,       boot: true,  << : *llvm_android}

--- a/tuxsuite/android-mainline-clang-android.tux.yml
+++ b/tuxsuite/android-mainline-clang-android.tux.yml
@@ -31,18 +31,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: riscv
-    toolchain: clang-android
-    kconfig:
-    - gki_defconfig
-    - 64-bit.config
-    - gki.config
-    targets:
-    - kernel
-    kernel_image: Image
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-android
     kconfig: gki_defconfig


### PR DESCRIPTION
Link: https://github.com/ClangBuiltLinux/continuous-integration2/issues/556
