### PR TITLE
Drop Fedora's armv7hl configuration

### DIFF
--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -690,30 +690,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _9787aef428bca7a8aa1b80968a889942:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 11
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _a56d649bf59d04b145998497ffd3d36c:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -762,30 +762,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5956d62ae6edadd4596591a4267ef913:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 12
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _c65a27b37c5a7caf522020d62a097166:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -834,30 +834,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2dd1b5be6535967701a383add1a82022:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _1435de1ebd93ba0b4f841682571dd69b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -834,30 +834,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _9417efa1a2a916b417a8798be9c16791:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _f68ffc140cb41005f45ddf889b6a0d4b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -834,30 +834,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3043016e5ad70f22927f065ac8cb8a1b:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 15
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _0796c5af6dafa12890c543fadd812bd5:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/5.15-clang-16.yml
+++ b/.github/workflows/5.15-clang-16.yml
@@ -834,30 +834,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _234837f85b982993f75103c3aa71a7b6:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 16
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _683a2e8cafe0c2e856fc58476c6e7cef:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/5.15-clang-17.yml
+++ b/.github/workflows/5.15-clang-17.yml
@@ -834,30 +834,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ea0d5df50e67e8c68e5acd6ca61968fc:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 17
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _2d8f7e16ac2775b5b26484b59229226f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/5.15-clang-18.yml
+++ b/.github/workflows/5.15-clang-18.yml
@@ -834,30 +834,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b3401f401a112d74abf1fadb7511af55:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 18
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _52af769878102eaf2e33e3d466021cf9:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/6.1-clang-11.yml
+++ b/.github/workflows/6.1-clang-11.yml
@@ -714,30 +714,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _9787aef428bca7a8aa1b80968a889942:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 11
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _a56d649bf59d04b145998497ffd3d36c:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/6.1-clang-12.yml
+++ b/.github/workflows/6.1-clang-12.yml
@@ -738,30 +738,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5956d62ae6edadd4596591a4267ef913:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 12
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _c65a27b37c5a7caf522020d62a097166:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/6.1-clang-13.yml
+++ b/.github/workflows/6.1-clang-13.yml
@@ -762,30 +762,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2dd1b5be6535967701a383add1a82022:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _1435de1ebd93ba0b4f841682571dd69b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/6.1-clang-14.yml
+++ b/.github/workflows/6.1-clang-14.yml
@@ -762,30 +762,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _9417efa1a2a916b417a8798be9c16791:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _f68ffc140cb41005f45ddf889b6a0d4b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/6.1-clang-15.yml
+++ b/.github/workflows/6.1-clang-15.yml
@@ -810,30 +810,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3043016e5ad70f22927f065ac8cb8a1b:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 15
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _0796c5af6dafa12890c543fadd812bd5:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/6.1-clang-16.yml
+++ b/.github/workflows/6.1-clang-16.yml
@@ -930,30 +930,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _234837f85b982993f75103c3aa71a7b6:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 16
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _683a2e8cafe0c2e856fc58476c6e7cef:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/6.1-clang-17.yml
+++ b/.github/workflows/6.1-clang-17.yml
@@ -930,30 +930,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ea0d5df50e67e8c68e5acd6ca61968fc:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 17
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _2d8f7e16ac2775b5b26484b59229226f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/6.1-clang-18.yml
+++ b/.github/workflows/6.1-clang-18.yml
@@ -930,30 +930,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b3401f401a112d74abf1fadb7511af55:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 18
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _52af769878102eaf2e33e3d466021cf9:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/mainline-clang-11.yml
+++ b/.github/workflows/mainline-clang-11.yml
@@ -714,30 +714,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _9787aef428bca7a8aa1b80968a889942:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 11
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _a56d649bf59d04b145998497ffd3d36c:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/mainline-clang-12.yml
+++ b/.github/workflows/mainline-clang-12.yml
@@ -738,30 +738,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5956d62ae6edadd4596591a4267ef913:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 12
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _c65a27b37c5a7caf522020d62a097166:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/mainline-clang-13.yml
+++ b/.github/workflows/mainline-clang-13.yml
@@ -762,30 +762,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2dd1b5be6535967701a383add1a82022:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _1435de1ebd93ba0b4f841682571dd69b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -762,30 +762,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _9417efa1a2a916b417a8798be9c16791:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _f68ffc140cb41005f45ddf889b6a0d4b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -810,30 +810,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3043016e5ad70f22927f065ac8cb8a1b:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 15
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _0796c5af6dafa12890c543fadd812bd5:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -930,30 +930,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _234837f85b982993f75103c3aa71a7b6:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 16
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _683a2e8cafe0c2e856fc58476c6e7cef:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/mainline-clang-17.yml
+++ b/.github/workflows/mainline-clang-17.yml
@@ -930,30 +930,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ea0d5df50e67e8c68e5acd6ca61968fc:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 17
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _2d8f7e16ac2775b5b26484b59229226f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/mainline-clang-18.yml
+++ b/.github/workflows/mainline-clang-18.yml
@@ -930,30 +930,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b3401f401a112d74abf1fadb7511af55:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 18
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _52af769878102eaf2e33e3d466021cf9:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/next-clang-11.yml
+++ b/.github/workflows/next-clang-11.yml
@@ -714,30 +714,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _9787aef428bca7a8aa1b80968a889942:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 11
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _a56d649bf59d04b145998497ffd3d36c:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/next-clang-12.yml
+++ b/.github/workflows/next-clang-12.yml
@@ -738,30 +738,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5956d62ae6edadd4596591a4267ef913:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 12
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _c65a27b37c5a7caf522020d62a097166:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/next-clang-13.yml
+++ b/.github/workflows/next-clang-13.yml
@@ -786,30 +786,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2dd1b5be6535967701a383add1a82022:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _1435de1ebd93ba0b4f841682571dd69b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -786,30 +786,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _9417efa1a2a916b417a8798be9c16791:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _f68ffc140cb41005f45ddf889b6a0d4b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -834,30 +834,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3043016e5ad70f22927f065ac8cb8a1b:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 15
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _0796c5af6dafa12890c543fadd812bd5:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -954,30 +954,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _234837f85b982993f75103c3aa71a7b6:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 16
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _683a2e8cafe0c2e856fc58476c6e7cef:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/next-clang-17.yml
+++ b/.github/workflows/next-clang-17.yml
@@ -954,30 +954,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ea0d5df50e67e8c68e5acd6ca61968fc:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 17
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _2d8f7e16ac2775b5b26484b59229226f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/next-clang-18.yml
+++ b/.github/workflows/next-clang-18.yml
@@ -954,30 +954,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b3401f401a112d74abf1fadb7511af55:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 18
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _52af769878102eaf2e33e3d466021cf9:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/stable-clang-11.yml
+++ b/.github/workflows/stable-clang-11.yml
@@ -714,30 +714,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _9787aef428bca7a8aa1b80968a889942:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 11
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _a56d649bf59d04b145998497ffd3d36c:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/stable-clang-12.yml
+++ b/.github/workflows/stable-clang-12.yml
@@ -738,30 +738,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5956d62ae6edadd4596591a4267ef913:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 12
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _c65a27b37c5a7caf522020d62a097166:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -762,30 +762,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _2dd1b5be6535967701a383add1a82022:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _1435de1ebd93ba0b4f841682571dd69b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -762,30 +762,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _9417efa1a2a916b417a8798be9c16791:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _f68ffc140cb41005f45ddf889b6a0d4b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -810,30 +810,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _3043016e5ad70f22927f065ac8cb8a1b:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 15
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _0796c5af6dafa12890c543fadd812bd5:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/stable-clang-16.yml
+++ b/.github/workflows/stable-clang-16.yml
@@ -930,30 +930,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _234837f85b982993f75103c3aa71a7b6:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 16
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _683a2e8cafe0c2e856fc58476c6e7cef:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/stable-clang-17.yml
+++ b/.github/workflows/stable-clang-17.yml
@@ -930,30 +930,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _ea0d5df50e67e8c68e5acd6ca61968fc:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 17
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _2d8f7e16ac2775b5b26484b59229226f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/.github/workflows/stable-clang-18.yml
+++ b/.github/workflows/stable-clang-18.yml
@@ -930,30 +930,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b3401f401a112d74abf1fadb7511af55:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_distribution_configs
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    env:
-      ARCH: arm
-      LLVM_VERSION: 18
-      BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config+CONFIG_BPF_PRELOAD=n
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _52af769878102eaf2e33e3d466021cf9:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_distribution_configs

--- a/generator.yml
+++ b/generator.yml
@@ -19,7 +19,6 @@ urls:
   - &arm64-url    https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
   # Configuration URLs
   - &arm32-alpine-config-url   https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
-  - &arm32-fedora-config-url   https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
   - &arm32-suse-config-url     https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
   - &arm64-alpine-config-url   https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
   - &arm64-fedora-config-url   https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
@@ -281,8 +280,6 @@ configs:
   - &arm32_allno       {config: allnoconfig,                                                                                               ARCH: *arm-arch,        << : *default}
   - &arm32_allyes      {config: [allyesconfig, CONFIG_WERROR=n],                                                                           ARCH: *arm-arch,        << : *default}
   - &arm32_alpine      {config: *arm32-alpine-config-url,                                                                                  ARCH: *arm-arch,        << : *kernel}
-  # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
-  - &arm32_fedora      {config: [*arm32-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                          ARCH: *arm-arch,        << : *kernel}
   - &arm32_suse        {config: *arm32-suse-config-url,                                                                                    ARCH: *arm-arch,        << : *kernel}
   - &arm64             {config: defconfig,                                                                                                 ARCH: *arm64-arch,      << : *kernel}
   #                                         https://github.com/ClangBuiltLinux/linux/issues/595
@@ -390,7 +387,6 @@ builds:
   - {<< : *arm32_allno,       << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm32_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm32_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *arm32_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -460,7 +456,6 @@ builds:
   - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm32_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm32_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *arm32_fedora,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -531,7 +526,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm32_allyes,      << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm32_alpine,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *arm32_fedora,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm32_suse,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64,             << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64be,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -601,7 +595,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable-6_1,       << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm32_allyes,      << : *stable-6_1,       << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm32_alpine,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *arm32_fedora,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm32_suse,        << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64,             << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64be,           << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -670,7 +663,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm32_alpine,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -860,7 +852,6 @@ builds:
   - {<< : *arm32_allno,       << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm32_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm32_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *arm32_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -930,7 +921,6 @@ builds:
   - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm32_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm32_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *arm32_fedora,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -1001,7 +991,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable,           << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm32_allyes,      << : *stable,           << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm32_alpine,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *arm32_fedora,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm32_suse,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64,             << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64be,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -1071,7 +1060,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable-6_1,       << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm32_allyes,      << : *stable-6_1,       << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm32_alpine,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *arm32_fedora,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm32_suse,        << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64,             << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64be,           << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -1140,7 +1128,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm32_alpine,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -1330,7 +1317,6 @@ builds:
   - {<< : *arm32_allno,       << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *arm32_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *arm32_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *arm32_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_16}
@@ -1400,7 +1386,6 @@ builds:
   - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *arm32_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *arm32_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *arm32_fedora,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
@@ -1471,7 +1456,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable,           << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *arm32_allyes,      << : *stable,           << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *arm32_alpine,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *arm32_fedora,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm32_suse,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64,             << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64be,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
@@ -1541,7 +1525,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable-6_1,       << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *arm32_allyes,      << : *stable-6_1,       << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *arm32_alpine,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *arm32_fedora,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm32_suse,        << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64,             << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64be,           << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
@@ -1610,7 +1593,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *arm32_alpine,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_16}
@@ -1800,7 +1782,6 @@ builds:
   - {<< : *arm32_allno,       << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *arm32_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *arm32_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
-  - {<< : *arm32_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
@@ -1866,7 +1847,6 @@ builds:
   - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *arm32_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *arm32_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
-  - {<< : *arm32_fedora,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
@@ -1933,7 +1913,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable,           << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *arm32_allyes,      << : *stable,           << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *arm32_alpine,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_15}
-  - {<< : *arm32_fedora,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm32_suse,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64,             << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64be,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_15}
@@ -1999,7 +1978,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable-6_1,       << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *arm32_allyes,      << : *stable-6_1,       << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *arm32_alpine,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_15}
-  - {<< : *arm32_fedora,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm32_suse,        << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64,             << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64be,           << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_15}
@@ -2064,7 +2042,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *arm32_alpine,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_15}
-  - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_15}
@@ -2254,7 +2231,6 @@ builds:
   - {<< : *arm32_allno,       << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm32_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm32_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *arm32_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
@@ -2315,7 +2291,6 @@ builds:
   - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm32_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm32_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *arm32_fedora,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
@@ -2377,7 +2352,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable,           << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm32_allyes,      << : *stable,           << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm32_alpine,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *arm32_fedora,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm32_suse,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64,             << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64be,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_14}
@@ -2438,7 +2412,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable-6_1,       << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm32_allyes,      << : *stable-6_1,       << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm32_alpine,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *arm32_fedora,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm32_suse,        << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64,             << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64be,           << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_14}
@@ -2499,7 +2472,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm32_alpine,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
@@ -2688,7 +2660,6 @@ builds:
   - {<< : *arm32_allno,       << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm32_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
@@ -2749,7 +2720,6 @@ builds:
   - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm32_fedora,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
@@ -2811,7 +2781,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable,           << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_allyes,      << : *stable,           << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_alpine,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm32_fedora,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm32_suse,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64,             << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64be,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
@@ -2872,7 +2841,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable-6_1,       << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_allyes,      << : *stable-6_1,       << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_alpine,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm32_fedora,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm32_suse,        << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64,             << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64be,           << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_13}
@@ -2933,7 +2901,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_alpine,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
@@ -3123,7 +3090,6 @@ builds:
   # ARM allyesconfig build disabled: https://github.com/ClangBuiltLinux/linux/issues/1615
   # - {<< : *arm32_allyes,      << : *mainline,         << : *llvm,            boot: false, << : *llvm_12}
   - {<< : *arm32_alpine,      << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
-  - {<< : *arm32_fedora,      << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
@@ -3183,7 +3149,6 @@ builds:
   # ARM allyesconfig build disabled: https://github.com/ClangBuiltLinux/linux/issues/1615
   # - {<< : *arm32_allyes,      << : *next,             << : *llvm,            boot: false, << : *llvm_12}
   - {<< : *arm32_alpine,      << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
-  - {<< : *arm32_fedora,      << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *arm32_suse,        << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
@@ -3243,7 +3208,6 @@ builds:
   # ARM allyesconfig build disabled: https://github.com/ClangBuiltLinux/linux/issues/1615
   # - {<< : *arm32_allyes,      << : *stable,           << : *llvm,            boot: false, << : *llvm_12}
   - {<< : *arm32_alpine,      << : *stable,           << : *llvm,            boot: true,  << : *llvm_12}
-  - {<< : *arm32_fedora,      << : *stable,           << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *arm32_suse,        << : *stable,           << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *arm64,             << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *arm64_lto_full,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_12}
@@ -3303,7 +3267,6 @@ builds:
   # ARM allyesconfig build disabled: https://github.com/ClangBuiltLinux/linux/issues/1615
   # - {<< : *arm32_allyes,      << : *stable-6_1,       << : *llvm,            boot: false, << : *llvm_12}
   - {<< : *arm32_alpine,      << : *stable-6_1,       << : *llvm,            boot: true,  << : *llvm_12}
-  - {<< : *arm32_fedora,      << : *stable-6_1,       << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *arm32_suse,        << : *stable-6_1,       << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *arm64,             << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *arm64_lto_full,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_12}
@@ -3362,7 +3325,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_12}
   - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_12}
   - {<< : *arm32_alpine,      << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
-  - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
@@ -3513,7 +3475,6 @@ builds:
   # ARM allyesconfig build disabled: https://github.com/ClangBuiltLinux/linux/issues/1615
   # - {<< : *arm32_allyes,      << : *mainline,         << : *llvm,            boot: false, << : *llvm_11}
   - {<< : *arm32_alpine,      << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
-  - {<< : *arm32_fedora,      << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_11}
@@ -3573,7 +3534,6 @@ builds:
   # ARM allyesconfig build disabled: https://github.com/ClangBuiltLinux/linux/issues/1615
   # - {<< : *arm32_allyes,      << : *next,             << : *llvm,            boot: false, << : *llvm_11}
   - {<< : *arm32_alpine,      << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
-  - {<< : *arm32_fedora,      << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *arm32_suse,        << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_11}
@@ -3633,7 +3593,6 @@ builds:
   # ARM allyesconfig build disabled: https://github.com/ClangBuiltLinux/linux/issues/1615
   # - {<< : *arm32_allyes,      << : *stable,           << : *llvm,            boot: false, << : *llvm_11}
   - {<< : *arm32_alpine,      << : *stable,           << : *llvm,            boot: true,  << : *llvm_11}
-  - {<< : *arm32_fedora,      << : *stable,           << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *arm32_suse,        << : *stable,           << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *arm64,             << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *arm64_lto_full,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_11}
@@ -3693,7 +3652,6 @@ builds:
   # ARM allyesconfig build disabled: https://github.com/ClangBuiltLinux/linux/issues/1615
   # - {<< : *arm32_allyes,      << : *stable-6_1,       << : *llvm,            boot: false, << : *llvm_11}
   - {<< : *arm32_alpine,      << : *stable-6_1,       << : *llvm,            boot: true,  << : *llvm_11}
-  - {<< : *arm32_fedora,      << : *stable-6_1,       << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *arm32_suse,        << : *stable-6_1,       << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *arm64,             << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *arm64_lto_full,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_11}
@@ -3752,7 +3710,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_11}
   - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_11}
   - {<< : *arm32_alpine,      << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
-  - {<< : *arm32_fedora,      << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}

--- a/tuxsuite/5.15-clang-11.tux.yml
+++ b/tuxsuite/5.15-clang-11.tux.yml
@@ -276,16 +276,6 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm
     toolchain: clang-11
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: arm
-    toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/5.15-clang-12.tux.yml
+++ b/tuxsuite/5.15-clang-12.tux.yml
@@ -307,16 +307,6 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm
     toolchain: clang-12
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: arm
-    toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/5.15-clang-13.tux.yml
+++ b/tuxsuite/5.15-clang-13.tux.yml
@@ -335,16 +335,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-13
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/5.15-clang-14.tux.yml
+++ b/tuxsuite/5.15-clang-14.tux.yml
@@ -335,16 +335,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-14
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/5.15-clang-15.tux.yml
+++ b/tuxsuite/5.15-clang-15.tux.yml
@@ -335,16 +335,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-15
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/5.15-clang-16.tux.yml
+++ b/tuxsuite/5.15-clang-16.tux.yml
@@ -335,16 +335,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-16
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/5.15-clang-17.tux.yml
+++ b/tuxsuite/5.15-clang-17.tux.yml
@@ -335,16 +335,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-17
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/5.15-clang-18.tux.yml
+++ b/tuxsuite/5.15-clang-18.tux.yml
@@ -335,16 +335,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-nightly
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/6.1-clang-11.tux.yml
+++ b/tuxsuite/6.1-clang-11.tux.yml
@@ -284,16 +284,6 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm
     toolchain: clang-11
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: arm
-    toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/6.1-clang-12.tux.yml
+++ b/tuxsuite/6.1-clang-12.tux.yml
@@ -295,16 +295,6 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm
     toolchain: clang-12
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: arm
-    toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/6.1-clang-13.tux.yml
+++ b/tuxsuite/6.1-clang-13.tux.yml
@@ -304,16 +304,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-13
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/6.1-clang-14.tux.yml
+++ b/tuxsuite/6.1-clang-14.tux.yml
@@ -304,16 +304,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-14
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/6.1-clang-15.tux.yml
+++ b/tuxsuite/6.1-clang-15.tux.yml
@@ -323,16 +323,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-15
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/6.1-clang-16.tux.yml
+++ b/tuxsuite/6.1-clang-16.tux.yml
@@ -374,16 +374,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-16
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/6.1-clang-17.tux.yml
+++ b/tuxsuite/6.1-clang-17.tux.yml
@@ -374,16 +374,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-17
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/6.1-clang-18.tux.yml
+++ b/tuxsuite/6.1-clang-18.tux.yml
@@ -374,16 +374,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-nightly
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-11.tux.yml
+++ b/tuxsuite/mainline-clang-11.tux.yml
@@ -284,16 +284,6 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm
     toolchain: clang-11
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: arm
-    toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-12.tux.yml
+++ b/tuxsuite/mainline-clang-12.tux.yml
@@ -294,16 +294,6 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm
     toolchain: clang-12
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: arm
-    toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-13.tux.yml
+++ b/tuxsuite/mainline-clang-13.tux.yml
@@ -303,16 +303,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-13
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-14.tux.yml
+++ b/tuxsuite/mainline-clang-14.tux.yml
@@ -303,16 +303,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-14
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-15.tux.yml
+++ b/tuxsuite/mainline-clang-15.tux.yml
@@ -322,16 +322,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-15
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-16.tux.yml
+++ b/tuxsuite/mainline-clang-16.tux.yml
@@ -373,16 +373,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-16
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-17.tux.yml
+++ b/tuxsuite/mainline-clang-17.tux.yml
@@ -373,16 +373,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-17
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-18.tux.yml
+++ b/tuxsuite/mainline-clang-18.tux.yml
@@ -373,16 +373,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-nightly
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/next-clang-11.tux.yml
+++ b/tuxsuite/next-clang-11.tux.yml
@@ -283,16 +283,6 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm
     toolchain: clang-11
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: arm
-    toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/next-clang-12.tux.yml
+++ b/tuxsuite/next-clang-12.tux.yml
@@ -293,16 +293,6 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm
     toolchain: clang-12
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: arm
-    toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/next-clang-13.tux.yml
+++ b/tuxsuite/next-clang-13.tux.yml
@@ -313,16 +313,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-13
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/next-clang-14.tux.yml
+++ b/tuxsuite/next-clang-14.tux.yml
@@ -313,16 +313,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-14
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/next-clang-15.tux.yml
+++ b/tuxsuite/next-clang-15.tux.yml
@@ -332,16 +332,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-15
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/next-clang-16.tux.yml
+++ b/tuxsuite/next-clang-16.tux.yml
@@ -383,16 +383,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-16
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/next-clang-17.tux.yml
+++ b/tuxsuite/next-clang-17.tux.yml
@@ -383,16 +383,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-17
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/next-clang-18.tux.yml
+++ b/tuxsuite/next-clang-18.tux.yml
@@ -383,16 +383,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-nightly
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/stable-clang-11.tux.yml
+++ b/tuxsuite/stable-clang-11.tux.yml
@@ -284,16 +284,6 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm
     toolchain: clang-11
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: arm
-    toolchain: clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/stable-clang-12.tux.yml
+++ b/tuxsuite/stable-clang-12.tux.yml
@@ -295,16 +295,6 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm
     toolchain: clang-12
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: arm
-    toolchain: clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/stable-clang-13.tux.yml
+++ b/tuxsuite/stable-clang-13.tux.yml
@@ -304,16 +304,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-13
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/stable-clang-14.tux.yml
+++ b/tuxsuite/stable-clang-14.tux.yml
@@ -304,16 +304,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-14
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/stable-clang-15.tux.yml
+++ b/tuxsuite/stable-clang-15.tux.yml
@@ -323,16 +323,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-15
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/stable-clang-16.tux.yml
+++ b/tuxsuite/stable-clang-16.tux.yml
@@ -374,16 +374,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-16
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/stable-clang-17.tux.yml
+++ b/tuxsuite/stable-clang-17.tux.yml
@@ -374,16 +374,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-17
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel

--- a/tuxsuite/stable-clang-18.tux.yml
+++ b/tuxsuite/stable-clang-18.tux.yml
@@ -374,16 +374,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-nightly
-    kconfig:
-    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-armv7hl-fedora.config
-    - CONFIG_BPF_PRELOAD=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: clang-nightly
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel


### PR DESCRIPTION
It no longer exists, as Fedora has not supported 32-bit ARM since Fedora
37.

Link: https://fedoraproject.org/wiki/Changes/RetireARMv7
Link: https://src.fedoraproject.org/rpms/kernel/c/5c30685a34d59ff21f3fe2832e1a1850a02507d6
