### PR TITLE
patches: Fix android-4.14 and android-4.19 brk backports

### DIFF
--- a/patches/android-4.14/0002-x86-mm-Fix-RESERVE_BRK-for-older-binutils.patch
+++ b/patches/android-4.14/0002-x86-mm-Fix-RESERVE_BRK-for-older-binutils.patch
@@ -102,9 +102,9 @@ index e1110e2ebc9e..e0e6aad9cd51 100644
 +
 +.macro __RESERVE_BRK name, size
 +	.pushsection .bss..brk, "aw"
-+SYM_DATA_START(__brk_\name)
++GLOBAL(__brk_\name)
 +	.skip \size
-+SYM_DATA_END(__brk_\name)
++END(__brk_\name)
  	.popsection
 +.endm
 +

--- a/patches/android-4.19/0002-x86-mm-Fix-RESERVE_BRK-for-older-binutils.patch
+++ b/patches/android-4.19/0002-x86-mm-Fix-RESERVE_BRK-for-older-binutils.patch
@@ -102,9 +102,9 @@ index e1110e2ebc9e..e0e6aad9cd51 100644
 +
 +.macro __RESERVE_BRK name, size
 +	.pushsection .bss..brk, "aw"
-+SYM_DATA_START(__brk_\name)
++GLOBAL(__brk_\name)
 +	.skip \size
-+SYM_DATA_END(__brk_\name)
++END(__brk_\name)
  	.popsection
 +.endm
 +


### PR DESCRIPTION
While there have been no errors reported from this in CI yet, it is a
known issue with these patches, so fix them just in case.

Link: https://lore.kernel.org/CA+G9fYtS81+Tze6Zs0f908xXZ7zeMMEdpq65=betjDnyAkLn_g@mail.gmail.com/
