### PR TITLE
Fix LoongArch LTO builds

### DIFF
--- a/.github/workflows/mainline-clang-17.yml
+++ b/.github/workflows/mainline-clang-17.yml
@@ -1579,15 +1579,15 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _dc607225b4a7c8aaaf2c353ef699d987:
+  _ce867994d17bf4dafa58594a2be17d37:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: loongarch
       LLVM_VERSION: 17
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/mainline-clang-18.yml
+++ b/.github/workflows/mainline-clang-18.yml
@@ -1579,15 +1579,15 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _546e6efa66be3ef5a4bdd296a5df4abb:
+  _673d987b5a25dadd0583fed890ffd15d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-17.yml
+++ b/.github/workflows/next-clang-17.yml
@@ -1603,15 +1603,15 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _dc607225b4a7c8aaaf2c353ef699d987:
+  _ce867994d17bf4dafa58594a2be17d37:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: loongarch
       LLVM_VERSION: 17
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/next-clang-18.yml
+++ b/.github/workflows/next-clang-18.yml
@@ -1603,15 +1603,15 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _546e6efa66be3ef5a4bdd296a5df4abb:
+  _673d987b5a25dadd0583fed890ffd15d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-17.yml
+++ b/.github/workflows/stable-clang-17.yml
@@ -1579,15 +1579,15 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _dc607225b4a7c8aaaf2c353ef699d987:
+  _ce867994d17bf4dafa58594a2be17d37:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: loongarch
       LLVM_VERSION: 17
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/.github/workflows/stable-clang-18.yml
+++ b/.github/workflows/stable-clang-18.yml
@@ -1579,15 +1579,15 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _546e6efa66be3ef5a4bdd296a5df4abb:
+  _673d987b5a25dadd0583fed890ffd15d:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_allconfigs
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
     container:
       image: ghcr.io/clangbuiltlinux/qemu
       options: --ipc=host

--- a/generator.yml
+++ b/generator.yml
@@ -275,7 +275,7 @@ loongarch_configs:
   - &loongarch-defconfigs             {config: [defconfig, CONFIG_CRASH_DUMP=n, CONFIG_MODULES=n, CONFIG_RELOCATABLE=n]}
   - &loongarch-defconfigs-lto-thin    {config: [defconfig, CONFIG_CRASH_DUMP=n, CONFIG_MODULES=n, CONFIG_RELOCATABLE=n, CONFIG_LTO_CLANG_THIN=y]}
   - &loongarch-allyesconfigs          {config: [allyesconfig, CONFIG_CRASH_DUMP=n, CONFIG_KCOV=n, CONFIG_MODULES=n, CONFIG_RELOCATABLE=n]}
-  - &loongarch-allyesconfigs-lto-thin {config: [allyesconfig, CONFIG_CRASH_DUMP=n, CONFIG_KCOV=n, CONFIG_MODULES=n, CONFIG_RELOCATABLE=n, CONFIG_GCOV_KERNEL=n, CONFIG_LTO_CLANG_THIN=y]}
+  - &loongarch-allyesconfigs-lto-thin {config: [allyesconfig, CONFIG_CRASH_DUMP=n, CONFIG_FTRACE=n, CONFIG_KCOV=n, CONFIG_MODULES=n, CONFIG_RELOCATABLE=n, CONFIG_GCOV_KERNEL=n, CONFIG_LTO_CLANG_THIN=y]}
 configs:
   #                     config:                                                                                image target (optional)    [ARCH:] (Optional: x86)  targets to build
   - &arm32_v5          {config: multi_v5_defconfig,                                                                                        ARCH: *arm-arch,        << : *kernel_dtbs}

--- a/tuxsuite/mainline-clang-17.tux.yml
+++ b/tuxsuite/mainline-clang-17.tux.yml
@@ -617,6 +617,7 @@ jobs:
     kconfig:
     - allyesconfig
     - CONFIG_CRASH_DUMP=n
+    - CONFIG_FTRACE=n
     - CONFIG_KCOV=n
     - CONFIG_MODULES=n
     - CONFIG_RELOCATABLE=n

--- a/tuxsuite/mainline-clang-18.tux.yml
+++ b/tuxsuite/mainline-clang-18.tux.yml
@@ -617,6 +617,7 @@ jobs:
     kconfig:
     - allyesconfig
     - CONFIG_CRASH_DUMP=n
+    - CONFIG_FTRACE=n
     - CONFIG_KCOV=n
     - CONFIG_MODULES=n
     - CONFIG_RELOCATABLE=n

--- a/tuxsuite/next-clang-17.tux.yml
+++ b/tuxsuite/next-clang-17.tux.yml
@@ -628,6 +628,7 @@ jobs:
     kconfig:
     - allyesconfig
     - CONFIG_CRASH_DUMP=n
+    - CONFIG_FTRACE=n
     - CONFIG_KCOV=n
     - CONFIG_MODULES=n
     - CONFIG_RELOCATABLE=n

--- a/tuxsuite/next-clang-18.tux.yml
+++ b/tuxsuite/next-clang-18.tux.yml
@@ -628,6 +628,7 @@ jobs:
     kconfig:
     - allyesconfig
     - CONFIG_CRASH_DUMP=n
+    - CONFIG_FTRACE=n
     - CONFIG_KCOV=n
     - CONFIG_MODULES=n
     - CONFIG_RELOCATABLE=n

--- a/tuxsuite/stable-clang-17.tux.yml
+++ b/tuxsuite/stable-clang-17.tux.yml
@@ -618,6 +618,7 @@ jobs:
     kconfig:
     - allyesconfig
     - CONFIG_CRASH_DUMP=n
+    - CONFIG_FTRACE=n
     - CONFIG_KCOV=n
     - CONFIG_MODULES=n
     - CONFIG_RELOCATABLE=n

--- a/tuxsuite/stable-clang-18.tux.yml
+++ b/tuxsuite/stable-clang-18.tux.yml
@@ -618,6 +618,7 @@ jobs:
     kconfig:
     - allyesconfig
     - CONFIG_CRASH_DUMP=n
+    - CONFIG_FTRACE=n
     - CONFIG_KCOV=n
     - CONFIG_MODULES=n
     - CONFIG_RELOCATABLE=n


### PR DESCRIPTION
I missed that CONFIG_FTRACE needs to be disabled because LoongArch uses
recordmcount, which is not supported when building with LTO.
