### PR TITLE
Disable arm64 big endian builds with LLVM 13 and 14

### DIFF
--- a/.github/workflows/4.14-clang-13.yml
+++ b/.github/workflows/4.14-clang-13.yml
@@ -113,30 +113,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _17d159a26103728e87685971646fbba4:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 CC=clang LD=ld.lld LLVM_IAS=0 LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _f4d3de3db46c87da313d87e1f3f6dc29:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/4.14-clang-14.yml
+++ b/.github/workflows/4.14-clang-14.yml
@@ -113,30 +113,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _fb25554ef8c0a315a0e359602d1e58ba:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 CC=clang LD=ld.lld LLVM_IAS=0 LLVM_VERSION=14 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _93adcc31e3e500dcde3470940f30d9f4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/4.19-clang-13.yml
+++ b/.github/workflows/4.19-clang-13.yml
@@ -113,30 +113,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _9eb09c7190bf44727170b34b8557352d:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _f4d3de3db46c87da313d87e1f3f6dc29:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/4.19-clang-14.yml
+++ b/.github/workflows/4.19-clang-14.yml
@@ -113,30 +113,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _e0c42d25c62400f3397e3a4da15fed2d:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _93adcc31e3e500dcde3470940f30d9f4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/5.10-clang-13.yml
+++ b/.github/workflows/5.10-clang-13.yml
@@ -161,30 +161,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _63a33d081dc4000b2eaf65e367d99441:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _7dde147b804e95998e110f5dfe487e8f:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/5.10-clang-14.yml
+++ b/.github/workflows/5.10-clang-14.yml
@@ -161,30 +161,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _93edda8d8511b7a181ff233017422068:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _6b9b48c5ca690a81c94f317d6baf1765:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -233,30 +233,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _63a33d081dc4000b2eaf65e367d99441:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _db43a82d57f22c3d14f773847535c8d4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -233,30 +233,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _93edda8d8511b7a181ff233017422068:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _74abf9fa882dcc857d6c2466f2ba12ce:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/5.4-clang-13.yml
+++ b/.github/workflows/5.4-clang-13.yml
@@ -113,30 +113,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _63a33d081dc4000b2eaf65e367d99441:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _0eecb2df639bfc6c34cb18f6437e649b:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/5.4-clang-14.yml
+++ b/.github/workflows/5.4-clang-14.yml
@@ -113,30 +113,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _93edda8d8511b7a181ff233017422068:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _3ee45057c88242c3397698de92e3b147:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/6.1-clang-13.yml
+++ b/.github/workflows/6.1-clang-13.yml
@@ -233,30 +233,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _63a33d081dc4000b2eaf65e367d99441:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _db43a82d57f22c3d14f773847535c8d4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/6.1-clang-14.yml
+++ b/.github/workflows/6.1-clang-14.yml
@@ -233,30 +233,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _93edda8d8511b7a181ff233017422068:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _74abf9fa882dcc857d6c2466f2ba12ce:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/arm64-clang-13.yml
+++ b/.github/workflows/arm64-clang-13.yml
@@ -65,30 +65,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _63a33d081dc4000b2eaf65e367d99441:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest

--- a/.github/workflows/arm64-clang-14.yml
+++ b/.github/workflows/arm64-clang-14.yml
@@ -65,30 +65,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _93edda8d8511b7a181ff233017422068:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest

--- a/.github/workflows/arm64-fixes-clang-13.yml
+++ b/.github/workflows/arm64-fixes-clang-13.yml
@@ -65,30 +65,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _63a33d081dc4000b2eaf65e367d99441:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest

--- a/.github/workflows/arm64-fixes-clang-14.yml
+++ b/.github/workflows/arm64-fixes-clang-14.yml
@@ -65,30 +65,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _93edda8d8511b7a181ff233017422068:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest

--- a/.github/workflows/mainline-clang-13.yml
+++ b/.github/workflows/mainline-clang-13.yml
@@ -233,30 +233,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _63a33d081dc4000b2eaf65e367d99441:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _db43a82d57f22c3d14f773847535c8d4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -233,30 +233,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _93edda8d8511b7a181ff233017422068:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _74abf9fa882dcc857d6c2466f2ba12ce:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/next-clang-13.yml
+++ b/.github/workflows/next-clang-13.yml
@@ -233,30 +233,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _63a33d081dc4000b2eaf65e367d99441:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _db43a82d57f22c3d14f773847535c8d4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -233,30 +233,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _93edda8d8511b7a181ff233017422068:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _74abf9fa882dcc857d6c2466f2ba12ce:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -233,30 +233,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _63a33d081dc4000b2eaf65e367d99441:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _db43a82d57f22c3d14f773847535c8d4:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -233,30 +233,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _93edda8d8511b7a181ff233017422068:
-    runs-on: ubuntu-latest
-    needs: kick_tuxsuite_defconfigs
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _74abf9fa882dcc857d6c2466f2ba12ce:
     runs-on: ubuntu-latest
     needs: kick_tuxsuite_defconfigs

--- a/generator.yml
+++ b/generator.yml
@@ -2300,7 +2300,6 @@ builds:
   - {<< : *arm32_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_kasan,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
@@ -2360,7 +2359,6 @@ builds:
   - {<< : *arm32_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
@@ -2421,7 +2419,6 @@ builds:
   - {<< : *arm32_alpine,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm32_suse,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64,             << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *arm64be,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_lto_full,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_lto_thin,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_kasan,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_14}
@@ -2481,7 +2478,6 @@ builds:
   - {<< : *arm32_alpine,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm32_suse,        << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64,             << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *arm64be,           << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_lto_full,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_lto_thin,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_kasan,       << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_14}
@@ -2541,7 +2537,6 @@ builds:
   - {<< : *arm32_alpine,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_cfi_lto,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
@@ -2599,7 +2594,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm32_allyes,      << : *stable-5_10,      << : *llvm,            boot: false, << : *llvm_14}
   - {<< : *arm64,             << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *arm64be,           << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_14}
@@ -2621,7 +2615,6 @@ builds:
   - {<< : *arm32_v7,          << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_14}
   - {<< : *arm32_v7_t,        << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_14}
   - {<< : *arm64_no_vdso32,   << : *stable-5_4,       << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *arm64be,           << : *stable-5_4,       << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *mips,              << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_14}
   - {<< : *mipsel,            << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_14}
   - {<< : *ppc32,             << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_14}
@@ -2635,7 +2628,6 @@ builds:
   - {<< : *arm32_v7,          << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_14}
   - {<< : *arm32_v7_t,        << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_14}
   - {<< : *arm64,             << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_14}
-  - {<< : *arm64be,           << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_14}
   - {<< : *ppc64le,           << : *stable-4_19,      << : *clang,           boot: true,  << : *llvm_14}
   - {<< : *x86_64,            << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_14}
   ############
@@ -2644,7 +2636,6 @@ builds:
   - {<< : *arm32_v7,          << : *stable-4_14,      << : *clang,           boot: true,  << : *llvm_14}
   - {<< : *arm32_v7_t,        << : *stable-4_14,      << : *clang,           boot: true,  << : *llvm_14}
   - {<< : *arm64,             << : *stable-4_14,      << : *lld,             boot: true,  << : *llvm_14}
-  - {<< : *arm64be,           << : *stable-4_14,      << : *lld,             boot: true,  << : *llvm_14}
   - {<< : *ppc64le,           << : *stable-4_14,      << : *clang,           boot: true,  << : *llvm_14}
   - {<< : *x86_64,            << : *stable-4_14,      << : *lld,             boot: true,  << : *llvm_14}
   #############
@@ -2706,12 +2697,10 @@ builds:
   #  ARM64  #
   ###########
   - {<< : *arm64,             << : *arm64-core,       << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *arm64be,           << : *arm64-core,       << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_allmod,      << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm64_allno,       << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm64_allyes,      << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm64,             << : *arm64-fixes,      << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *arm64be,           << : *arm64-fixes,      << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm64_allno,       << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_14}
@@ -2734,7 +2723,6 @@ builds:
   - {<< : *arm32_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_kasan,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
@@ -2794,7 +2782,6 @@ builds:
   - {<< : *arm32_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
@@ -2855,7 +2842,6 @@ builds:
   - {<< : *arm32_alpine,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm32_suse,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64,             << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm64be,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_lto_full,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_lto_thin,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_kasan,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_13}
@@ -2915,7 +2901,6 @@ builds:
   - {<< : *arm32_alpine,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm32_suse,        << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64,             << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm64be,           << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_lto_full,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_lto_thin,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_kasan,       << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_13}
@@ -2975,7 +2960,6 @@ builds:
   - {<< : *arm32_alpine,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_cfi_lto,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
@@ -3033,7 +3017,6 @@ builds:
   - {<< : *arm32_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_allyes,      << : *stable-5_10,      << : *llvm,            boot: false, << : *llvm_13}
   - {<< : *arm64,             << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm64be,           << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_allmod,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_13}
@@ -3055,7 +3038,6 @@ builds:
   - {<< : *arm32_v7,          << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_13}
   - {<< : *arm32_v7_t,        << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_13}
   - {<< : *arm64_no_vdso32,   << : *stable-5_4,       << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm64be,           << : *stable-5_4,       << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *mips,              << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_13}
   - {<< : *mipsel,            << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_13}
   - {<< : *ppc32,             << : *stable-5_4,       << : *llvm,            boot: true,  << : *llvm_13}
@@ -3069,7 +3051,6 @@ builds:
   - {<< : *arm32_v7,          << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_13}
   - {<< : *arm32_v7_t,        << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_13}
   - {<< : *arm64,             << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_13}
-  - {<< : *arm64be,           << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_13}
   - {<< : *ppc64le,           << : *stable-4_19,      << : *clang,           boot: true,  << : *llvm_13}
   - {<< : *x86_64,            << : *stable-4_19,      << : *llvm,            boot: true,  << : *llvm_13}
   ############
@@ -3078,7 +3059,6 @@ builds:
   - {<< : *arm32_v7,          << : *stable-4_14,      << : *clang,           boot: true,  << : *llvm_13}
   - {<< : *arm32_v7_t,        << : *stable-4_14,      << : *clang,           boot: true,  << : *llvm_13}
   - {<< : *arm64,             << : *stable-4_14,      << : *lld,             boot: true,  << : *llvm_13}
-  - {<< : *arm64be,           << : *stable-4_14,      << : *lld,             boot: true,  << : *llvm_13}
   - {<< : *ppc64le,           << : *stable-4_14,      << : *clang,           boot: true,  << : *llvm_13}
   - {<< : *x86_64,            << : *stable-4_14,      << : *lld,             boot: true,  << : *llvm_13}
   #############
@@ -3140,12 +3120,10 @@ builds:
   #  ARM64  #
   ###########
   - {<< : *arm64,             << : *arm64-core,       << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm64be,           << : *arm64-core,       << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_allmod,      << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm64_allno,       << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm64_allyes,      << : *arm64-core,       << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm64,             << : *arm64-fixes,      << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm64be,           << : *arm64-fixes,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_allmod,      << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm64_allno,       << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm64_allyes,      << : *arm64-fixes,      << : *llvm_full,       boot: false, << : *llvm_13}

--- a/tuxsuite/4.14-clang-13.tux.yml
+++ b/tuxsuite/4.14-clang-13.tux.yml
@@ -36,16 +36,6 @@ jobs:
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0
-  - target_arch: arm64
-    toolchain: clang-13
-    kconfig:
-    - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LD: ld.lld
-      LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-13
     kconfig: powernv_defconfig

--- a/tuxsuite/4.14-clang-14.tux.yml
+++ b/tuxsuite/4.14-clang-14.tux.yml
@@ -36,16 +36,6 @@ jobs:
     make_variables:
       LD: ld.lld
       LLVM_IAS: 0
-  - target_arch: arm64
-    toolchain: clang-14
-    kconfig:
-    - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LD: ld.lld
-      LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-14
     kconfig: powernv_defconfig

--- a/tuxsuite/4.19-clang-13.tux.yml
+++ b/tuxsuite/4.19-clang-13.tux.yml
@@ -38,16 +38,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
-  - target_arch: arm64
-    toolchain: clang-13
-    kconfig:
-    - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-13
     kconfig: powernv_defconfig

--- a/tuxsuite/4.19-clang-14.tux.yml
+++ b/tuxsuite/4.19-clang-14.tux.yml
@@ -38,16 +38,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
-  - target_arch: arm64
-    toolchain: clang-14
-    kconfig:
-    - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
   - target_arch: powerpc
     toolchain: clang-14
     kconfig: powernv_defconfig

--- a/tuxsuite/5.10-clang-13.tux.yml
+++ b/tuxsuite/5.10-clang-13.tux.yml
@@ -56,16 +56,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-13
-    kconfig:
-    - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: i386
     toolchain: clang-13
     kconfig: defconfig

--- a/tuxsuite/5.10-clang-14.tux.yml
+++ b/tuxsuite/5.10-clang-14.tux.yml
@@ -56,16 +56,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-14
-    kconfig:
-    - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: i386
     toolchain: clang-14
     kconfig: defconfig

--- a/tuxsuite/5.15-clang-13.tux.yml
+++ b/tuxsuite/5.15-clang-13.tux.yml
@@ -87,16 +87,6 @@ jobs:
     toolchain: clang-13
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-13
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/5.15-clang-14.tux.yml
+++ b/tuxsuite/5.15-clang-14.tux.yml
@@ -87,16 +87,6 @@ jobs:
     toolchain: clang-14
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-14
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/5.4-clang-13.tux.yml
+++ b/tuxsuite/5.4-clang-13.tux.yml
@@ -40,16 +40,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-13
-    kconfig:
-    - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: mips
     toolchain: clang-13
     kconfig:

--- a/tuxsuite/5.4-clang-14.tux.yml
+++ b/tuxsuite/5.4-clang-14.tux.yml
@@ -40,16 +40,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-14
-    kconfig:
-    - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: mips
     toolchain: clang-14
     kconfig:

--- a/tuxsuite/6.1-clang-13.tux.yml
+++ b/tuxsuite/6.1-clang-13.tux.yml
@@ -87,16 +87,6 @@ jobs:
     toolchain: clang-13
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-13
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/6.1-clang-14.tux.yml
+++ b/tuxsuite/6.1-clang-14.tux.yml
@@ -87,16 +87,6 @@ jobs:
     toolchain: clang-14
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-14
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/arm64-clang-13.tux.yml
+++ b/tuxsuite/arm64-clang-13.tux.yml
@@ -20,16 +20,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-13
-    kconfig:
-    - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
 - name: allconfigs
   builds:
   - target_arch: arm64

--- a/tuxsuite/arm64-clang-14.tux.yml
+++ b/tuxsuite/arm64-clang-14.tux.yml
@@ -20,16 +20,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-14
-    kconfig:
-    - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
 - name: allconfigs
   builds:
   - target_arch: arm64

--- a/tuxsuite/arm64-fixes-clang-13.tux.yml
+++ b/tuxsuite/arm64-fixes-clang-13.tux.yml
@@ -20,16 +20,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-13
-    kconfig:
-    - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
 - name: allconfigs
   builds:
   - target_arch: arm64

--- a/tuxsuite/arm64-fixes-clang-14.tux.yml
+++ b/tuxsuite/arm64-fixes-clang-14.tux.yml
@@ -20,16 +20,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-14
-    kconfig:
-    - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
 - name: allconfigs
   builds:
   - target_arch: arm64

--- a/tuxsuite/mainline-clang-13.tux.yml
+++ b/tuxsuite/mainline-clang-13.tux.yml
@@ -87,16 +87,6 @@ jobs:
     toolchain: clang-13
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-13
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-14.tux.yml
+++ b/tuxsuite/mainline-clang-14.tux.yml
@@ -87,16 +87,6 @@ jobs:
     toolchain: clang-14
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-14
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/next-clang-13.tux.yml
+++ b/tuxsuite/next-clang-13.tux.yml
@@ -87,16 +87,6 @@ jobs:
     toolchain: clang-13
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-13
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/next-clang-14.tux.yml
+++ b/tuxsuite/next-clang-14.tux.yml
@@ -87,16 +87,6 @@ jobs:
     toolchain: clang-14
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-14
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/stable-clang-13.tux.yml
+++ b/tuxsuite/stable-clang-13.tux.yml
@@ -87,16 +87,6 @@ jobs:
     toolchain: clang-13
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-13
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/stable-clang-14.tux.yml
+++ b/tuxsuite/stable-clang-14.tux.yml
@@ -87,16 +87,6 @@ jobs:
     toolchain: clang-14
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-14
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel


### PR DESCRIPTION
LLVM's integrated assembler incorrect generates the encoding for nop when targeting arm64 big endian. This was fixed in LLVM 15, so disable builds for LLVM 13 and 14.

Link: https://github.com/ClangBuiltLinux/linux/issues/1948

NOTE: Instead of outright disabling these builds, we could move them to `LLVM=1 LLVM_IAS=0` instead. I do not have a strong opinion either way.
