### PR TITLE
Update RISC-V gki_defconfig build

### DIFF
--- a/.github/workflows/android-mainline-clang-12.yml
+++ b/.github/workflows/android-mainline-clang-12.yml
@@ -89,15 +89,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _6ad60675c9981595d86d7e7fbd31c255:
+  _93eebbb3d39e4138918480a96661bfb5:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 gki_defconfig+64-bit.config+gki.config
+    name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 gki_defconfig
     env:
       ARCH: riscv
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig+64-bit.config+gki.config
+      CONFIG: gki_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android-mainline-clang-13.yml
+++ b/.github/workflows/android-mainline-clang-13.yml
@@ -89,15 +89,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _c43f518fb52a16e2b8e0fd25f2a7e218:
+  _64d4082e3dfd4dbc4b23b68a5633e431:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+64-bit.config+gki.config
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
     env:
       ARCH: riscv
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig+64-bit.config+gki.config
+      CONFIG: gki_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android-mainline-clang-14.yml
+++ b/.github/workflows/android-mainline-clang-14.yml
@@ -89,15 +89,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3532b287edbe7f6588508657aaefceb8:
+  _bc4d9e79bec5d808043a57233a5d69be:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+64-bit.config+gki.config
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
     env:
       ARCH: riscv
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig+64-bit.config+gki.config
+      CONFIG: gki_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android-mainline-clang-15.yml
+++ b/.github/workflows/android-mainline-clang-15.yml
@@ -113,15 +113,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _0566906bccc5502c90b356eb73a9444d:
+  _9d63787dd80567f37c0fba29cbdcbc48:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+64-bit.config+gki.config
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
     env:
       ARCH: riscv
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig+64-bit.config+gki.config
+      CONFIG: gki_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android-mainline-clang-16.yml
+++ b/.github/workflows/android-mainline-clang-16.yml
@@ -89,15 +89,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _7acbf28a24aa730a781229f80e4e38a3:
+  _92b9a047dd08de5f3292d2704a843d08:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+64-bit.config+gki.config
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
     env:
       ARCH: riscv
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig+64-bit.config+gki.config
+      CONFIG: gki_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android-mainline-clang-17.yml
+++ b/.github/workflows/android-mainline-clang-17.yml
@@ -89,15 +89,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e092be3d7f86c9252b19810bd1fba7ef:
+  _4953f3011f75ad44d5368294c9e65852:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+64-bit.config+gki.config
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
     env:
       ARCH: riscv
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig+64-bit.config+gki.config
+      CONFIG: gki_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/android-mainline-clang-android.yml
+++ b/.github/workflows/android-mainline-clang-android.yml
@@ -89,15 +89,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _a84110171ba256e7841d0a1808611e52:
+  _b23e48c76a43ea3ebc8dad420a5b5d4b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+64-bit.config+gki.config
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
     env:
       ARCH: riscv
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig+64-bit.config+gki.config
+      CONFIG: gki_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/generator.yml
+++ b/generator.yml
@@ -303,7 +303,7 @@ configs:
   - &riscv_no_efi      {config: [defconfig, CONFIG_EFI=n],                                                     kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
   - &riscv_alpine      {config: *riscv-alpine-config-url,                                                      kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
   - &riscv_suse        {config: *riscv-suse-config-url,                                                        kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
-  - &riscv_gki         {config: [gki_defconfig, 64-bit.config, gki.config],                                    kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
+  - &riscv_gki         {config: gki_defconfig,                                                                 kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
   - &s390              {config: defconfig,                                                                                                 ARCH: *s390-arch,       << : *kernel}
   - &s390_kasan        {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],            ARCH: *s390-arch,       << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433

--- a/tuxsuite/android-mainline-clang-12.tux.yml
+++ b/tuxsuite/android-mainline-clang-12.tux.yml
@@ -32,10 +32,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: riscv
     toolchain: clang-12
-    kconfig:
-    - gki_defconfig
-    - 64-bit.config
-    - gki.config
+    kconfig: gki_defconfig
     targets:
     - kernel
     kernel_image: Image

--- a/tuxsuite/android-mainline-clang-13.tux.yml
+++ b/tuxsuite/android-mainline-clang-13.tux.yml
@@ -32,10 +32,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: riscv
     toolchain: clang-13
-    kconfig:
-    - gki_defconfig
-    - 64-bit.config
-    - gki.config
+    kconfig: gki_defconfig
     targets:
     - kernel
     kernel_image: Image

--- a/tuxsuite/android-mainline-clang-14.tux.yml
+++ b/tuxsuite/android-mainline-clang-14.tux.yml
@@ -32,10 +32,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: riscv
     toolchain: clang-14
-    kconfig:
-    - gki_defconfig
-    - 64-bit.config
-    - gki.config
+    kconfig: gki_defconfig
     targets:
     - kernel
     kernel_image: Image

--- a/tuxsuite/android-mainline-clang-15.tux.yml
+++ b/tuxsuite/android-mainline-clang-15.tux.yml
@@ -40,10 +40,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: riscv
     toolchain: clang-15
-    kconfig:
-    - gki_defconfig
-    - 64-bit.config
-    - gki.config
+    kconfig: gki_defconfig
     targets:
     - kernel
     kernel_image: Image

--- a/tuxsuite/android-mainline-clang-16.tux.yml
+++ b/tuxsuite/android-mainline-clang-16.tux.yml
@@ -32,10 +32,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: riscv
     toolchain: clang-16
-    kconfig:
-    - gki_defconfig
-    - 64-bit.config
-    - gki.config
+    kconfig: gki_defconfig
     targets:
     - kernel
     kernel_image: Image

--- a/tuxsuite/android-mainline-clang-17.tux.yml
+++ b/tuxsuite/android-mainline-clang-17.tux.yml
@@ -32,10 +32,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: riscv
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - 64-bit.config
-    - gki.config
+    kconfig: gki_defconfig
     targets:
     - kernel
     kernel_image: Image

--- a/tuxsuite/android-mainline-clang-android.tux.yml
+++ b/tuxsuite/android-mainline-clang-android.tux.yml
@@ -32,10 +32,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: riscv
     toolchain: clang-android
-    kconfig:
-    - gki_defconfig
-    - 64-bit.config
-    - gki.config
+    kconfig: gki_defconfig
     targets:
     - kernel
     kernel_image: Image


### PR DESCRIPTION
After the linked change, `gki.config` does not exist, so the build fails.
As the change notes, `arch/riscv` now uses just `gki_defconfig` like arm64
and x86_64.

Link: https://android.googlesource.com/kernel/common/+/e5e65575783ef212a568077cbb6f850e1f5d07c9
