### PR TITLE
Temporarily change cron string to test caching

### DIFF
--- a/.github/workflows/tip-clang-17.yml
+++ b/.github/workflows/tip-clang-17.yml
@@ -12,7 +12,7 @@ name: tip (clang-17)
     - tuxsuite/tip-clang-17.tux.yml
     - .github/workflows/tip-clang-17.yml
   schedule:
-  - cron: 0 0 * * 1,2,3,4,5
+  - cron: 41 22 19 12 2
   workflow_dispatch: null
 permissions: read-all
 jobs:


### PR DESCRIPTION
The caching infrastructure gets out of the way when using
workflow_dispatch, so we need to change the cron string to something
that will run right away when merged. This will be reverted once the job
has started.
