### PR TITLE
check_logs.py: Remove unnecessary conversion to fix updated RUF010

### DIFF
--- a/check_logs.py
+++ b/check_logs.py
@@ -26,7 +26,7 @@ def _fetch(title, url, dest):
             urllib.request.urlretrieve(url, dest)
             break
         except ConnectionResetError as err:
-            print_yellow(f"{title} download error ('{err!s}'), retrying...")
+            print_yellow(f"{title} download error ('{err}'), retrying...")
         except urllib.error.HTTPError as err:
             if err.code in retry_codes:
                 print_yellow(
@@ -35,7 +35,7 @@ def _fetch(title, url, dest):
                 print_red(f"{err.code} error trying to download {title}")
                 sys.exit(1)
         except urllib.error.URLError as err:
-            print_yellow(f"{title} download error ('{err!s}'), retrying...")
+            print_yellow(f"{title} download error ('{err}'), retrying...")
 
     if retries == max_retries:
         print_red(f"Unable to download {title} after {max_retries} tries")


### PR DESCRIPTION
15103a6 ("check_logs: fix RUF010 warnings about f-strings") added a conversion to silence a Ruff warning (`RUF010`). That warning has been updated in 0.0.273 to note that `f"{foo!s}"` is equivalent to `f"{foo}"`. The conversion is only needed if there is a format spec (such as a length).

This is the result of:

```
$ ruff --fix .
```
