### PR TITLE
Fix ChromeOS boot testing

### DIFF
--- a/.github/workflows/chromeos-5.10-clang-12.yml
+++ b/.github/workflows/chromeos-5.10-clang-12.yml
@@ -33,15 +33,15 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  _e7ae88f2477be7c2a0091d6ac55d4ea1:
+  _17de81744156a95fda35864bb478d05d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -54,15 +54,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _c2223ae17627d3ac3ca928be5d5b2eb1:
+  _131cfb520cd1e8f563fc59232db16422:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/chromeos-5.10-clang-13.yml
+++ b/.github/workflows/chromeos-5.10-clang-13.yml
@@ -33,15 +33,15 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  _05bbbf8cf9e223c1ac9169bb92e8ae61:
+  _af1efbcbd39ff43b352a6e8edf4ad3b2:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -54,15 +54,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _bdf80a4aa66677b6a5e7b0bea831512b:
+  _fc424a46dad91bc66f3f86d135f8af11:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/chromeos-5.10-clang-14.yml
+++ b/.github/workflows/chromeos-5.10-clang-14.yml
@@ -33,15 +33,15 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  _cfc1a1cb0eb857521422f1c94c6463e6:
+  _ba0405fc73f16ae6a9868701e4c950dc:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -54,15 +54,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ddbccfcffb83310bca0e7b1f5f48397b:
+  _9e03668c5b3338c9682b2b878a07c95b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/chromeos-5.10-clang-15.yml
+++ b/.github/workflows/chromeos-5.10-clang-15.yml
@@ -33,15 +33,15 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  _b2bc2e58c295bb3a09d49521768e8fde:
+  _31ee3d731e865b2146f75f090b33f956:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -54,15 +54,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _7b55b1e60f66604dead64940c8a187ac:
+  _a56c30895b9968505227e3e7fb1a747e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/chromeos-5.10-clang-16.yml
+++ b/.github/workflows/chromeos-5.10-clang-16.yml
@@ -33,15 +33,15 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  _c137518c12e95b590a7480708cfa9df0:
+  _f1768ac7892d6bd62769977642fe5001:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: arm64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -54,15 +54,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _44acd999117064972b94bc434a6aede2:
+  _f4b5735ed34b157b0bdaab7bb7be54d0:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/chromeos-5.10-clang-17.yml
+++ b/.github/workflows/chromeos-5.10-clang-17.yml
@@ -33,15 +33,15 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  _b88c465de0b7765732bdd57d507ff833:
+  _20c17b15ee9b3076b6a29bf6811b0633:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -54,15 +54,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _1cdac7b0607b643a6a8c8f9ce22bb8d4:
+  _7b2465900a113fc27ea8e9c2d030af14:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/chromeos-5.15-clang-12.yml
+++ b/.github/workflows/chromeos-5.15-clang-12.yml
@@ -33,15 +33,15 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  _e7ae88f2477be7c2a0091d6ac55d4ea1:
+  _17de81744156a95fda35864bb478d05d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -54,15 +54,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _c2223ae17627d3ac3ca928be5d5b2eb1:
+  _131cfb520cd1e8f563fc59232db16422:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/chromeos-5.15-clang-13.yml
+++ b/.github/workflows/chromeos-5.15-clang-13.yml
@@ -33,15 +33,15 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  _05bbbf8cf9e223c1ac9169bb92e8ae61:
+  _af1efbcbd39ff43b352a6e8edf4ad3b2:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -54,15 +54,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _bdf80a4aa66677b6a5e7b0bea831512b:
+  _fc424a46dad91bc66f3f86d135f8af11:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/chromeos-5.15-clang-14.yml
+++ b/.github/workflows/chromeos-5.15-clang-14.yml
@@ -33,15 +33,15 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  _cfc1a1cb0eb857521422f1c94c6463e6:
+  _ba0405fc73f16ae6a9868701e4c950dc:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -54,15 +54,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ddbccfcffb83310bca0e7b1f5f48397b:
+  _9e03668c5b3338c9682b2b878a07c95b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/chromeos-5.15-clang-15.yml
+++ b/.github/workflows/chromeos-5.15-clang-15.yml
@@ -33,15 +33,15 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  _b2bc2e58c295bb3a09d49521768e8fde:
+  _31ee3d731e865b2146f75f090b33f956:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -54,15 +54,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _7b55b1e60f66604dead64940c8a187ac:
+  _a56c30895b9968505227e3e7fb1a747e:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/chromeos-5.15-clang-16.yml
+++ b/.github/workflows/chromeos-5.15-clang-16.yml
@@ -33,15 +33,15 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  _c137518c12e95b590a7480708cfa9df0:
+  _f1768ac7892d6bd62769977642fe5001:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: arm64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -54,15 +54,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _44acd999117064972b94bc434a6aede2:
+  _f4b5735ed34b157b0bdaab7bb7be54d0:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/chromeos-5.15-clang-17.yml
+++ b/.github/workflows/chromeos-5.15-clang-17.yml
@@ -33,15 +33,15 @@ jobs:
         path: builds.json
         name: output_artifact_defconfigs
         if-no-files-found: error
-  _b88c465de0b7765732bdd57d507ff833:
+  _20c17b15ee9b3076b6a29bf6811b0633:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host
@@ -54,15 +54,15 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _1cdac7b0607b643a6a8c8f9ce22bb8d4:
+  _7b2465900a113fc27ea8e9c2d030af14:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/generator.yml
+++ b/generator.yml
@@ -239,8 +239,8 @@ targets:
   - &kernel      {targets: [kernel]}
   - &kernel_dtbs {targets: [kernel,dtbs]}
 chromeos_configs:
-  - &arm64-cros-configs  {config: [chromeos/config/chromeos/base.config, chromeos/config/chromeos/arm64/common.config, chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config]}
-  - &x86_64-cros-configs {config: [chromeos/config/chromeos/base.config, chromeos/config/chromeos/x86_64/common.config, chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config]}
+  - &arm64-cros-configs  {config: [chromeos/config/chromeos/base.config, chromeos/config/chromeos/arm64/common.config, chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config, CONFIG_SECURITY_CHROMIUMOS=n]}
+  - &x86_64-cros-configs {config: [chromeos/config/chromeos/base.config, chromeos/config/chromeos/x86_64/common.config, chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config, CONFIG_SECURITY_CHROMIUMOS=n]}
 kasan_configs:
   - &arm64-kasan-configs    {config: [defconfig, CONFIG_FTRACE=y, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y]}
   - &arm64-kasan-sw-configs {config: [defconfig, CONFIG_FTRACE=y, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_SW_TAGS=y, CONFIG_KUNIT=y]}

--- a/tuxsuite/chromeos-5.10-clang-12.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-12.tux.yml
@@ -18,6 +18,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
     - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:
@@ -29,6 +30,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config
     - chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/chromeos-5.10-clang-13.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-13.tux.yml
@@ -18,6 +18,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
     - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:
@@ -29,6 +30,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config
     - chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/chromeos-5.10-clang-14.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-14.tux.yml
@@ -18,6 +18,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
     - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:
@@ -29,6 +30,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config
     - chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/chromeos-5.10-clang-15.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-15.tux.yml
@@ -18,6 +18,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
     - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:
@@ -29,6 +30,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config
     - chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/chromeos-5.10-clang-16.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-16.tux.yml
@@ -18,6 +18,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
     - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:
@@ -29,6 +30,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config
     - chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/chromeos-5.10-clang-17.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-17.tux.yml
@@ -18,6 +18,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
     - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:
@@ -29,6 +30,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config
     - chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/chromeos-5.15-clang-12.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-12.tux.yml
@@ -18,6 +18,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
     - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:
@@ -29,6 +30,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config
     - chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/chromeos-5.15-clang-13.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-13.tux.yml
@@ -18,6 +18,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
     - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:
@@ -29,6 +30,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config
     - chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/chromeos-5.15-clang-14.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-14.tux.yml
@@ -18,6 +18,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
     - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:
@@ -29,6 +30,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config
     - chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/chromeos-5.15-clang-15.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-15.tux.yml
@@ -18,6 +18,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
     - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:
@@ -29,6 +30,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config
     - chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/chromeos-5.15-clang-16.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-16.tux.yml
@@ -18,6 +18,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
     - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:
@@ -29,6 +30,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config
     - chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/chromeos-5.15-clang-17.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-17.tux.yml
@@ -18,6 +18,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
     - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:
@@ -29,6 +30,7 @@ jobs:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config
     - chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config
+    - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel
     make_variables:


### PR DESCRIPTION
Our CrOS configurations have been failing to boot for quite some time
with:

```
[    1.934702] Freeing unused kernel memory: 1664K
[    1.937104] Run /init as init process
[    1.938678] audit: type=1400 audit(1.844:2): ChromeOS LSM: memfd execution attempt, cmd=(null), pid=1
[    1.939082] Chromium OS LSM: memfd execution blocked
[    1.939726] Failed to execute /init (error -13)
[    1.940373] Run /sbin/init as init process
[    1.943098] audit: type=1400 audit(1.849:3): ChromeOS LSM: memfd execution attempt, cmd=(null), pid=1
[    1.943460] Chromium OS LSM: memfd execution blocked
[    1.944104] Starting init: /sbin/init exists but couldn't execute it (error -13)
[    1.944424] Run /etc/init as init process
[    1.945941] Run /bin/init as init process
[    1.946948] Run /bin/sh as init process
[    1.947996] audit: type=1400 audit(1.854:4): ChromeOS LSM: memfd execution attempt, cmd=(null), pid=1
[    1.948368] Chromium OS LSM: memfd execution blocked
[    1.948724] Starting init: /bin/sh exists but couldn't execute it (error -13)
[    1.949967] Kernel panic - not syncing: No working init found.  Try passing init= option to kernel. See Linux Documentation/admin-guide/init.rst for guidance.
[    1.950717] CPU: 0 PID: 1 Comm: swapper/0 Not tainted 5.15.107 #1 fb2203b973e26ad3e97ed43395a9088e83086f27
[    1.951212] Hardware name: linux,dummy-virt (DT)
[    1.951652] Call trace:
[    1.951799]  dump_backtrace+0x0/0x1e4
[    1.952553]  show_stack+0x20/0x2c
[    1.952728]  dump_stack_lvl+0x60/0x78
[    1.952934]  dump_stack+0x18/0x38
[    1.953127]  panic+0x158/0x38c
[    1.953268]  kernel_init+0xfc/0x124
[    1.953455]  ret_from_fork+0x10/0x20
[    1.954058] Kernel Offset: 0x198f800000 from 0xffffffc008000000
[    1.954284] PHYS_OFFSET: 0x40000000
[    1.954484] CPU features: 0x00000341,ff354eea
```

The ChromeOS LSM refuses to allow memfd calls after the commit linked
below with no way to opt out of it so just disable the whole LSM to fix
our boot testing.

Link: https://chromium.googlesource.com/chromiumos/third_party/kernel/+/1e07acb18f10e71835032b7117c09eb927ae9838
