### PR TITLE
Add PowerPC allmodconfig build for mainline with LLVM 15+

### DIFF
--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -1222,6 +1222,27 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _516fac05d5416a9f78740a10f02ebe3f:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n
+    env:
+      ARCH: powerpc
+      LLVM_VERSION: 15
+      BOOT: 0
+      CONFIG: allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _5173235a7c271979a177be1eb5cb40b0:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs

--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -1306,6 +1306,27 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _746c6cc9d865631749721e0b69fa26e8:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n
+    env:
+      ARCH: powerpc
+      LLVM_VERSION: 16
+      BOOT: 0
+      CONFIG: allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _fbc0af0db8490a9977f5e99915bf441a:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs

--- a/.github/workflows/mainline-clang-17.yml
+++ b/.github/workflows/mainline-clang-17.yml
@@ -1306,6 +1306,27 @@ jobs:
         name: output_artifact_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _fba586c9a687192e653123eeeab7d2e3:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_allconfigs
+    name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n
+    env:
+      ARCH: powerpc
+      LLVM_VERSION: 17
+      BOOT: 0
+      CONFIG: allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _6ee344b20402930df88a0227d01bbe27:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs

--- a/generator.yml
+++ b/generator.yml
@@ -396,6 +396,7 @@ builds:
   - {<< : *ppc64le,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *ppc64le_fedora,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *ppc64le_suse,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *ppc64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *riscv,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *riscv_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -864,6 +865,7 @@ builds:
   - {<< : *ppc64le,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *ppc64le_fedora,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *ppc64le_suse,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *ppc64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *riscv,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *riscv_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -1330,6 +1332,7 @@ builds:
   - {<< : *ppc64le,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *ppc64le_fedora,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *ppc64le_suse,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
+  - {<< : *ppc64_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *riscv,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *riscv_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}

--- a/tuxsuite/mainline-clang-15.tux.yml
+++ b/tuxsuite/mainline-clang-15.tux.yml
@@ -536,6 +536,17 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: powerpc
+    toolchain: clang-15
+    kconfig:
+    - allmodconfig
+    - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
+    - CONFIG_WERROR=n
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
   - target_arch: riscv
     toolchain: clang-15
     kconfig:

--- a/tuxsuite/mainline-clang-16.tux.yml
+++ b/tuxsuite/mainline-clang-16.tux.yml
@@ -578,6 +578,17 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: powerpc
+    toolchain: clang-16
+    kconfig:
+    - allmodconfig
+    - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
+    - CONFIG_WERROR=n
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
   - target_arch: riscv
     toolchain: clang-16
     kconfig:

--- a/tuxsuite/mainline-clang-17.tux.yml
+++ b/tuxsuite/mainline-clang-17.tux.yml
@@ -578,6 +578,17 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: powerpc
+    toolchain: clang-nightly
+    kconfig:
+    - allmodconfig
+    - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
+    - CONFIG_WERROR=n
+    targets:
+    - default
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
   - target_arch: riscv
     toolchain: clang-nightly
     kconfig:


### PR DESCRIPTION
Now that my series to allow big endian ELFv2 to be selected with ld.lld
has been merged into mainline, we can start testing powerpc64
allmodconfig like -next, mirroring commit e4abcea ("generator: Add
PowerPC allmodconfig build").

This adds 25 builds per week:

```
diff --git a/tmp/estimate-builds.txt b/tmp/.psub.JyBf7GilsO
index 017dbea..b21671c 100644
--- a/tmp/estimate-builds.txt
+++ b/tmp/.psub.JyBf7GilsO
@@ -1,11 +1,11 @@
-Total builds per week: 8232
+Total builds per week: 8257

   - tree: mainline
-    total: 2925
+    total: 2950
     breakdown:
-    - clang-17: 640
-    - clang-16: 640
-    - clang-15: 300
+    - clang-17: 650
+    - clang-16: 650
+    - clang-15: 305
     - clang-14: 280
     - clang-13: 280
     - clang-12: 265
```
