### PR TITLE
Update Arch Linux x86_64 configuration link

### DIFF
--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -827,15 +827,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _8f357523d123bc85ac5e9d9a752e8a17:
+  _a03e00c8730a364f4ed614bf70b8e414:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -890,15 +890,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _6f25f53bece84b18b9d20700a1a6cba2:
+  _3ca88451e6dfb31c342fbb30240f2446:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -995,15 +995,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _cd3a9116f9c669b21bb4476766660a71:
+  _417a2a32449d514b66acb4f23450f5a8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -995,15 +995,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _4295d6942bf6d93fad93458fcc60d014:
+  _ee311b97a0cc7a44d99b9921ea9b8024:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -995,15 +995,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _9179d3c2d4ef8363ea00c72e1f66f517:
+  _eeefcd050b74da92c78fd3172f65a3c8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-16.yml
+++ b/.github/workflows/5.15-clang-16.yml
@@ -995,15 +995,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b8257cb04fc22a5bf72b46294e749c0c:
+  _76f5002d97faf5ac9992c0a5bdb0c2d7:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-17.yml
+++ b/.github/workflows/5.15-clang-17.yml
@@ -995,15 +995,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ba2745a60a62014755fc38b638cca55b:
+  _4073203e6a06e345c0c87e617f856a90:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/6.1-clang-11.yml
+++ b/.github/workflows/6.1-clang-11.yml
@@ -848,15 +848,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _8f357523d123bc85ac5e9d9a752e8a17:
+  _a03e00c8730a364f4ed614bf70b8e414:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/6.1-clang-12.yml
+++ b/.github/workflows/6.1-clang-12.yml
@@ -869,15 +869,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _6f25f53bece84b18b9d20700a1a6cba2:
+  _3ca88451e6dfb31c342fbb30240f2446:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/6.1-clang-13.yml
+++ b/.github/workflows/6.1-clang-13.yml
@@ -890,15 +890,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _cd3a9116f9c669b21bb4476766660a71:
+  _417a2a32449d514b66acb4f23450f5a8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/6.1-clang-14.yml
+++ b/.github/workflows/6.1-clang-14.yml
@@ -890,15 +890,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _4295d6942bf6d93fad93458fcc60d014:
+  _ee311b97a0cc7a44d99b9921ea9b8024:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/6.1-clang-15.yml
+++ b/.github/workflows/6.1-clang-15.yml
@@ -974,15 +974,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _9179d3c2d4ef8363ea00c72e1f66f517:
+  _eeefcd050b74da92c78fd3172f65a3c8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/6.1-clang-16.yml
+++ b/.github/workflows/6.1-clang-16.yml
@@ -1058,15 +1058,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b8257cb04fc22a5bf72b46294e749c0c:
+  _76f5002d97faf5ac9992c0a5bdb0c2d7:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/6.1-clang-17.yml
+++ b/.github/workflows/6.1-clang-17.yml
@@ -1058,15 +1058,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ba2745a60a62014755fc38b638cca55b:
+  _4073203e6a06e345c0c87e617f856a90:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-11.yml
+++ b/.github/workflows/mainline-clang-11.yml
@@ -848,15 +848,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _8f357523d123bc85ac5e9d9a752e8a17:
+  _a03e00c8730a364f4ed614bf70b8e414:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-12.yml
+++ b/.github/workflows/mainline-clang-12.yml
@@ -869,15 +869,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _6f25f53bece84b18b9d20700a1a6cba2:
+  _3ca88451e6dfb31c342fbb30240f2446:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-13.yml
+++ b/.github/workflows/mainline-clang-13.yml
@@ -890,15 +890,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _cd3a9116f9c669b21bb4476766660a71:
+  _417a2a32449d514b66acb4f23450f5a8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -890,15 +890,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _4295d6942bf6d93fad93458fcc60d014:
+  _ee311b97a0cc7a44d99b9921ea9b8024:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -974,15 +974,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _9179d3c2d4ef8363ea00c72e1f66f517:
+  _eeefcd050b74da92c78fd3172f65a3c8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -1058,15 +1058,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b8257cb04fc22a5bf72b46294e749c0c:
+  _76f5002d97faf5ac9992c0a5bdb0c2d7:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-17.yml
+++ b/.github/workflows/mainline-clang-17.yml
@@ -1058,15 +1058,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ba2745a60a62014755fc38b638cca55b:
+  _4073203e6a06e345c0c87e617f856a90:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-11.yml
+++ b/.github/workflows/next-clang-11.yml
@@ -848,15 +848,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _8f357523d123bc85ac5e9d9a752e8a17:
+  _a03e00c8730a364f4ed614bf70b8e414:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-12.yml
+++ b/.github/workflows/next-clang-12.yml
@@ -869,15 +869,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _6f25f53bece84b18b9d20700a1a6cba2:
+  _3ca88451e6dfb31c342fbb30240f2446:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-13.yml
+++ b/.github/workflows/next-clang-13.yml
@@ -911,15 +911,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _cd3a9116f9c669b21bb4476766660a71:
+  _417a2a32449d514b66acb4f23450f5a8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -911,15 +911,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _4295d6942bf6d93fad93458fcc60d014:
+  _ee311b97a0cc7a44d99b9921ea9b8024:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -995,15 +995,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _9179d3c2d4ef8363ea00c72e1f66f517:
+  _eeefcd050b74da92c78fd3172f65a3c8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -1079,15 +1079,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b8257cb04fc22a5bf72b46294e749c0c:
+  _76f5002d97faf5ac9992c0a5bdb0c2d7:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-17.yml
+++ b/.github/workflows/next-clang-17.yml
@@ -1079,15 +1079,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ba2745a60a62014755fc38b638cca55b:
+  _4073203e6a06e345c0c87e617f856a90:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-11.yml
+++ b/.github/workflows/stable-clang-11.yml
@@ -848,15 +848,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _8f357523d123bc85ac5e9d9a752e8a17:
+  _a03e00c8730a364f4ed614bf70b8e414:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-12.yml
+++ b/.github/workflows/stable-clang-12.yml
@@ -869,15 +869,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _6f25f53bece84b18b9d20700a1a6cba2:
+  _3ca88451e6dfb31c342fbb30240f2446:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -890,15 +890,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _cd3a9116f9c669b21bb4476766660a71:
+  _417a2a32449d514b66acb4f23450f5a8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -890,15 +890,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _4295d6942bf6d93fad93458fcc60d014:
+  _ee311b97a0cc7a44d99b9921ea9b8024:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -974,15 +974,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _9179d3c2d4ef8363ea00c72e1f66f517:
+  _eeefcd050b74da92c78fd3172f65a3c8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-16.yml
+++ b/.github/workflows/stable-clang-16.yml
@@ -1058,15 +1058,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b8257cb04fc22a5bf72b46294e749c0c:
+  _76f5002d97faf5ac9992c0a5bdb0c2d7:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-17.yml
+++ b/.github/workflows/stable-clang-17.yml
@@ -1058,15 +1058,15 @@ jobs:
         name: output_artifact_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ba2745a60a62014755fc38b638cca55b:
+  _4073203e6a06e345c0c87e617f856a90:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+      CONFIG: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/generator.yml
+++ b/generator.yml
@@ -31,7 +31,7 @@ urls:
   - &s390-fedora-config-url    https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
   - &s390-suse-config-url      https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
   - &x86_64-alpine-config-url  https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
-  - &x86_64-arch-config-url    https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+  - &x86_64-arch-config-url    https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
   - &x86_64-fedora-config-url  https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
   - &x86_64-suse-config-url    https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
 schedules:

--- a/tuxsuite/5.15-clang-11.tux.yml
+++ b/tuxsuite/5.15-clang-11.tux.yml
@@ -373,7 +373,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-11
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/5.15-clang-12.tux.yml
+++ b/tuxsuite/5.15-clang-12.tux.yml
@@ -404,7 +404,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-12
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/5.15-clang-13.tux.yml
+++ b/tuxsuite/5.15-clang-13.tux.yml
@@ -448,7 +448,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-13
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/5.15-clang-14.tux.yml
+++ b/tuxsuite/5.15-clang-14.tux.yml
@@ -448,7 +448,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-14
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/5.15-clang-15.tux.yml
+++ b/tuxsuite/5.15-clang-15.tux.yml
@@ -448,7 +448,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-15
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/5.15-clang-16.tux.yml
+++ b/tuxsuite/5.15-clang-16.tux.yml
@@ -448,7 +448,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-16
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/5.15-clang-17.tux.yml
+++ b/tuxsuite/5.15-clang-17.tux.yml
@@ -448,7 +448,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/6.1-clang-11.tux.yml
+++ b/tuxsuite/6.1-clang-11.tux.yml
@@ -381,7 +381,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-11
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/6.1-clang-12.tux.yml
+++ b/tuxsuite/6.1-clang-12.tux.yml
@@ -392,7 +392,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-12
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/6.1-clang-13.tux.yml
+++ b/tuxsuite/6.1-clang-13.tux.yml
@@ -401,7 +401,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-13
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/6.1-clang-14.tux.yml
+++ b/tuxsuite/6.1-clang-14.tux.yml
@@ -403,7 +403,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-14
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/6.1-clang-15.tux.yml
+++ b/tuxsuite/6.1-clang-15.tux.yml
@@ -438,7 +438,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-15
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/6.1-clang-16.tux.yml
+++ b/tuxsuite/6.1-clang-16.tux.yml
@@ -480,7 +480,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-16
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/6.1-clang-17.tux.yml
+++ b/tuxsuite/6.1-clang-17.tux.yml
@@ -480,7 +480,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/mainline-clang-11.tux.yml
+++ b/tuxsuite/mainline-clang-11.tux.yml
@@ -381,7 +381,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-11
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/mainline-clang-12.tux.yml
+++ b/tuxsuite/mainline-clang-12.tux.yml
@@ -392,7 +392,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-12
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/mainline-clang-13.tux.yml
+++ b/tuxsuite/mainline-clang-13.tux.yml
@@ -401,7 +401,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-13
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/mainline-clang-14.tux.yml
+++ b/tuxsuite/mainline-clang-14.tux.yml
@@ -403,7 +403,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-14
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/mainline-clang-15.tux.yml
+++ b/tuxsuite/mainline-clang-15.tux.yml
@@ -438,7 +438,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-15
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/mainline-clang-16.tux.yml
+++ b/tuxsuite/mainline-clang-16.tux.yml
@@ -480,7 +480,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-16
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/mainline-clang-17.tux.yml
+++ b/tuxsuite/mainline-clang-17.tux.yml
@@ -480,7 +480,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/next-clang-11.tux.yml
+++ b/tuxsuite/next-clang-11.tux.yml
@@ -382,7 +382,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-11
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/next-clang-12.tux.yml
+++ b/tuxsuite/next-clang-12.tux.yml
@@ -393,7 +393,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-12
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/next-clang-13.tux.yml
+++ b/tuxsuite/next-clang-13.tux.yml
@@ -413,7 +413,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-13
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/next-clang-14.tux.yml
+++ b/tuxsuite/next-clang-14.tux.yml
@@ -415,7 +415,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-14
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/next-clang-15.tux.yml
+++ b/tuxsuite/next-clang-15.tux.yml
@@ -450,7 +450,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-15
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/next-clang-16.tux.yml
+++ b/tuxsuite/next-clang-16.tux.yml
@@ -492,7 +492,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-16
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/next-clang-17.tux.yml
+++ b/tuxsuite/next-clang-17.tux.yml
@@ -492,7 +492,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/stable-clang-11.tux.yml
+++ b/tuxsuite/stable-clang-11.tux.yml
@@ -381,7 +381,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-11
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/stable-clang-12.tux.yml
+++ b/tuxsuite/stable-clang-12.tux.yml
@@ -392,7 +392,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-12
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/stable-clang-13.tux.yml
+++ b/tuxsuite/stable-clang-13.tux.yml
@@ -401,7 +401,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-13
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/stable-clang-14.tux.yml
+++ b/tuxsuite/stable-clang-14.tux.yml
@@ -403,7 +403,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-14
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/stable-clang-15.tux.yml
+++ b/tuxsuite/stable-clang-15.tux.yml
@@ -438,7 +438,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-15
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/stable-clang-16.tux.yml
+++ b/tuxsuite/stable-clang-16.tux.yml
@@ -480,7 +480,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-16
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/stable-clang-17.tux.yml
+++ b/tuxsuite/stable-clang-17.tux.yml
@@ -480,7 +480,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: https://github.com/archlinux/svntogit-packages/raw/packages/linux/trunk/config
+    kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
     make_variables:


### PR DESCRIPTION
Arch Linux moved their packaging from svn to git, so the
svntogit-packages repo on GitHub is not being updated anymore. Switch
the link to the configuration in the git repo, so that we continue to
get configuration updates.
