### PR TITLE
Fix ChromeOS arm64 fragment name

### DIFF
--- a/.github/workflows/chromeos-5.10-clang-12.yml
+++ b/.github/workflows/chromeos-5.10-clang-12.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _17de81744156a95fda35864bb478d05d:
+  _8c47224d7ae0b4ccd3d5f77aa8382271:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/chromeos-5.10-clang-13.yml
+++ b/.github/workflows/chromeos-5.10-clang-13.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _af1efbcbd39ff43b352a6e8edf4ad3b2:
+  _3323608f71c7af5a18536d5396c63351:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/chromeos-5.10-clang-14.yml
+++ b/.github/workflows/chromeos-5.10-clang-14.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _ba0405fc73f16ae6a9868701e4c950dc:
+  _30b158c8f6c703686e9d753bcdaaef03:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/chromeos-5.10-clang-15.yml
+++ b/.github/workflows/chromeos-5.10-clang-15.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _31ee3d731e865b2146f75f090b33f956:
+  _b32e698364e25a698b7281eb2321d99b:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/chromeos-5.10-clang-16.yml
+++ b/.github/workflows/chromeos-5.10-clang-16.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _f1768ac7892d6bd62769977642fe5001:
+  _96e930e5225680fe8374c7f0d65f90fb:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/chromeos-5.10-clang-17.yml
+++ b/.github/workflows/chromeos-5.10-clang-17.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _20c17b15ee9b3076b6a29bf6811b0633:
+  _ff28f7f4cb820b8fbb490990d9469c9d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/chromeos-5.10-clang-18.yml
+++ b/.github/workflows/chromeos-5.10-clang-18.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _807e3c01541b9d1b2f8df7d1b5d107df:
+  _582cd986d26da9a841781d8fc9eab114:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/chromeos-5.15-clang-12.yml
+++ b/.github/workflows/chromeos-5.15-clang-12.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _17de81744156a95fda35864bb478d05d:
+  _8c47224d7ae0b4ccd3d5f77aa8382271:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/chromeos-5.15-clang-13.yml
+++ b/.github/workflows/chromeos-5.15-clang-13.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _af1efbcbd39ff43b352a6e8edf4ad3b2:
+  _3323608f71c7af5a18536d5396c63351:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/chromeos-5.15-clang-14.yml
+++ b/.github/workflows/chromeos-5.15-clang-14.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _ba0405fc73f16ae6a9868701e4c950dc:
+  _30b158c8f6c703686e9d753bcdaaef03:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/chromeos-5.15-clang-15.yml
+++ b/.github/workflows/chromeos-5.15-clang-15.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _31ee3d731e865b2146f75f090b33f956:
+  _b32e698364e25a698b7281eb2321d99b:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/chromeos-5.15-clang-16.yml
+++ b/.github/workflows/chromeos-5.15-clang-16.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _f1768ac7892d6bd62769977642fe5001:
+  _96e930e5225680fe8374c7f0d65f90fb:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/chromeos-5.15-clang-17.yml
+++ b/.github/workflows/chromeos-5.15-clang-17.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _20c17b15ee9b3076b6a29bf6811b0633:
+  _ff28f7f4cb820b8fbb490990d9469c9d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/chromeos-5.15-clang-18.yml
+++ b/.github/workflows/chromeos-5.15-clang-18.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _807e3c01541b9d1b2f8df7d1b5d107df:
+  _582cd986d26da9a841781d8fc9eab114:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
+      CONFIG: chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/generator.yml
+++ b/generator.yml
@@ -274,7 +274,7 @@ targets:
   - &kernel      {targets: [kernel]}
   - &kernel_dtbs {targets: [kernel,dtbs]}
 chromeos_configs:
-  - &arm64-cros-configs  {config: [chromeos/config/chromeos/base.config, chromeos/config/chromeos/arm64/common.config, chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config, CONFIG_SECURITY_CHROMIUMOS=n]}
+  - &arm64-cros-configs  {config: [chromeos/config/chromeos/base.config, chromeos/config/chromeos/arm64/common.config, chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config, CONFIG_SECURITY_CHROMIUMOS=n]}
   - &x86_64-cros-configs {config: [chromeos/config/chromeos/base.config, chromeos/config/chromeos/x86_64/common.config, chromeos/config/chromeos/x86_64/chromiumos-x86_64.flavour.config, CONFIG_SECURITY_CHROMIUMOS=n]}
 kasan_configs:
   - &arm64-kasan-configs    {config: [defconfig, CONFIG_FTRACE=y, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y]}

--- a/tuxsuite/chromeos-5.10-clang-12.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-12.tux.yml
@@ -17,7 +17,7 @@ jobs:
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
-    - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config
     - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel

--- a/tuxsuite/chromeos-5.10-clang-13.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-13.tux.yml
@@ -17,7 +17,7 @@ jobs:
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
-    - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config
     - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel

--- a/tuxsuite/chromeos-5.10-clang-14.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-14.tux.yml
@@ -17,7 +17,7 @@ jobs:
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
-    - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config
     - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel

--- a/tuxsuite/chromeos-5.10-clang-15.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-15.tux.yml
@@ -17,7 +17,7 @@ jobs:
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
-    - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config
     - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel

--- a/tuxsuite/chromeos-5.10-clang-16.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-16.tux.yml
@@ -17,7 +17,7 @@ jobs:
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
-    - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config
     - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel

--- a/tuxsuite/chromeos-5.10-clang-17.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-17.tux.yml
@@ -17,7 +17,7 @@ jobs:
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
-    - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config
     - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel

--- a/tuxsuite/chromeos-5.10-clang-18.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-18.tux.yml
@@ -17,7 +17,7 @@ jobs:
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
-    - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config
     - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel

--- a/tuxsuite/chromeos-5.15-clang-12.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-12.tux.yml
@@ -17,7 +17,7 @@ jobs:
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
-    - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config
     - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel

--- a/tuxsuite/chromeos-5.15-clang-13.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-13.tux.yml
@@ -17,7 +17,7 @@ jobs:
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
-    - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config
     - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel

--- a/tuxsuite/chromeos-5.15-clang-14.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-14.tux.yml
@@ -17,7 +17,7 @@ jobs:
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
-    - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config
     - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel

--- a/tuxsuite/chromeos-5.15-clang-15.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-15.tux.yml
@@ -17,7 +17,7 @@ jobs:
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
-    - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config
     - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel

--- a/tuxsuite/chromeos-5.15-clang-16.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-16.tux.yml
@@ -17,7 +17,7 @@ jobs:
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
-    - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config
     - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel

--- a/tuxsuite/chromeos-5.15-clang-17.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-17.tux.yml
@@ -17,7 +17,7 @@ jobs:
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
-    - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config
     - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel

--- a/tuxsuite/chromeos-5.15-clang-18.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-18.tux.yml
@@ -17,7 +17,7 @@ jobs:
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
-    - chromeos/config/chromeos/arm64/chromiumos-arm64.flavour.config
+    - chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config
     - CONFIG_SECURITY_CHROMIUMOS=n
     targets:
     - kernel


### PR DESCRIPTION
These were renamed in ChromeOS commit [a5aa380698531](https://chromium-review.googlesource.com/q/I9303f8d0913dec8b496d89cac22cb2e1336b6705) ("CHROMIUM: config: arm64: Rename chromiumos-arm64.flavour.config"), which causes our builds to fail because the fragment could not be found.

A similar change will be needed for x86_64 but [that change](https://chromium-review.googlesource.com/q/I39c3a4fa9984cf3e86f4290b1fdd3f42b18519bd) is still pending a merge.
