### PR TITLE
Stop enabling CONFIG_PPC_DISABLE_WERROR=y for clang-14+

### DIFF
--- a/.github/workflows/5.10-clang-12.yml
+++ b/.github/workflows/5.10-clang-12.yml
@@ -257,15 +257,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b93c483101f871a5ff674333fdf22ffd:
+  _0d3e8018d7c221aa7df31ad6c41066e3:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=12 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=12 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-13.yml
+++ b/.github/workflows/5.10-clang-13.yml
@@ -281,15 +281,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _fbf6cb49cd3c4d4a4ae82b6aa7149644:
+  _a8d0c6b961f8ab9a368338791f62e0b6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=13 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=13 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-14.yml
+++ b/.github/workflows/5.10-clang-14.yml
@@ -281,15 +281,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _150e446491c69d10725858f5c0ade242:
+  _2fe146ce78067661706ce3c941ab2c04:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=14 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=14 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-15.yml
+++ b/.github/workflows/5.10-clang-15.yml
@@ -281,15 +281,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b918f74f05e3928e6817ff663df31204:
+  _6afb266ee9fdf9147dad082968e9acd5:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=15 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=15 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-16.yml
+++ b/.github/workflows/5.10-clang-16.yml
@@ -281,15 +281,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _83948c3cdf8b6b582e11113694f2907a:
+  _f8f67e8d886523e8c09ae03f1e3bb7ab:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=16 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=16 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-17.yml
+++ b/.github/workflows/5.10-clang-17.yml
@@ -281,15 +281,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _af0e5ea88129bb92b30ebaff10922863:
+  _24a182c0e89aa4b9ca085f97e71efca4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=17 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=17 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.10-clang-18.yml
+++ b/.github/workflows/5.10-clang-18.yml
@@ -281,15 +281,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5f44d31fce16546466e04512adf3c331:
+  _d6d581bf38ec6350fafef71559776702:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=18 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=18 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -497,15 +497,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b93c483101f871a5ff674333fdf22ffd:
+  _0d3e8018d7c221aa7df31ad6c41066e3:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=12 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=12 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -521,15 +521,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _fbf6cb49cd3c4d4a4ae82b6aa7149644:
+  _a8d0c6b961f8ab9a368338791f62e0b6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=13 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=13 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -521,15 +521,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _150e446491c69d10725858f5c0ade242:
+  _2fe146ce78067661706ce3c941ab2c04:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=14 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=14 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -521,15 +521,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b918f74f05e3928e6817ff663df31204:
+  _6afb266ee9fdf9147dad082968e9acd5:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=15 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=15 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-16.yml
+++ b/.github/workflows/5.15-clang-16.yml
@@ -521,15 +521,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _83948c3cdf8b6b582e11113694f2907a:
+  _f8f67e8d886523e8c09ae03f1e3bb7ab:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=16 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=16 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-17.yml
+++ b/.github/workflows/5.15-clang-17.yml
@@ -521,15 +521,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _af0e5ea88129bb92b30ebaff10922863:
+  _24a182c0e89aa4b9ca085f97e71efca4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=17 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=17 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.15-clang-18.yml
+++ b/.github/workflows/5.15-clang-18.yml
@@ -521,15 +521,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5f44d31fce16546466e04512adf3c331:
+  _d6d581bf38ec6350fafef71559776702:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=18 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=18 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.4-clang-13.yml
+++ b/.github/workflows/5.4-clang-13.yml
@@ -209,15 +209,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _fbf6cb49cd3c4d4a4ae82b6aa7149644:
+  _a8d0c6b961f8ab9a368338791f62e0b6:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=13 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=13 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.4-clang-14.yml
+++ b/.github/workflows/5.4-clang-14.yml
@@ -209,15 +209,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _150e446491c69d10725858f5c0ade242:
+  _2fe146ce78067661706ce3c941ab2c04:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=14 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=14 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.4-clang-15.yml
+++ b/.github/workflows/5.4-clang-15.yml
@@ -209,15 +209,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b918f74f05e3928e6817ff663df31204:
+  _6afb266ee9fdf9147dad082968e9acd5:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=15 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=15 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.4-clang-16.yml
+++ b/.github/workflows/5.4-clang-16.yml
@@ -209,15 +209,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _83948c3cdf8b6b582e11113694f2907a:
+  _f8f67e8d886523e8c09ae03f1e3bb7ab:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=16 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=16 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.4-clang-17.yml
+++ b/.github/workflows/5.4-clang-17.yml
@@ -209,15 +209,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _af0e5ea88129bb92b30ebaff10922863:
+  _24a182c0e89aa4b9ca085f97e71efca4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=17 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=17 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/5.4-clang-18.yml
+++ b/.github/workflows/5.4-clang-18.yml
@@ -209,15 +209,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5f44d31fce16546466e04512adf3c331:
+  _d6d581bf38ec6350fafef71559776702:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=18 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=18 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/6.1-clang-14.yml
+++ b/.github/workflows/6.1-clang-14.yml
@@ -473,15 +473,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _150e446491c69d10725858f5c0ade242:
+  _2fe146ce78067661706ce3c941ab2c04:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=14 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=14 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/6.1-clang-15.yml
+++ b/.github/workflows/6.1-clang-15.yml
@@ -473,15 +473,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b918f74f05e3928e6817ff663df31204:
+  _6afb266ee9fdf9147dad082968e9acd5:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=15 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=15 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/6.1-clang-16.yml
+++ b/.github/workflows/6.1-clang-16.yml
@@ -545,15 +545,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _83948c3cdf8b6b582e11113694f2907a:
+  _f8f67e8d886523e8c09ae03f1e3bb7ab:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=16 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=16 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/6.1-clang-17.yml
+++ b/.github/workflows/6.1-clang-17.yml
@@ -545,15 +545,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _af0e5ea88129bb92b30ebaff10922863:
+  _24a182c0e89aa4b9ca085f97e71efca4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=17 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=17 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/6.1-clang-18.yml
+++ b/.github/workflows/6.1-clang-18.yml
@@ -545,15 +545,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5f44d31fce16546466e04512adf3c331:
+  _d6d581bf38ec6350fafef71559776702:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=18 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=18 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -473,15 +473,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _1e5541ce7961d05a1e3bde22d9f4c015:
+  _9c7f800a9125039c676aaf7380fa47eb:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -473,15 +473,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _59f977e37d712618352b665340bb25ce:
+  _c01f91b0300887260fb7a31261c5a7d8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -545,15 +545,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _0734e1f3e14c5d0828be61dd34046d9a:
+  _7ddd279bf4ada4235a9fe7b998cc544b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-17.yml
+++ b/.github/workflows/mainline-clang-17.yml
@@ -545,15 +545,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _f8e4d913daecadf7ef9f7232dd865ed7:
+  _0ff49e5a122fcde5a6d1d80a0ddf8805:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-18.yml
+++ b/.github/workflows/mainline-clang-18.yml
@@ -545,15 +545,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b5c6e32d6cac8167a9ef84c8c04b853d:
+  _4cc31eab7a6658d3ab878aac18ffa368:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -473,15 +473,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _1e5541ce7961d05a1e3bde22d9f4c015:
+  _9c7f800a9125039c676aaf7380fa47eb:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -473,15 +473,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _59f977e37d712618352b665340bb25ce:
+  _c01f91b0300887260fb7a31261c5a7d8:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -545,15 +545,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _0734e1f3e14c5d0828be61dd34046d9a:
+  _7ddd279bf4ada4235a9fe7b998cc544b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-17.yml
+++ b/.github/workflows/next-clang-17.yml
@@ -545,15 +545,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _f8e4d913daecadf7ef9f7232dd865ed7:
+  _0ff49e5a122fcde5a6d1d80a0ddf8805:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-18.yml
+++ b/.github/workflows/next-clang-18.yml
@@ -545,15 +545,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b5c6e32d6cac8167a9ef84c8c04b853d:
+  _4cc31eab7a6658d3ab878aac18ffa368:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -473,15 +473,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _150e446491c69d10725858f5c0ade242:
+  _2fe146ce78067661706ce3c941ab2c04:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=14 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=14 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -473,15 +473,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _b918f74f05e3928e6817ff663df31204:
+  _6afb266ee9fdf9147dad082968e9acd5:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=15 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=15 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-16.yml
+++ b/.github/workflows/stable-clang-16.yml
@@ -545,15 +545,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _83948c3cdf8b6b582e11113694f2907a:
+  _f8f67e8d886523e8c09ae03f1e3bb7ab:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=16 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=16 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-17.yml
+++ b/.github/workflows/stable-clang-17.yml
@@ -545,15 +545,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _af0e5ea88129bb92b30ebaff10922863:
+  _24a182c0e89aa4b9ca085f97e71efca4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=17 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=17 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-18.yml
+++ b/.github/workflows/stable-clang-18.yml
@@ -545,15 +545,15 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _5f44d31fce16546466e04512adf3c331:
+  _d6d581bf38ec6350fafef71559776702:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs
-    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=18 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+    name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=18 ppc64_guest_defconfig
     env:
       ARCH: powerpc
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
+      CONFIG: ppc64_guest_defconfig
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/generator.yml
+++ b/generator.yml
@@ -311,8 +311,9 @@ configs:
   - &mips              {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y, CONFIG_CPU_BIG_ENDIAN=y],           kernel_image: vmlinux,      ARCH: *mips-arch,       << : *kernel}
   - &mipsel            {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y],                                    kernel_image: vmlinux,      ARCH: *mips-arch,       << : *kernel}
   - &ppc32             {config: ppc44x_defconfig,                                                              kernel_image: uImage,       ARCH: *powerpc-arch,    << : *kernel}
-  # Disable -Werror for ppc64_guest_defconfig for now: https://github.com/ClangBuiltLinux/linux/issues/1445
-  - &ppc64             {config: [ppc64_guest_defconfig, CONFIG_PPC_DISABLE_WERROR=y],                          kernel_image: vmlinux,      ARCH: *powerpc-arch,    << : *kernel}
+  - &ppc64             {config: ppc64_guest_defconfig,                                                         kernel_image: vmlinux,      ARCH: *powerpc-arch,    << : *kernel}
+  # Disable -Werror for ppc64_guest_defconfig for clang-13 and older: https://github.com/ClangBuiltLinux/linux/issues/1445
+  - &ppc64_no_werror   {config: [ppc64_guest_defconfig, CONFIG_PPC_DISABLE_WERROR=y],                          kernel_image: vmlinux,      ARCH: *powerpc-arch,    << : *kernel}
   - &ppc64le           {config: powernv_defconfig,                                                             kernel_image: zImage.epapr, ARCH: *powerpc-arch,    << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for all cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
   - &ppc64le_fedora    {config: [*ppc64le-fedora-config-url, CONFIG_BPF_PRELOAD=n],                            kernel_image: zImage.epapr, ARCH: *powerpc-arch,    << : *kernel}
@@ -2683,7 +2684,7 @@ builds:
   - {<< : *mipsel,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
   # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)
   # - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: true,  << : *llvm_13}
-  - {<< : *ppc64,             << : *mainline,         << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *ppc64_no_werror,   << : *mainline,         << : *llvm,            boot: true,  << : *llvm_13}
   - {<< : *ppc64le,           << : *mainline,         << : *llvm,            boot: true,  << : *llvm_13}
   - {<< : *ppc64le_fedora,    << : *mainline,         << : *clang,           boot: true,  << : *llvm_13}
   - {<< : *ppc64le_suse,      << : *mainline,         << : *clang,           boot: true,  << : *llvm_13}
@@ -2743,7 +2744,7 @@ builds:
   - {<< : *mipsel,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)
   # - {<< : *ppc32,             << : *next,             << : *llvm,            boot: true,  << : *llvm_13}
-  - {<< : *ppc64,             << : *next,             << : *llvm,            boot: true,  << : *llvm_13}
+  - {<< : *ppc64_no_werror,   << : *next,             << : *llvm,            boot: true,  << : *llvm_13}
   - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  << : *llvm_13}
   - {<< : *ppc64le_fedora,    << : *next,             << : *clang,           boot: true,  << : *llvm_13}
   - {<< : *ppc64le_suse,      << : *next,             << : *clang,           boot: true,  << : *llvm_13}
@@ -2804,7 +2805,7 @@ builds:
   - {<< : *mipsel,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
   # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)
   # - {<< : *ppc32,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_13}
-  - {<< : *ppc64,             << : *stable,           << : *ppc64_llvm,      boot: true,  << : *llvm_13}
+  - {<< : *ppc64_no_werror,   << : *stable,           << : *ppc64_llvm,      boot: true,  << : *llvm_13}
   - {<< : *ppc64le,           << : *stable,           << : *llvm,            boot: true,  << : *llvm_13}
   - {<< : *ppc64le_fedora,    << : *stable,           << : *clang,           boot: true,  << : *llvm_13}
   - {<< : *ppc64le_suse,      << : *stable,           << : *clang,           boot: true,  << : *llvm_13}
@@ -2864,7 +2865,7 @@ builds:
   - {<< : *mipsel,            << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_13}
   # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)
   # - {<< : *ppc32,             << : *stable-6_1,       << : *llvm,            boot: true,  << : *llvm_13}
-  - {<< : *ppc64,             << : *stable-6_1,       << : *ppc64_llvm,      boot: true,  << : *llvm_13}
+  - {<< : *ppc64_no_werror,   << : *stable-6_1,       << : *ppc64_llvm,      boot: true,  << : *llvm_13}
   - {<< : *ppc64le,           << : *stable-6_1,       << : *llvm,            boot: true,  << : *llvm_13}
   - {<< : *ppc64le_fedora,    << : *stable-6_1,       << : *clang,           boot: true,  << : *llvm_13}
   - {<< : *ppc64le_suse,      << : *stable-6_1,       << : *clang,           boot: true,  << : *llvm_13}
@@ -3111,7 +3112,7 @@ builds:
   - {<< : *mipsel,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
   # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)
   # - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
-  - {<< : *ppc64,             << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *ppc64_no_werror,   << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *ppc64le,           << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *ppc64le_fedora,    << : *mainline,         << : *clang,           boot: true,  << : *llvm_12}
   - {<< : *ppc64le_suse,      << : *mainline,         << : *clang,           boot: true,  << : *llvm_12}
@@ -3170,7 +3171,7 @@ builds:
   - {<< : *mipsel,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_12}
   # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)
   # - {<< : *ppc32,             << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
-  - {<< : *ppc64,             << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
+  - {<< : *ppc64_no_werror,   << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *ppc64le,           << : *next,             << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *ppc64le_fedora,    << : *next,             << : *clang,           boot: true,  << : *llvm_12}
   - {<< : *ppc64le_suse,      << : *next,             << : *clang,           boot: true,  << : *llvm_12}
@@ -3229,7 +3230,7 @@ builds:
   - {<< : *mipsel,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_12}
   # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)
   # - {<< : *ppc32,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_12}
-  - {<< : *ppc64,             << : *stable,           << : *ppc64_llvm,      boot: true,  << : *llvm_12}
+  - {<< : *ppc64_no_werror,   << : *stable,           << : *ppc64_llvm,      boot: true,  << : *llvm_12}
   - {<< : *ppc64le,           << : *stable,           << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *ppc64le_fedora,    << : *stable,           << : *clang,           boot: true,  << : *llvm_12}
   - {<< : *ppc64le_suse,      << : *stable,           << : *clang,           boot: true,  << : *llvm_12}
@@ -3288,7 +3289,7 @@ builds:
   - {<< : *mipsel,            << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_12}
   # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)
   # - {<< : *ppc32,             << : *stable-6_1,       << : *llvm,            boot: true,  << : *llvm_12}
-  - {<< : *ppc64,             << : *stable-6_1,       << : *ppc64_llvm,      boot: true,  << : *llvm_12}
+  - {<< : *ppc64_no_werror,   << : *stable-6_1,       << : *ppc64_llvm,      boot: true,  << : *llvm_12}
   - {<< : *ppc64le,           << : *stable-6_1,       << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *ppc64le_fedora,    << : *stable-6_1,       << : *clang,           boot: true,  << : *llvm_12}
   - {<< : *ppc64le_suse,      << : *stable-6_1,       << : *clang,           boot: true,  << : *llvm_12}
@@ -3496,7 +3497,7 @@ builds:
   - {<< : *mipsel,            << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
   # ppc32 and ppc64: Build disabled (https://gitlab.com/Linaro/tuxmake/-/issues/108)
   # - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
-  # - {<< : *ppc64,             << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
+  # - {<< : *ppc64_no_werror,   << : *mainline,         << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *ppc64le,           << : *mainline,         << : *ppc64_llvm,      boot: true,  << : *llvm_11}
   - {<< : *ppc64le_fedora,    << : *mainline,         << : *clang,           boot: true,  << : *llvm_11}
   - {<< : *ppc64le_suse,      << : *mainline,         << : *clang,           boot: true,  << : *llvm_11}
@@ -3555,7 +3556,7 @@ builds:
   - {<< : *mipsel,            << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
   # ppc32 and ppc64: Build disabled (https://gitlab.com/Linaro/tuxmake/-/issues/108)
   # - {<< : *ppc32,             << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
-  # - {<< : *ppc64,             << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
+  # - {<< : *ppc64_no_werror,   << : *next,             << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *ppc64le,           << : *next,             << : *ppc64_llvm,      boot: true,  << : *llvm_11}
   - {<< : *ppc64le_fedora,    << : *next,             << : *clang,           boot: true,  << : *llvm_11}
   - {<< : *ppc64le_suse,      << : *next,             << : *clang,           boot: true,  << : *llvm_11}
@@ -3614,7 +3615,7 @@ builds:
   - {<< : *mipsel,            << : *stable,           << : *llvm,            boot: true,  << : *llvm_11}
   # ppc32 and ppc64: Build disabled (https://gitlab.com/Linaro/tuxmake/-/issues/108)
   # - {<< : *ppc32,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_11}
-  # - {<< : *ppc64,             << : *stable,           << : *ppc64_llvm,      boot: true,  << : *llvm_11}
+  # - {<< : *ppc64_no_werror,   << : *stable,           << : *ppc64_llvm,      boot: true,  << : *llvm_11}
   - {<< : *ppc64le,           << : *stable,           << : *ppc64_llvm,      boot: true,  << : *llvm_11}
   - {<< : *ppc64le_fedora,    << : *stable,           << : *clang,           boot: true,  << : *llvm_11}
   - {<< : *ppc64le_suse,      << : *stable,           << : *clang,           boot: true,  << : *llvm_11}
@@ -3673,7 +3674,7 @@ builds:
   - {<< : *mipsel,            << : *stable-6_1,       << : *llvm,            boot: true,  << : *llvm_11}
   # ppc32 and ppc64: Build disabled (https://gitlab.com/Linaro/tuxmake/-/issues/108)
   # - {<< : *ppc32,             << : *stable-6_1,       << : *llvm,            boot: true,  << : *llvm_11}
-  # - {<< : *ppc64,             << : *stable-6_1,       << : *ppc64_llvm,      boot: true,  << : *llvm_11}
+  # - {<< : *ppc64_no_werror,   << : *stable-6_1,       << : *ppc64_llvm,      boot: true,  << : *llvm_11}
   - {<< : *ppc64le,           << : *stable-6_1,       << : *ppc64_llvm,      boot: true,  << : *llvm_11}
   - {<< : *ppc64le_fedora,    << : *stable-6_1,       << : *clang,           boot: true,  << : *llvm_11}
   - {<< : *ppc64le_suse,      << : *stable-6_1,       << : *clang,           boot: true,  << : *llvm_11}

--- a/tuxsuite/5.10-clang-12.tux.yml
+++ b/tuxsuite/5.10-clang-12.tux.yml
@@ -99,9 +99,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-12
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.10-clang-13.tux.yml
+++ b/tuxsuite/5.10-clang-13.tux.yml
@@ -108,9 +108,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-13
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.10-clang-14.tux.yml
+++ b/tuxsuite/5.10-clang-14.tux.yml
@@ -108,9 +108,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-14
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.10-clang-15.tux.yml
+++ b/tuxsuite/5.10-clang-15.tux.yml
@@ -108,9 +108,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-15
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.10-clang-16.tux.yml
+++ b/tuxsuite/5.10-clang-16.tux.yml
@@ -108,9 +108,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-16
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.10-clang-17.tux.yml
+++ b/tuxsuite/5.10-clang-17.tux.yml
@@ -108,9 +108,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-17
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.10-clang-18.tux.yml
+++ b/tuxsuite/5.10-clang-18.tux.yml
@@ -108,9 +108,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.15-clang-12.tux.yml
+++ b/tuxsuite/5.15-clang-12.tux.yml
@@ -204,9 +204,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-12
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.15-clang-13.tux.yml
+++ b/tuxsuite/5.15-clang-13.tux.yml
@@ -213,9 +213,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-13
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.15-clang-14.tux.yml
+++ b/tuxsuite/5.15-clang-14.tux.yml
@@ -213,9 +213,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-14
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.15-clang-15.tux.yml
+++ b/tuxsuite/5.15-clang-15.tux.yml
@@ -213,9 +213,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-15
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.15-clang-16.tux.yml
+++ b/tuxsuite/5.15-clang-16.tux.yml
@@ -213,9 +213,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-16
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.15-clang-17.tux.yml
+++ b/tuxsuite/5.15-clang-17.tux.yml
@@ -213,9 +213,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-17
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.15-clang-18.tux.yml
+++ b/tuxsuite/5.15-clang-18.tux.yml
@@ -213,9 +213,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.4-clang-13.tux.yml
+++ b/tuxsuite/5.4-clang-13.tux.yml
@@ -84,9 +84,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-13
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.4-clang-14.tux.yml
+++ b/tuxsuite/5.4-clang-14.tux.yml
@@ -84,9 +84,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-14
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.4-clang-15.tux.yml
+++ b/tuxsuite/5.4-clang-15.tux.yml
@@ -84,9 +84,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-15
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.4-clang-16.tux.yml
+++ b/tuxsuite/5.4-clang-16.tux.yml
@@ -84,9 +84,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-16
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.4-clang-17.tux.yml
+++ b/tuxsuite/5.4-clang-17.tux.yml
@@ -84,9 +84,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-17
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.4-clang-18.tux.yml
+++ b/tuxsuite/5.4-clang-18.tux.yml
@@ -84,9 +84,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/6.1-clang-14.tux.yml
+++ b/tuxsuite/6.1-clang-14.tux.yml
@@ -193,9 +193,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: clang-14
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/6.1-clang-15.tux.yml
+++ b/tuxsuite/6.1-clang-15.tux.yml
@@ -193,9 +193,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: clang-15
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/6.1-clang-16.tux.yml
+++ b/tuxsuite/6.1-clang-16.tux.yml
@@ -223,9 +223,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-16
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/6.1-clang-17.tux.yml
+++ b/tuxsuite/6.1-clang-17.tux.yml
@@ -223,9 +223,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-17
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/6.1-clang-18.tux.yml
+++ b/tuxsuite/6.1-clang-18.tux.yml
@@ -223,9 +223,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/mainline-clang-14.tux.yml
+++ b/tuxsuite/mainline-clang-14.tux.yml
@@ -193,9 +193,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: clang-14
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/mainline-clang-15.tux.yml
+++ b/tuxsuite/mainline-clang-15.tux.yml
@@ -193,9 +193,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: clang-15
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/mainline-clang-16.tux.yml
+++ b/tuxsuite/mainline-clang-16.tux.yml
@@ -223,9 +223,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-16
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/mainline-clang-17.tux.yml
+++ b/tuxsuite/mainline-clang-17.tux.yml
@@ -223,9 +223,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-17
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/mainline-clang-18.tux.yml
+++ b/tuxsuite/mainline-clang-18.tux.yml
@@ -223,9 +223,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/next-clang-14.tux.yml
+++ b/tuxsuite/next-clang-14.tux.yml
@@ -192,9 +192,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: clang-14
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/next-clang-15.tux.yml
+++ b/tuxsuite/next-clang-15.tux.yml
@@ -192,9 +192,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: clang-15
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/next-clang-16.tux.yml
+++ b/tuxsuite/next-clang-16.tux.yml
@@ -222,9 +222,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-16
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/next-clang-17.tux.yml
+++ b/tuxsuite/next-clang-17.tux.yml
@@ -222,9 +222,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-17
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/next-clang-18.tux.yml
+++ b/tuxsuite/next-clang-18.tux.yml
@@ -222,9 +222,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/stable-clang-14.tux.yml
+++ b/tuxsuite/stable-clang-14.tux.yml
@@ -193,9 +193,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: clang-14
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/stable-clang-15.tux.yml
+++ b/tuxsuite/stable-clang-15.tux.yml
@@ -193,9 +193,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: clang-15
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/stable-clang-16.tux.yml
+++ b/tuxsuite/stable-clang-16.tux.yml
@@ -223,9 +223,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-16
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/stable-clang-17.tux.yml
+++ b/tuxsuite/stable-clang-17.tux.yml
@@ -223,9 +223,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-17
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/stable-clang-18.tux.yml
+++ b/tuxsuite/stable-clang-18.tux.yml
@@ -223,9 +223,7 @@ jobs:
       LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig:
-    - ppc64_guest_defconfig
-    - CONFIG_PPC_DISABLE_WERROR=y
+    kconfig: ppc64_guest_defconfig
     targets:
     - kernel
     kernel_image: vmlinux


### PR DESCRIPTION
Split up the ppc64 configuration into a "no `-Werror`" variant so that `-Werror` can be enabled for clang-14+. `-Warray-bounds` is only enabled for 5.18+, so we only need this configuration enabled for clang-13 and older on 6.1 and newer.

Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/617
