### PR TITLE
Update LoongArch builds for latest developments

### DIFF
--- a/.github/workflows/6.6-clang-17.yml
+++ b/.github/workflows/6.6-clang-17.yml
@@ -582,62 +582,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _fe27947e3c9dc4bbbefbfe70b86b6e43:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: loongarch
-      LLVM_VERSION: 17
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
-  _4d0e66a3eda489124a6b93a6763f95db:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_LTO_CLANG_THIN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: loongarch
-      LLVM_VERSION: 17
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_LTO_CLANG_THIN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _31c8bcfe68e731d6236ca25af17bb0bd:
     runs-on: ubuntu-latest
     needs:
@@ -1880,62 +1824,6 @@ jobs:
       LLVM_VERSION: 17
       BOOT: 0
       CONFIG: allmodconfig+CONFIG_WERROR=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
-  _0f188cdec94cf485dea1acbe9e6fe2da:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_allconfigs
-    - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: loongarch
-      LLVM_VERSION: 17
-      BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
-  _ce867994d17bf4dafa58594a2be17d37:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_allconfigs
-    - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: loongarch
-      LLVM_VERSION: 17
-      BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.6-clang-18.yml
+++ b/.github/workflows/6.6-clang-18.yml
@@ -582,18 +582,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _c14d023a315cad36e5d5d6ea80436cc5:
+  _607f4ff88c5ce4336318ec876582deb2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
+    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
+      CONFIG: defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -610,18 +610,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _075efb0c529fa75ac5def59ccf273284:
+  _c5f8d365b4a86ea82ea6f05e48c6158f:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1896,18 +1896,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _815f1cb999e7b905e3f7afa1d8c552ec:
+  _03fb3a458a2932225d42f868649d6285:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
+      CONFIG: allmodconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1924,18 +1924,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _673d987b5a25dadd0583fed890ffd15d:
+  _c1cdf2678eeae9d3f6207b9c46a72d59:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-17.yml
+++ b/.github/workflows/mainline-clang-17.yml
@@ -582,62 +582,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _fe27947e3c9dc4bbbefbfe70b86b6e43:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: loongarch
-      LLVM_VERSION: 17
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
-  _4d0e66a3eda489124a6b93a6763f95db:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_LTO_CLANG_THIN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: loongarch
-      LLVM_VERSION: 17
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_LTO_CLANG_THIN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _31c8bcfe68e731d6236ca25af17bb0bd:
     runs-on: ubuntu-latest
     needs:
@@ -1880,62 +1824,6 @@ jobs:
       LLVM_VERSION: 17
       BOOT: 0
       CONFIG: allmodconfig+CONFIG_WERROR=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
-  _0f188cdec94cf485dea1acbe9e6fe2da:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_allconfigs
-    - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: loongarch
-      LLVM_VERSION: 17
-      BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
-  _ce867994d17bf4dafa58594a2be17d37:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_allconfigs
-    - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: loongarch
-      LLVM_VERSION: 17
-      BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-18.yml
+++ b/.github/workflows/mainline-clang-18.yml
@@ -610,18 +610,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _c14d023a315cad36e5d5d6ea80436cc5:
+  _607f4ff88c5ce4336318ec876582deb2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
+    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
+      CONFIG: defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -638,18 +638,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _075efb0c529fa75ac5def59ccf273284:
+  _c5f8d365b4a86ea82ea6f05e48c6158f:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1952,18 +1952,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _815f1cb999e7b905e3f7afa1d8c552ec:
+  _03fb3a458a2932225d42f868649d6285:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
+      CONFIG: allmodconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1980,18 +1980,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _673d987b5a25dadd0583fed890ffd15d:
+  _c1cdf2678eeae9d3f6207b9c46a72d59:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-17.yml
+++ b/.github/workflows/next-clang-17.yml
@@ -582,62 +582,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _fe27947e3c9dc4bbbefbfe70b86b6e43:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: loongarch
-      LLVM_VERSION: 17
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
-  _4d0e66a3eda489124a6b93a6763f95db:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_LTO_CLANG_THIN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: loongarch
-      LLVM_VERSION: 17
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_LTO_CLANG_THIN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _31c8bcfe68e731d6236ca25af17bb0bd:
     runs-on: ubuntu-latest
     needs:
@@ -1908,62 +1852,6 @@ jobs:
       LLVM_VERSION: 17
       BOOT: 0
       CONFIG: allmodconfig+CONFIG_WERROR=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
-  _0f188cdec94cf485dea1acbe9e6fe2da:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_allconfigs
-    - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: loongarch
-      LLVM_VERSION: 17
-      BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
-  _ce867994d17bf4dafa58594a2be17d37:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_allconfigs
-    - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: loongarch
-      LLVM_VERSION: 17
-      BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-18.yml
+++ b/.github/workflows/next-clang-18.yml
@@ -610,18 +610,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _c14d023a315cad36e5d5d6ea80436cc5:
+  _607f4ff88c5ce4336318ec876582deb2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
+    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
+      CONFIG: defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -638,18 +638,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _075efb0c529fa75ac5def59ccf273284:
+  _c5f8d365b4a86ea82ea6f05e48c6158f:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1980,18 +1980,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _815f1cb999e7b905e3f7afa1d8c552ec:
+  _03fb3a458a2932225d42f868649d6285:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
+      CONFIG: allmodconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -2008,18 +2008,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _673d987b5a25dadd0583fed890ffd15d:
+  _c1cdf2678eeae9d3f6207b9c46a72d59:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/stable-clang-17.yml
+++ b/.github/workflows/stable-clang-17.yml
@@ -582,62 +582,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _fe27947e3c9dc4bbbefbfe70b86b6e43:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: loongarch
-      LLVM_VERSION: 17
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
-  _4d0e66a3eda489124a6b93a6763f95db:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_LTO_CLANG_THIN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: loongarch
-      LLVM_VERSION: 17
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_LTO_CLANG_THIN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
   _31c8bcfe68e731d6236ca25af17bb0bd:
     runs-on: ubuntu-latest
     needs:
@@ -1880,62 +1824,6 @@ jobs:
       LLVM_VERSION: 17
       BOOT: 0
       CONFIG: allmodconfig+CONFIG_WERROR=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
-  _0f188cdec94cf485dea1acbe9e6fe2da:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_allconfigs
-    - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: loongarch
-      LLVM_VERSION: 17
-      BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v3
-      with:
-        name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
-      with:
-        name: boot_utils_json_allconfigs
-    - name: Check Build and Boot Logs
-      run: ./check_logs.py
-  _ce867994d17bf4dafa58594a2be17d37:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_allconfigs
-    - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: loongarch
-      LLVM_VERSION: 17
-      BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/stable-clang-18.yml
+++ b/.github/workflows/stable-clang-18.yml
@@ -610,18 +610,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _c14d023a315cad36e5d5d6ea80436cc5:
+  _607f4ff88c5ce4336318ec876582deb2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
+    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
+      CONFIG: defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -638,18 +638,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _075efb0c529fa75ac5def59ccf273284:
+  _c5f8d365b4a86ea82ea6f05e48c6158f:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CRASH_DUMP=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1952,18 +1952,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _815f1cb999e7b905e3f7afa1d8c552ec:
+  _03fb3a458a2932225d42f868649d6285:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n
+      CONFIG: allmodconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1980,18 +1980,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
-  _673d987b5a25dadd0583fed890ffd15d:
+  _c1cdf2678eeae9d3f6207b9c46a72d59:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allyesconfig+CONFIG_CRASH_DUMP=n+CONFIG_FTRACE=n+CONFIG_KCOV=n+CONFIG_MODULES=n+CONFIG_RELOCATABLE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/generator.yml
+++ b/generator.yml
@@ -295,14 +295,6 @@ chromeos_configs:
 kasan_configs:
   - &arm64-kasan-configs    {config: [defconfig, CONFIG_FTRACE=y, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y]}
   - &arm64-kasan-sw-configs {config: [defconfig, CONFIG_FTRACE=y, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_SW_TAGS=y, CONFIG_KUNIT=y]}
-loongarch_configs:
-  # CONFIG_CRASH_DUMP / CONFIG_RELOCATABLE: https://github.com/ClangBuiltLinux/linux/issues/1883
-  # CONFIG_KCOV: https://github.com/ClangBuiltLinux/linux/issues/1895
-  # CONFIG_MODULES: https://github.com/ClangBuiltLinux/linux/issues/1884
-  - &loongarch-defconfigs             {config: [defconfig, CONFIG_CRASH_DUMP=n, CONFIG_MODULES=n, CONFIG_RELOCATABLE=n]}
-  - &loongarch-defconfigs-lto-thin    {config: [defconfig, CONFIG_CRASH_DUMP=n, CONFIG_MODULES=n, CONFIG_RELOCATABLE=n, CONFIG_LTO_CLANG_THIN=y]}
-  - &loongarch-allyesconfigs          {config: [allyesconfig, CONFIG_CRASH_DUMP=n, CONFIG_KCOV=n, CONFIG_MODULES=n, CONFIG_RELOCATABLE=n]}
-  - &loongarch-allyesconfigs-lto-thin {config: [allyesconfig, CONFIG_CRASH_DUMP=n, CONFIG_FTRACE=n, CONFIG_KCOV=n, CONFIG_MODULES=n, CONFIG_RELOCATABLE=n, CONFIG_GCOV_KERNEL=n, CONFIG_LTO_CLANG_THIN=y]}
 configs:
   #                     config:                                                                                image target (optional)    [ARCH:] (Optional: x86)  targets to build
   - &arm32_v5          {config: multi_v5_defconfig,                                                                                        ARCH: *arm-arch,        << : *kernel_dtbs}
@@ -347,10 +339,10 @@ configs:
   - &hexagon_allmod    {config: [allmodconfig, CONFIG_WERROR=n],                                                                           ARCH: *hexagon-arch,    << : *default}
   - &i386              {config: defconfig,                                                                                                 ARCH: *i386-arch,       << : *kernel}
   - &i386_suse         {config: *i386-suse-config-url,                                                                                     ARCH: *i386-arch,       << : *default}
-  - &loong             {<< : *loongarch-defconfigs,                                                                                        ARCH: *loongarch-arch,  << : *kernel}
-  - &loong_lto_thin    {<< : *loongarch-defconfigs-lto-thin,                                                                               ARCH: *loongarch-arch,  << : *kernel}
-  - &loong_allyes      {<< : *loongarch-allyesconfigs,                                                                                     ARCH: *loongarch-arch,  << : *default}
-  - &loong_allyes_lto  {<< : *loongarch-allyesconfigs-lto-thin,                                                                            ARCH: *loongarch-arch,  << : *default}
+  - &loong             {config: defconfig,                                                                                                 ARCH: *loongarch-arch,  << : *kernel}
+  - &loong_lto_thin    {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                      ARCH: *loongarch-arch,  << : *kernel}
+  - &loong_allmod      {config: allmodconfig,                                                                                              ARCH: *loongarch-arch,  << : *default}
+  - &loong_allmod_lto  {config: [allmodconfig, CONFIG_FTRACE=n, CONFIG_GCOV_KERNEL=n, CONFIG_LTO_CLANG_THIN=y],                            ARCH: *loongarch-arch,  << : *default}
   - &mips              {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y, CONFIG_CPU_BIG_ENDIAN=y],           kernel_image: vmlinux,      ARCH: *mips-arch,       << : *kernel}
   - &mipsel            {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y],                                    kernel_image: vmlinux,      ARCH: *mips-arch,       << : *kernel}
   - &ppc32             {config: ppc44x_defconfig,                                                              kernel_image: uImage,       ARCH: *powerpc-arch,    << : *kernel}
@@ -459,8 +451,8 @@ builds:
   - {<< : *i386_suse,         << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *loong,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *loong_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *loong_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
-  - {<< : *loong_allyes_lto,  << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *loong_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *loong_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *mips,              << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *mipsel,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   # ppc32: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1814)
@@ -535,8 +527,8 @@ builds:
   - {<< : *i386_suse,         << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *loong,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *loong_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *loong_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
-  - {<< : *loong_allyes_lto,  << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *loong_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *loong_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *mips,              << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *mipsel,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   # ppc32: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1814)
@@ -612,8 +604,8 @@ builds:
   - {<< : *i386_suse,         << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *loong,             << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *loong_lto_thin,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *loong_allyes,      << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
-  - {<< : *loong_allyes_lto,  << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *loong_allmod,      << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *loong_allmod_lto,  << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *mips,              << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *mipsel,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   # ppc32: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1814)
@@ -687,8 +679,8 @@ builds:
   - {<< : *i386_suse,         << : *stable-6_6,       << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *loong,             << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *loong_lto_thin,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *loong_allyes,      << : *stable-6_6,       << : *llvm_full,       boot: false, << : *llvm_tot}
-  - {<< : *loong_allyes_lto,  << : *stable-6_6,       << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *loong_allmod,      << : *stable-6_6,       << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *loong_allmod_lto,  << : *stable-6_6,       << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *mips,              << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *mipsel,            << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   # ppc32: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1814)
@@ -1018,10 +1010,6 @@ builds:
   - {<< : *hexagon_allmod,    << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *i386_suse,         << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
-  - {<< : *loong,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *loong_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *loong_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
-  - {<< : *loong_allyes_lto,  << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *mips,              << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *mipsel,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   # ppc32: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1814)
@@ -1092,10 +1080,6 @@ builds:
   - {<< : *hexagon_allmod,    << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *i386,              << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *i386_suse,         << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
-  - {<< : *loong,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *loong_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *loong_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
-  - {<< : *loong_allyes_lto,  << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *mips,              << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *mipsel,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   # ppc32: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1814)
@@ -1167,10 +1151,6 @@ builds:
   - {<< : *hexagon_allmod,    << : *stable,           << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *i386,              << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *i386_suse,         << : *stable,           << : *llvm_full,       boot: false, << : *llvm_latest}
-  - {<< : *loong,             << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *loong_lto_thin,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *loong_allyes,      << : *stable,           << : *llvm_full,       boot: false, << : *llvm_latest}
-  - {<< : *loong_allyes_lto,  << : *stable,           << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *mips,              << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *mipsel,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   # ppc32: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1814)
@@ -1241,10 +1221,6 @@ builds:
   - {<< : *hexagon_allmod,    << : *stable-6_6,       << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *i386,              << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *i386_suse,         << : *stable-6_6,       << : *llvm_full,       boot: false, << : *llvm_latest}
-  - {<< : *loong,             << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *loong_lto_thin,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *loong_allyes,      << : *stable-6_6,       << : *llvm_full,       boot: false, << : *llvm_latest}
-  - {<< : *loong_allyes_lto,  << : *stable-6_6,       << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *mips,              << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *mipsel,            << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   # ppc32: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1814)

--- a/tuxsuite/6.6-clang-17.tux.yml
+++ b/tuxsuite/6.6-clang-17.tux.yml
@@ -188,31 +188,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: loongarch
-    toolchain: clang-17
-    kconfig:
-    - defconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: loongarch
-    toolchain: clang-17
-    kconfig:
-    - defconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
-    - CONFIG_LTO_CLANG_THIN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: mips
     toolchain: clang-17
     kconfig:
@@ -596,35 +571,6 @@ jobs:
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: loongarch
-    toolchain: clang-17
-    kconfig:
-    - allyesconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_KCOV=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: loongarch
-    toolchain: clang-17
-    kconfig:
-    - allyesconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_FTRACE=n
-    - CONFIG_KCOV=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
-    - CONFIG_GCOV_KERNEL=n
-    - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
     make_variables:

--- a/tuxsuite/6.6-clang-18.tux.yml
+++ b/tuxsuite/6.6-clang-18.tux.yml
@@ -190,11 +190,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: loongarch
     toolchain: clang-nightly
-    kconfig:
-    - defconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
+    kconfig: defconfig
     targets:
     - kernel
     make_variables:
@@ -204,9 +200,6 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - defconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
@@ -603,12 +596,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: loongarch
     toolchain: clang-nightly
-    kconfig:
-    - allyesconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_KCOV=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -617,12 +605,8 @@ jobs:
   - target_arch: loongarch
     toolchain: clang-nightly
     kconfig:
-    - allyesconfig
-    - CONFIG_CRASH_DUMP=n
+    - allmodconfig
     - CONFIG_FTRACE=n
-    - CONFIG_KCOV=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:

--- a/tuxsuite/mainline-clang-17.tux.yml
+++ b/tuxsuite/mainline-clang-17.tux.yml
@@ -188,31 +188,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: loongarch
-    toolchain: clang-17
-    kconfig:
-    - defconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: loongarch
-    toolchain: clang-17
-    kconfig:
-    - defconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
-    - CONFIG_LTO_CLANG_THIN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: mips
     toolchain: clang-17
     kconfig:
@@ -596,35 +571,6 @@ jobs:
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: loongarch
-    toolchain: clang-17
-    kconfig:
-    - allyesconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_KCOV=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: loongarch
-    toolchain: clang-17
-    kconfig:
-    - allyesconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_FTRACE=n
-    - CONFIG_KCOV=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
-    - CONFIG_GCOV_KERNEL=n
-    - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
     make_variables:

--- a/tuxsuite/mainline-clang-18.tux.yml
+++ b/tuxsuite/mainline-clang-18.tux.yml
@@ -200,11 +200,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: loongarch
     toolchain: clang-nightly
-    kconfig:
-    - defconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
+    kconfig: defconfig
     targets:
     - kernel
     make_variables:
@@ -214,9 +210,6 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - defconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
@@ -623,12 +616,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: loongarch
     toolchain: clang-nightly
-    kconfig:
-    - allyesconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_KCOV=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -637,12 +625,8 @@ jobs:
   - target_arch: loongarch
     toolchain: clang-nightly
     kconfig:
-    - allyesconfig
-    - CONFIG_CRASH_DUMP=n
+    - allmodconfig
     - CONFIG_FTRACE=n
-    - CONFIG_KCOV=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:

--- a/tuxsuite/next-clang-17.tux.yml
+++ b/tuxsuite/next-clang-17.tux.yml
@@ -188,31 +188,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: loongarch
-    toolchain: clang-17
-    kconfig:
-    - defconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: loongarch
-    toolchain: clang-17
-    kconfig:
-    - defconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
-    - CONFIG_LTO_CLANG_THIN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: mips
     toolchain: clang-17
     kconfig:
@@ -607,35 +582,6 @@ jobs:
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: loongarch
-    toolchain: clang-17
-    kconfig:
-    - allyesconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_KCOV=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: loongarch
-    toolchain: clang-17
-    kconfig:
-    - allyesconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_FTRACE=n
-    - CONFIG_KCOV=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
-    - CONFIG_GCOV_KERNEL=n
-    - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
     make_variables:

--- a/tuxsuite/next-clang-18.tux.yml
+++ b/tuxsuite/next-clang-18.tux.yml
@@ -200,11 +200,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: loongarch
     toolchain: clang-nightly
-    kconfig:
-    - defconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
+    kconfig: defconfig
     targets:
     - kernel
     make_variables:
@@ -214,9 +210,6 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - defconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
@@ -634,12 +627,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: loongarch
     toolchain: clang-nightly
-    kconfig:
-    - allyesconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_KCOV=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -648,12 +636,8 @@ jobs:
   - target_arch: loongarch
     toolchain: clang-nightly
     kconfig:
-    - allyesconfig
-    - CONFIG_CRASH_DUMP=n
+    - allmodconfig
     - CONFIG_FTRACE=n
-    - CONFIG_KCOV=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:

--- a/tuxsuite/stable-clang-17.tux.yml
+++ b/tuxsuite/stable-clang-17.tux.yml
@@ -188,31 +188,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: loongarch
-    toolchain: clang-17
-    kconfig:
-    - defconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: loongarch
-    toolchain: clang-17
-    kconfig:
-    - defconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
-    - CONFIG_LTO_CLANG_THIN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: mips
     toolchain: clang-17
     kconfig:
@@ -596,35 +571,6 @@ jobs:
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: loongarch
-    toolchain: clang-17
-    kconfig:
-    - allyesconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_KCOV=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: loongarch
-    toolchain: clang-17
-    kconfig:
-    - allyesconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_FTRACE=n
-    - CONFIG_KCOV=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
-    - CONFIG_GCOV_KERNEL=n
-    - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
     make_variables:

--- a/tuxsuite/stable-clang-18.tux.yml
+++ b/tuxsuite/stable-clang-18.tux.yml
@@ -200,11 +200,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: loongarch
     toolchain: clang-nightly
-    kconfig:
-    - defconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
+    kconfig: defconfig
     targets:
     - kernel
     make_variables:
@@ -214,9 +210,6 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - defconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
@@ -623,12 +616,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: loongarch
     toolchain: clang-nightly
-    kconfig:
-    - allyesconfig
-    - CONFIG_CRASH_DUMP=n
-    - CONFIG_KCOV=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
+    kconfig: allmodconfig
     targets:
     - default
     make_variables:
@@ -637,12 +625,8 @@ jobs:
   - target_arch: loongarch
     toolchain: clang-nightly
     kconfig:
-    - allyesconfig
-    - CONFIG_CRASH_DUMP=n
+    - allmodconfig
     - CONFIG_FTRACE=n
-    - CONFIG_KCOV=n
-    - CONFIG_MODULES=n
-    - CONFIG_RELOCATABLE=n
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_LTO_CLANG_THIN=y
     targets:


### PR DESCRIPTION
`CONFIG_RELOCATABLE` has been fixed since 6.7 with two changes (the first one fixes the build and the second one fixes boot):

  [aa0cbc1b506b](https://git.kernel.org/linus/aa0cbc1b506b090c3a775b547c693ada108cc0d7) ("LoongArch: Record pc instead of offset in la_abs relocation")
  [eea673e9d5ea](https://git.kernel.org/linus/eea673e9d5ea994c60b550ffb684413d3759b3f4) ("LoongArch: Apply dynamic relocations for LLD")

Re-enable `CONFIG_RELOCATABLE` (removing `CONFIG_CRASH_DUMP=n` as well, as it was only disabled to allow `CONFIG_RELOCATABLE` to be disabled) for all trees. [eea673e9d5ea](https://git.kernel.org/linus/eea673e9d5ea994c60b550ffb684413d3759b3f4) has been [flagged by `AUTOSEL` for 6.6](https://lore.kernel.org/stable/20231211135147.380223-45-sashal@kernel.org/) but it has not been added to the tree yet, so just apply it locally for the time being.

The minimum supported version of clang for LoongArch has been updated to 18.0.0 in -next with commit [4d35d6e56447](https://git.kernel.org/next/linux-next/c/4d35d6e56447a5d09ccd1c1b3a6d3783b2947670) ("scripts/min-tool-version.sh: Raise minimum clang version to 18.0.0 for loongarch") because it is the first version that supports `__attribute__((model("extreme")))`, which allows us to build with `CONFIG_MODULES`.

In order to support `CONFIG_MODULES` unconditionally (i.e., not disable it at all), we must drop support for `clang-17` everywhere. We already have to do it for -next (and eventually mainline) due to the aforementioned commit. Do so, which helps drastically simplify the matrix.

Because `CONFIG_MODULES` does not need to be disabled anymore, we can build `allmodconfig` instead of `allyesconfig`, which also allows us to stop disabling `CONFIG_KCOV` because the image size is much smaller.

I am testing this locally with `scripts/build-local.py`, I plan to merge it once this pull is approved and those tests pass.
