### PR TITLE
build-local.py improvements

### DIFF
--- a/scripts/build-local.py
+++ b/scripts/build-local.py
@@ -73,9 +73,7 @@ if shutil.which('podman'):
 elif shutil.which('docker'):
     runtime = 'docker'
 else:
-    raise RuntimeError(
-        "tuxmake requires either podman or docker for versioned toolchains but neither could be found on your system!"
-    )
+    runtime = None
 
 # Combine all jobs into one object for easy iteration
 jobs = {}
@@ -109,6 +107,11 @@ for name, builds in jobs.items():
         kconfig = build['kconfig']
         target_arch = build['target_arch']
         toolchain = build['toolchain']
+
+        if '-' in toolchain and not runtime:
+            raise RuntimeError(
+                f"tuxmake requires either podman or docker to use versioned toolchains ('{toolchain}') but neither could be found on your system!"
+            )
 
         cfg_str = '+'.join(kconfig) if isinstance(kconfig, list) else kconfig
         print(f"I: Building {target_arch} {cfg_str} ({toolchain})... ",

--- a/scripts/build-local.py
+++ b/scripts/build-local.py
@@ -5,6 +5,7 @@ from argparse import ArgumentParser
 import copy
 from pathlib import Path
 import re
+import signal
 import shutil
 import sys
 
@@ -13,6 +14,16 @@ import yaml
 NORMAL = '\033[0m'
 RED = '\033[01;31m'
 GREEN = '\033[01;32m'
+
+
+def interrupt_handler(_signum, _frame):
+    """
+    Allows script to exit immediately when Ctrl-C is pressed
+    """
+    sys.exit(130)
+
+
+signal.signal(signal.SIGINT, interrupt_handler)
 
 try:
     import tuxmake.build

--- a/scripts/build-local.py
+++ b/scripts/build-local.py
@@ -14,6 +14,7 @@ import yaml
 NORMAL = '\033[0m'
 RED = '\033[01;31m'
 GREEN = '\033[01;32m'
+YELLOW = '\033[01;33m'
 
 
 def interrupt_handler(_signum, _frame):
@@ -46,6 +47,10 @@ parser.add_argument('-b',
                     '--build-dir',
                     default=default_build_dir,
                     help=f"Build folder (default: {default_build_dir})")
+parser.add_argument('-c',
+                    '--ccache',
+                    action='store_true',
+                    help='Use ccache if it is available')
 parser.add_argument('-C',
                     '--directory',
                     help='Path to kernel source',
@@ -85,6 +90,15 @@ elif shutil.which('docker'):
     runtime = 'docker'
 else:
     runtime = None
+
+wrapper = None
+if args.ccache:
+    if shutil.which('ccache'):
+        wrapper = 'ccache'
+    else:
+        print(
+            f"{YELLOW}ccache was requested but it is not installed, ignoring...{NORMAL}"
+        )
 
 # Combine all jobs into one object for easy iteration
 jobs = {}
@@ -162,6 +176,7 @@ for name, builds in jobs.items():
                                      quiet=(not args.verbose),
                                      runtime=runtime,
                                      tree=tree,
+                                     wrapper=wrapper,
                                      **build)
 
         if all(info.passed for info in result.status.values()):

--- a/scripts/build-local.py
+++ b/scripts/build-local.py
@@ -133,6 +133,11 @@ for name, builds in jobs.items():
         target_arch = build['target_arch']
         toolchain = build['toolchain']
 
+        # If there is a dash in the toolchain, it means it is a versioned
+        # toolchain in tuxmake terms, which requires a container runtime. If no
+        # runtime was found in the user's current environment, let them know
+        # immediately so that it can be corrected, versus tuxmake erroring out
+        # and causing all the builds to appear to fail.
         if '-' in toolchain and not runtime:
             raise RuntimeError(
                 f"tuxmake requires either podman or docker to use versioned toolchains ('{toolchain}') but neither could be found on your system!"


### PR DESCRIPTION
This pull request adds some quality of life improvements to `scripts/build-local.py`.

The first commit allows local toolchains to be used with `tuxmake` by having something like:

```yaml
toolchain: clang
make_variables:
  LLVM: 1
```

or

```yaml
toolchain: gcc
make_variables:
  CROSS_COMPILE: aarch64-linux-
```

then running `build-local.py` like

```
$ PATH=$TC_PREFIX_1/bin:$TC_PREFIX_2/bin:$PATH scripts/build-local.py ...
```

This is useful for using the versions of GCC and LLVM available on [kernel.org](https://kernel.org/pub/tools) with `tuxmake`. `podman` or `docker` is not required in this instance, so the error is made conditional on whether or not versioned toolchains (ones with a `-` in them) are actually requested.

The second patch allows interrupting `build-local.py` with Ctrl-C. The current behavior just kills `tuxmake` internally and the iteration of builds continue, rather than being immediately stopped.

The third patch allows the use of `ccache` if it is available in the user's environment.
