### PR TITLE
re-enable riscv_gki builds with llvm_android

### DIFF
--- a/.github/workflows/android-mainline-clang-android.yml
+++ b/.github/workflows/android-mainline-clang-android.yml
@@ -75,6 +75,27 @@ jobs:
         name: output_artifact_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _a84110171ba256e7841d0a1808611e52:
+    runs-on: ubuntu-latest
+    needs: kick_tuxsuite_defconfigs
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+64-bit.config+gki.config
+    env:
+      ARCH: riscv
+      LLVM_VERSION: android
+      BOOT: 1
+      CONFIG: gki_defconfig+64-bit.config+gki.config
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _e8eaa6c4609c31891f40230b3aa2339f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/generator.yml
+++ b/generator.yml
@@ -3383,8 +3383,7 @@ builds:
   - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, << : *llvm_android}
   - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
   - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
-  # riscv_gki disabled until tuxsuite properly supports it: https://github.com/ClangBuiltLinux/continuous-integration2/issues/556
-  # - {<< : *riscv_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
+  - {<< : *riscv_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
   - {<< : *arm32_allmod,      << : *android14-5_15,   << : *llvm_full,       boot: false, << : *llvm_android}
   - {<< : *arm32_v7_t,        << : *android14-5_15,   << : *llvm_full,       boot: true,  << : *llvm_android}

--- a/tuxsuite/android-mainline-clang-android.tux.yml
+++ b/tuxsuite/android-mainline-clang-android.tux.yml
@@ -30,6 +30,18 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: riscv
+    toolchain: clang-android
+    kconfig:
+    - gki_defconfig
+    - 64-bit.config
+    - gki.config
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-android
     kconfig: gki_defconfig


### PR DESCRIPTION
```diff
--- before.txt	2023-05-23 10:31:59.266672171 -0700
+++ after.txt	2023-05-23 10:31:46.806634649 -0700
@@ -1,4 +1,4 @@
-Total builds per week: 8257
+Total builds per week: 8262
 
   - tree: mainline
     total: 2950
@@ -101,7 +101,7 @@
     - clang-11: 20
 
   - tree: android-mainline
-    total: 90
+    total: 95
     breakdown:
     - clang-17: 25
     - clang-16: 25
@@ -109,7 +109,7 @@
     - clang-14: 5
     - clang-13: 5
     - clang-12: 5
-    - clang-android: 20
+    - clang-android: 25
 
   - tree: android14-5.15
     total: 76
```