### PR TITLE
Add support for RISC-V LTO on -next

### DIFF
--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -638,6 +638,62 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _40f8b547f75f3890da243a4d79d32380:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_defconfigs
+    - check_cache
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 14
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_LTO_CLANG_FULL=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_defconfigs
+    - uses: actions/download-artifact@v3
+      with:
+        name: boot_utils_json_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
+  _3b55af602ee9ae620028f2ed3f6ce5a4:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_defconfigs
+    - check_cache
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 14
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_defconfigs
+    - uses: actions/download-artifact@v3
+      with:
+        name: boot_utils_json_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _159d60218d64add121c8e24ad1c4d12c:
     runs-on: ubuntu-latest
     needs:
@@ -1572,6 +1628,34 @@ jobs:
       LLVM_VERSION: 14
       BOOT: 0
       CONFIG: allmodconfig+CONFIG_WERROR=n
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - uses: actions/download-artifact@v3
+      with:
+        name: boot_utils_json_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
+  _61518498f4443a6807716b931f2f4100:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_allconfigs
+    - check_cache
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 14
+      BOOT: 0
+      CONFIG: allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -666,6 +666,62 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _88e358b7196d1217d326738d5c2015c1:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_defconfigs
+    - check_cache
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 15
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_LTO_CLANG_FULL=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_defconfigs
+    - uses: actions/download-artifact@v3
+      with:
+        name: boot_utils_json_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
+  _15b8b0e296115788f58645a621bd36b7:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_defconfigs
+    - check_cache
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 15
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_defconfigs
+    - uses: actions/download-artifact@v3
+      with:
+        name: boot_utils_json_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _c88baa59bd61d2b4032d85d9ddcbdc87:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -750,6 +750,62 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _07073b9543e3f48f0309036e9e5bef98:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_defconfigs
+    - check_cache
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 16
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_LTO_CLANG_FULL=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_defconfigs
+    - uses: actions/download-artifact@v3
+      with:
+        name: boot_utils_json_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
+  _3708260fa48b65515bbe40d2cd3c60dd:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_defconfigs
+    - check_cache
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 16
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_defconfigs
+    - uses: actions/download-artifact@v3
+      with:
+        name: boot_utils_json_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _0fce5375f2c705729f1ed1ddd4b65cff:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/next-clang-17.yml
+++ b/.github/workflows/next-clang-17.yml
@@ -750,6 +750,62 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _42a07d4a54c8a66bfd91e656e415f2d9:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_defconfigs
+    - check_cache
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 17
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_LTO_CLANG_FULL=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_defconfigs
+    - uses: actions/download-artifact@v3
+      with:
+        name: boot_utils_json_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
+  _ae41e464f781c261eb801b44477cb242:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_defconfigs
+    - check_cache
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 17
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_defconfigs
+    - uses: actions/download-artifact@v3
+      with:
+        name: boot_utils_json_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _301a6c9ef046c24f9c8f86339aed8d6f:
     runs-on: ubuntu-latest
     needs:
@@ -1908,6 +1964,34 @@ jobs:
       LLVM_VERSION: 17
       BOOT: 0
       CONFIG: allmodconfig+CONFIG_WERROR=n
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - uses: actions/download-artifact@v3
+      with:
+        name: boot_utils_json_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
+  _f3f1eb4f4682d6ecfaa9958e7f7f9123:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_allconfigs
+    - check_cache
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 17
+      BOOT: 0
+      CONFIG: allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-19.yml
+++ b/.github/workflows/next-clang-19.yml
@@ -834,6 +834,62 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: ./check_logs.py
+  _b67fd2b72f5eb54fb9025c410854cd27:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_defconfigs
+    - check_cache
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 19
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_LTO_CLANG_FULL=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_defconfigs
+    - uses: actions/download-artifact@v3
+      with:
+        name: boot_utils_json_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
+  _1a1380d870fd0387daba9726adcdbaab:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_defconfigs
+    - check_cache
+    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 19
+      BOOT: 1
+      CONFIG: defconfig+CONFIG_LTO_CLANG_THIN=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_defconfigs
+    - uses: actions/download-artifact@v3
+      with:
+        name: boot_utils_json_defconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
   _a7016a4f3a73a508d1b00dd9b9dfa168:
     runs-on: ubuntu-latest
     needs:
@@ -2076,6 +2132,34 @@ jobs:
       LLVM_VERSION: 19
       BOOT: 0
       CONFIG: allmodconfig+CONFIG_WERROR=n
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v3
+      with:
+        name: output_artifact_allconfigs
+    - uses: actions/download-artifact@v3
+      with:
+        name: boot_utils_json_allconfigs
+    - name: Check Build and Boot Logs
+      run: ./check_logs.py
+  _1199a6a1f3e4fdacbf194b86d7f3f518:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_allconfigs
+    - check_cache
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 19
+      BOOT: 0
+      CONFIG: allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/0010-configs.yml
+++ b/0010-configs.yml
@@ -1,95 +1,98 @@
 configs:
-  #                     config:                                                                                image target (optional)    [ARCH:] (Optional: x86)  targets to build
-  - &arm32_v5          {config: multi_v5_defconfig,                                                                                        ARCH: *arm-arch,        << : *kernel_dtbs}
-  - &arm32_v6          {config: aspeed_g5_defconfig,                                                                                       ARCH: *arm-arch,        << : *kernel_dtbs}
-  - &arm32_v7          {config: multi_v7_defconfig,                                                                                        ARCH: *arm-arch,        << : *kernel}
-  - &arm32_v7_t        {config: [multi_v7_defconfig, CONFIG_THUMB2_KERNEL=y],                                                              ARCH: *arm-arch,        << : *kernel}
-  - &arm32_imx         {config: imx_v4_v5_defconfig,                                                                                       ARCH: *arm-arch,        << : *default}
-  - &arm32_omap        {config: omap2plus_defconfig,                                                                                       ARCH: *arm-arch,        << : *default}
-  - &arm32_lpae_fp     {config: [multi_v7_defconfig, CONFIG_ARM_LPAE=y, CONFIG_UNWINDER_FRAME_POINTER=y],                                  ARCH: *arm-arch,        << : *kernel}
-  - &arm32_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                                                           ARCH: *arm-arch,        << : *default}
-  - &arm32_allno       {config: allnoconfig,                                                                                               ARCH: *arm-arch,        << : *default}
-  - &arm32_allyes      {config: [allyesconfig, CONFIG_WERROR=n],                                                                           ARCH: *arm-arch,        << : *default}
-  - &arm32_alpine      {config: *arm32-alpine-config-url,                                                                                  ARCH: *arm-arch,        << : *kernel}
-  - &arm32_suse        {config: *arm32-suse-config-url,                                                                                    ARCH: *arm-arch,        << : *kernel}
-  - &arm64             {config: defconfig,                                                                                                 ARCH: *arm64-arch,      << : *kernel}
+  #                     config:                                                                                 image target (optional)    [ARCH:] (Optional: x86)  targets to build
+  - &arm32_v5          {config: multi_v5_defconfig,                                                                                         ARCH: *arm-arch,        << : *kernel_dtbs}
+  - &arm32_v6          {config: aspeed_g5_defconfig,                                                                                        ARCH: *arm-arch,        << : *kernel_dtbs}
+  - &arm32_v7          {config: multi_v7_defconfig,                                                                                         ARCH: *arm-arch,        << : *kernel}
+  - &arm32_v7_t        {config: [multi_v7_defconfig, CONFIG_THUMB2_KERNEL=y],                                                               ARCH: *arm-arch,        << : *kernel}
+  - &arm32_imx         {config: imx_v4_v5_defconfig,                                                                                        ARCH: *arm-arch,        << : *default}
+  - &arm32_omap        {config: omap2plus_defconfig,                                                                                        ARCH: *arm-arch,        << : *default}
+  - &arm32_lpae_fp     {config: [multi_v7_defconfig, CONFIG_ARM_LPAE=y, CONFIG_UNWINDER_FRAME_POINTER=y],                                   ARCH: *arm-arch,        << : *kernel}
+  - &arm32_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                                                            ARCH: *arm-arch,        << : *default}
+  - &arm32_allno       {config: allnoconfig,                                                                                                ARCH: *arm-arch,        << : *default}
+  - &arm32_allyes      {config: [allyesconfig, CONFIG_WERROR=n],                                                                            ARCH: *arm-arch,        << : *default}
+  - &arm32_alpine      {config: *arm32-alpine-config-url,                                                                                   ARCH: *arm-arch,        << : *kernel}
+  - &arm32_suse        {config: *arm32-suse-config-url,                                                                                     ARCH: *arm-arch,        << : *kernel}
+  - &arm64             {config: defconfig,                                                                                                  ARCH: *arm64-arch,      << : *kernel}
   #                                         https://github.com/ClangBuiltLinux/linux/issues/595
-  - &arm64_no_vdso32   {config: [defconfig, CONFIG_COMPAT_VDSO=n],                                                                         ARCH: *arm64-arch,      << : *kernel}
-  - &arm64be           {config: [defconfig, CONFIG_CPU_BIG_ENDIAN=y],                                                                      ARCH: *arm64-arch,      << : *kernel}
-  - &arm64_cros        {<< : *arm64-cros-configs,                                                                                          ARCH: *arm64-arch,      << : *kernel}
-  - &arm64_lto_full    {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                      ARCH: *arm64-arch,      << : *kernel}
-  - &arm64_lto_thin    {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                      ARCH: *arm64-arch,      << : *kernel}
-  - &arm64_cfi         {config: [defconfig, CONFIG_CFI_CLANG=y],                                                                           ARCH: *arm64-arch,      << : *kernel}
-  - &arm64_cfi_lto     {config: [defconfig, CONFIG_CFI_CLANG=y, CONFIG_LTO_CLANG_THIN=y],                                                  ARCH: *arm64-arch,      << : *kernel}
-  - &arm64_kasan       {<< : *arm64-kasan-configs,                                                                                         ARCH: *arm64-arch,      << : *kernel}
-  - &arm64_kasan_sw    {<< : *arm64-kasan-sw-configs,                                                                                      ARCH: *arm64-arch,      << : *kernel}
-  - &arm64_ubsan       {config: [defconfig, CONFIG_UBSAN=y],                                                                               ARCH: *arm64-arch,      << : *kernel}
-  - &arm64_gki         {config: gki_defconfig,                                                                                             ARCH: *arm64-arch,      << : *kernel}
-  - &arm64_cut         {config: cuttlefish_defconfig,                                                                                      ARCH: *arm64-arch,      << : *kernel}
-  - &arm64_allmod      {config: allmodconfig,                                                                                              ARCH: *arm64-arch,      << : *default}
-  - &arm64_allmod_lto  {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_LTO_CLANG_THIN=y],                             ARCH: *arm64-arch,      << : *default}
-  - &arm64_allno       {config: allnoconfig,                                                                                               ARCH: *arm64-arch,      << : *default}
-  - &arm64_allyes      {config: allyesconfig,                                                                                              ARCH: *arm64-arch,      << : *default}
-  - &arm64_alpine      {config: *arm64-alpine-config-url,                                                                                  ARCH: *arm64-arch,      << : *kernel}
-  - &arm64_fedora      {config: *arm64-fedora-config-url,                                                                                  ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_no_vdso32   {config: [defconfig, CONFIG_COMPAT_VDSO=n],                                                                          ARCH: *arm64-arch,      << : *kernel}
+  - &arm64be           {config: [defconfig, CONFIG_CPU_BIG_ENDIAN=y],                                                                       ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_cros        {<< : *arm64-cros-configs,                                                                                           ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_lto_full    {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                       ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_lto_thin    {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                       ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_cfi         {config: [defconfig, CONFIG_CFI_CLANG=y],                                                                            ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_cfi_lto     {config: [defconfig, CONFIG_CFI_CLANG=y, CONFIG_LTO_CLANG_THIN=y],                                                   ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_kasan       {<< : *arm64-kasan-configs,                                                                                          ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_kasan_sw    {<< : *arm64-kasan-sw-configs,                                                                                       ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_ubsan       {config: [defconfig, CONFIG_UBSAN=y],                                                                                ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_gki         {config: gki_defconfig,                                                                                              ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_cut         {config: cuttlefish_defconfig,                                                                                       ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_allmod      {config: allmodconfig,                                                                                               ARCH: *arm64-arch,      << : *default}
+  - &arm64_allmod_lto  {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_LTO_CLANG_THIN=y],                              ARCH: *arm64-arch,      << : *default}
+  - &arm64_allno       {config: allnoconfig,                                                                                                ARCH: *arm64-arch,      << : *default}
+  - &arm64_allyes      {config: allyesconfig,                                                                                               ARCH: *arm64-arch,      << : *default}
+  - &arm64_alpine      {config: *arm64-alpine-config-url,                                                                                   ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_fedora      {config: *arm64-fedora-config-url,                                                                                   ARCH: *arm64-arch,      << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for pre-5.18 cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
-  - &arm64_fedora_bpf  {config: [*arm64-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                          ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_fedora_bpf  {config: [*arm64-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                           ARCH: *arm64-arch,      << : *kernel}
   # CONFIG_DEBUG_INFO_BTF disabled for certain SUSE configs due to pahole issue: https://lore.kernel.org/r/20210506205622.3663956-1-kafai@fb.com/
-  - &arm64_suse        {config: [*arm64-suse-config-url, CONFIG_DEBUG_INFO_BTF=n],                                                         ARCH: *arm64-arch,      << : *kernel}
-  - &arm64_virt        {config: virtconfig,                                                                                                ARCH: *arm64-arch,      << : *kernel}
-  - &arm64_hardening   {config: [defconfig, hardening.config],                                                                             ARCH: *arm64-arch,      << : *kernel}
-  - &hexagon           {config: defconfig,                                                                                                 ARCH: *hexagon-arch,    << : *default}
-  - &hexagon_allmod    {config: [allmodconfig, CONFIG_WERROR=n],                                                                           ARCH: *hexagon-arch,    << : *default}
-  - &i386              {config: defconfig,                                                                                                 ARCH: *i386-arch,       << : *kernel}
-  - &i386_suse         {config: *i386-suse-config-url,                                                                                     ARCH: *i386-arch,       << : *default}
-  - &loong             {config: defconfig,                                                                                                 ARCH: *loongarch-arch,  << : *kernel}
-  - &loong_lto_thin    {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                      ARCH: *loongarch-arch,  << : *kernel}
-  - &loong_allmod      {config: allmodconfig,                                                                                              ARCH: *loongarch-arch,  << : *default}
-  - &loong_allmod_lto  {config: [allmodconfig, CONFIG_FTRACE=n, CONFIG_GCOV_KERNEL=n, CONFIG_LTO_CLANG_THIN=y],                            ARCH: *loongarch-arch,  << : *default}
-  - &mips              {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y, CONFIG_CPU_BIG_ENDIAN=y],           kernel_image: vmlinux,      ARCH: *mips-arch,       << : *kernel}
-  - &mipsel            {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y],                                    kernel_image: vmlinux,      ARCH: *mips-arch,       << : *kernel}
-  - &ppc32             {config: ppc44x_defconfig,                                                              kernel_image: uImage,       ARCH: *powerpc-arch,    << : *kernel}
-  - &ppc64             {config: ppc64_guest_defconfig,                                                         kernel_image: vmlinux,      ARCH: *powerpc-arch,    << : *kernel}
+  - &arm64_suse        {config: [*arm64-suse-config-url, CONFIG_DEBUG_INFO_BTF=n],                                                          ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_virt        {config: virtconfig,                                                                                                 ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_hardening   {config: [defconfig, hardening.config],                                                                              ARCH: *arm64-arch,      << : *kernel}
+  - &hexagon           {config: defconfig,                                                                                                  ARCH: *hexagon-arch,    << : *default}
+  - &hexagon_allmod    {config: [allmodconfig, CONFIG_WERROR=n],                                                                            ARCH: *hexagon-arch,    << : *default}
+  - &i386              {config: defconfig,                                                                                                  ARCH: *i386-arch,       << : *kernel}
+  - &i386_suse         {config: *i386-suse-config-url,                                                                                      ARCH: *i386-arch,       << : *default}
+  - &loong             {config: defconfig,                                                                                                  ARCH: *loongarch-arch,  << : *kernel}
+  - &loong_lto_thin    {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                       ARCH: *loongarch-arch,  << : *kernel}
+  - &loong_allmod      {config: allmodconfig,                                                                                               ARCH: *loongarch-arch,  << : *default}
+  - &loong_allmod_lto  {config: [allmodconfig, CONFIG_FTRACE=n, CONFIG_GCOV_KERNEL=n, CONFIG_LTO_CLANG_THIN=y],                             ARCH: *loongarch-arch,  << : *default}
+  - &mips              {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y, CONFIG_CPU_BIG_ENDIAN=y],            kernel_image: vmlinux,      ARCH: *mips-arch,       << : *kernel}
+  - &mipsel            {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y],                                     kernel_image: vmlinux,      ARCH: *mips-arch,       << : *kernel}
+  - &ppc32             {config: ppc44x_defconfig,                                                               kernel_image: uImage,       ARCH: *powerpc-arch,    << : *kernel}
+  - &ppc64             {config: ppc64_guest_defconfig,                                                          kernel_image: vmlinux,      ARCH: *powerpc-arch,    << : *kernel}
   # Disable -Werror for ppc64_guest_defconfig for clang-13 and older: https://github.com/ClangBuiltLinux/linux/issues/1445
-  - &ppc64_no_werror   {config: [ppc64_guest_defconfig, CONFIG_PPC_DISABLE_WERROR=y],                          kernel_image: vmlinux,      ARCH: *powerpc-arch,    << : *kernel}
-  - &ppc64le           {config: powernv_defconfig,                                                             kernel_image: zImage.epapr, ARCH: *powerpc-arch,    << : *kernel}
-  - &ppc64le_fedora    {config: *ppc64le-fedora-config-url,                                                    kernel_image: zImage.epapr, ARCH: *powerpc-arch,    << : *kernel}
+  - &ppc64_no_werror   {config: [ppc64_guest_defconfig, CONFIG_PPC_DISABLE_WERROR=y],                           kernel_image: vmlinux,      ARCH: *powerpc-arch,    << : *kernel}
+  - &ppc64le           {config: powernv_defconfig,                                                              kernel_image: zImage.epapr, ARCH: *powerpc-arch,    << : *kernel}
+  - &ppc64le_fedora    {config: *ppc64le-fedora-config-url,                                                     kernel_image: zImage.epapr, ARCH: *powerpc-arch,    << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for pre-5.18 cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
-  - &ppc64le_fedora_bpf {config: [*ppc64le-fedora-config-url, CONFIG_BPF_PRELOAD=n],                           kernel_image: zImage.epapr, ARCH: *powerpc-arch,    << : *kernel}
-  - &ppc64le_suse      {config: *ppc64le-suse-config-url,                                                      kernel_image: zImage.epapr, ARCH: *powerpc-arch,    << : *kernel}
-  - &ppc64_allmod      {config: [allmodconfig, CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y, CONFIG_WERROR=n],                                     ARCH: *powerpc-arch,    << : *default}
-  - &riscv             {config: defconfig,                                                                     kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
-  - &riscv_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                               kernel_image: Image,        ARCH: *riscv-arch,      << : *default}
+  - &ppc64le_fedora_bpf {config: [*ppc64le-fedora-config-url, CONFIG_BPF_PRELOAD=n],                            kernel_image: zImage.epapr, ARCH: *powerpc-arch,    << : *kernel}
+  - &ppc64le_suse      {config: *ppc64le-suse-config-url,                                                       kernel_image: zImage.epapr, ARCH: *powerpc-arch,    << : *kernel}
+  - &ppc64_allmod      {config: [allmodconfig, CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y, CONFIG_WERROR=n],                                      ARCH: *powerpc-arch,    << : *default}
+  - &riscv             {config: defconfig,                                                                      kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
+  - &riscv_lto_full    {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                           kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
+  - &riscv_lto_thin    {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                           kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
+  - &riscv_allmod      {config: [allmodconfig, CONFIG_WERROR=n],                                                kernel_image: Image,        ARCH: *riscv-arch,      << : *default}
+  - &riscv_allmod_lto  {config: [allmodconfig, CONFIG_WERROR=n, CONFIG_GCOV_KERNEL=n, CONFIG_LTO_CLANG_THIN=y], kernel_image: Image,        ARCH: *riscv-arch,      << : *default}
   #                                         https://github.com/ClangBuiltLinux/linux/issues/1143
-  - &riscv_no_efi      {config: [defconfig, CONFIG_EFI=n],                                                     kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
-  - &riscv_alpine      {config: *riscv-alpine-config-url,                                                      kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
-  - &riscv_suse        {config: *riscv-suse-config-url,                                                        kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
-  - &riscv_gki         {config: gki_defconfig,                                                                 kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
-  - &s390              {config: defconfig,                                                                                                 ARCH: *s390-arch,       << : *kernel}
-  - &s390_kasan        {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],            ARCH: *s390-arch,       << : *kernel}
-  - &s390_fedora       {config: *s390-fedora-config-url,                                                                                   ARCH: *s390-arch,       << : *kernel}
+  - &riscv_no_efi      {config: [defconfig, CONFIG_EFI=n],                                                      kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
+  - &riscv_alpine      {config: *riscv-alpine-config-url,                                                       kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
+  - &riscv_suse        {config: *riscv-suse-config-url,                                                         kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
+  - &riscv_gki         {config: gki_defconfig,                                                                  kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
+  - &s390              {config: defconfig,                                                                                                  ARCH: *s390-arch,       << : *kernel}
+  - &s390_kasan        {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],             ARCH: *s390-arch,       << : *kernel}
+  - &s390_fedora       {config: *s390-fedora-config-url,                                                                                    ARCH: *s390-arch,       << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for pre-5.18 cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
-  - &s390_fedora_bpf   {config: [*s390-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                           ARCH: *s390-arch,       << : *kernel}
-  - &s390_suse         {config: *s390-suse-config-url,                                                                                     ARCH: *s390-arch,       << : *kernel}
-  - &um                {config: defconfig,                                                                                                 ARCH: *um-arch,         << : *kernel}
-  - &x86_64            {config: defconfig,                                                                                                                         << : *kernel}
-  - &x86_64_lto_full   {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                                              << : *kernel}
-  - &x86_64_lto_thin   {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                                              << : *kernel}
-  - &x86_64_cfi        {config: [defconfig, CONFIG_CFI_CLANG=y],                                                                                                   << : *kernel}
-  - &x86_64_cfi_lto    {config: [defconfig, CONFIG_CFI_CLANG=y, CONFIG_LTO_CLANG_THIN=y],                                                                          << : *kernel}
-  - &x86_64_cros       {<< : *x86_64-cros-configs,                                                                                                                 << : *kernel}
-  - &x86_64_gki        {config: gki_defconfig,                                                                                                                     << : *kernel}
-  - &x86_64_cut        {config: x86_64_cuttlefish_defconfig,                                                                                                       << : *kernel}
-  - &x86_64_allmod     {config: allmodconfig,                                                                                                                      << : *default}
-  - &x86_64_allmod_lto {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_LTO_CLANG_THIN=y],                                                     << : *default}
-  - &x86_64_allno      {config: allnoconfig,                                                                                                                       << : *default}
-  - &x86_64_allyes     {config: allyesconfig,                                                                                                                      << : *default}
-  - &x86_64_gcov       {config: [defconfig, CONFIG_GCOV_KERNEL=y, CONFIG_GCOV_PROFILE_ALL=y],                                                                      << : *kernel}
-  - &x86_64_kasan      {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],                                    << : *kernel}
-  - &x86_64_kcsan      {config: [defconfig, CONFIG_KCSAN=y, CONFIG_KCSAN_KUNIT_TEST=y, CONFIG_KUNIT=y],                                                            << : *kernel}
-  - &x86_64_ubsan      {config: [defconfig, CONFIG_UBSAN=y],                                                                                                       << : *kernel}
-  - &x86_64_hardening  {config: [defconfig, hardening.config],                                                                                                     << : *kernel}
-  - &x86_64_alpine     {config: *x86_64-alpine-config-url,                                                                                                         << : *kernel}
-  - &x86_64_arch       {config: *x86_64-arch-config-url,                                                                                                           << : *kernel}
-  - &x86_64_fedora     {config: *x86_64-fedora-config-url,                                                                                                         << : *kernel}
-  - &x86_64_suse       {config: *x86_64-suse-config-url,                                                                                                           << : *kernel}
+  - &s390_fedora_bpf   {config: [*s390-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                            ARCH: *s390-arch,       << : *kernel}
+  - &s390_suse         {config: *s390-suse-config-url,                                                                                      ARCH: *s390-arch,       << : *kernel}
+  - &um                {config: defconfig,                                                                                                  ARCH: *um-arch,         << : *kernel}
+  - &x86_64            {config: defconfig,                                                                                                                          << : *kernel}
+  - &x86_64_lto_full   {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                                               << : *kernel}
+  - &x86_64_lto_thin   {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                                               << : *kernel}
+  - &x86_64_cfi        {config: [defconfig, CONFIG_CFI_CLANG=y],                                                                                                    << : *kernel}
+  - &x86_64_cfi_lto    {config: [defconfig, CONFIG_CFI_CLANG=y, CONFIG_LTO_CLANG_THIN=y],                                                                           << : *kernel}
+  - &x86_64_cros       {<< : *x86_64-cros-configs,                                                                                                                  << : *kernel}
+  - &x86_64_gki        {config: gki_defconfig,                                                                                                                      << : *kernel}
+  - &x86_64_cut        {config: x86_64_cuttlefish_defconfig,                                                                                                        << : *kernel}
+  - &x86_64_allmod     {config: allmodconfig,                                                                                                                       << : *default}
+  - &x86_64_allmod_lto {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_LTO_CLANG_THIN=y],                                                      << : *default}
+  - &x86_64_allno      {config: allnoconfig,                                                                                                                        << : *default}
+  - &x86_64_allyes     {config: allyesconfig,                                                                                                                       << : *default}
+  - &x86_64_gcov       {config: [defconfig, CONFIG_GCOV_KERNEL=y, CONFIG_GCOV_PROFILE_ALL=y],                                                                       << : *kernel}
+  - &x86_64_kasan      {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],                                     << : *kernel}
+  - &x86_64_kcsan      {config: [defconfig, CONFIG_KCSAN=y, CONFIG_KCSAN_KUNIT_TEST=y, CONFIG_KUNIT=y],                                                             << : *kernel}
+  - &x86_64_ubsan      {config: [defconfig, CONFIG_UBSAN=y],                                                                                                        << : *kernel}
+  - &x86_64_hardening  {config: [defconfig, hardening.config],                                                                                                      << : *kernel}
+  - &x86_64_alpine     {config: *x86_64-alpine-config-url,                                                                                                          << : *kernel}
+  - &x86_64_arch       {config: *x86_64-arch-config-url,                                                                                                            << : *kernel}
+  - &x86_64_fedora     {config: *x86_64-fedora-config-url,                                                                                                          << : *kernel}
+  - &x86_64_suse       {config: *x86_64-suse-config-url,                                                                                                            << : *kernel}

--- a/0012-llvm-14.yml
+++ b/0012-llvm-14.yml
@@ -102,7 +102,10 @@
   - {<< : *ppc64le_fedora,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *ppc64le_suse,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
+  - {<< : *riscv_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
+  - {<< : *riscv_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *riscv_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_14}
+  - {<< : *riscv_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *riscv_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *riscv_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *um,                << : *next,             << : *llvm_full,       boot: true,  << : *llvm_14}

--- a/0012-llvm-15.yml
+++ b/0012-llvm-15.yml
@@ -110,6 +110,8 @@
   - {<< : *ppc64le_suse,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *ppc64_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
+  - {<< : *riscv_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
+  - {<< : *riscv_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *riscv_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *riscv_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *riscv_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}

--- a/0012-llvm-16.yml
+++ b/0012-llvm-16.yml
@@ -118,6 +118,8 @@
   - {<< : *ppc64le_suse,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *ppc64_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *riscv_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *riscv_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *riscv_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *riscv_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *riscv_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}

--- a/0012-llvm-latest.yml
+++ b/0012-llvm-latest.yml
@@ -118,7 +118,10 @@
   - {<< : *ppc64le_suse,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *ppc64_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *riscv_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *riscv_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *riscv_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *riscv_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *riscv_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *riscv_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *s390,              << : *next,             << : *clang_ias,       boot: true,  << : *llvm_latest}

--- a/0012-llvm-tot.yml
+++ b/0012-llvm-tot.yml
@@ -129,7 +129,10 @@
   - {<< : *ppc64le_suse,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *ppc64_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *riscv,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *riscv_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *riscv_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *riscv_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *riscv_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *riscv_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *riscv_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *s390,              << : *next,             << : *clang_ias,       boot: true,  << : *llvm_tot}

--- a/tuxsuite/next-clang-14.tux.yml
+++ b/tuxsuite/next-clang-14.tux.yml
@@ -208,6 +208,28 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: riscv
+    toolchain: clang-14
+    kconfig:
+    - defconfig
+    - CONFIG_LTO_CLANG_FULL=y
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: riscv
+    toolchain: clang-14
+    kconfig:
+    - defconfig
+    - CONFIG_LTO_CLANG_THIN=y
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
   - target_arch: um
     toolchain: clang-14
     kconfig: defconfig
@@ -491,6 +513,19 @@ jobs:
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
+    targets:
+    - default
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: riscv
+    toolchain: clang-14
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
+    - CONFIG_GCOV_KERNEL=n
+    - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
     kernel_image: Image

--- a/tuxsuite/next-clang-15.tux.yml
+++ b/tuxsuite/next-clang-15.tux.yml
@@ -218,6 +218,28 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: riscv
+    toolchain: clang-15
+    kconfig:
+    - defconfig
+    - CONFIG_LTO_CLANG_FULL=y
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: riscv
+    toolchain: clang-15
+    kconfig:
+    - defconfig
+    - CONFIG_LTO_CLANG_THIN=y
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
   - target_arch: s390
     toolchain: clang-15
     kconfig: defconfig

--- a/tuxsuite/next-clang-16.tux.yml
+++ b/tuxsuite/next-clang-16.tux.yml
@@ -248,6 +248,28 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: riscv
+    toolchain: clang-16
+    kconfig:
+    - defconfig
+    - CONFIG_LTO_CLANG_FULL=y
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: riscv
+    toolchain: clang-16
+    kconfig:
+    - defconfig
+    - CONFIG_LTO_CLANG_THIN=y
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
   - target_arch: s390
     toolchain: clang-16
     kconfig: defconfig

--- a/tuxsuite/next-clang-17.tux.yml
+++ b/tuxsuite/next-clang-17.tux.yml
@@ -248,6 +248,28 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: riscv
+    toolchain: clang-17
+    kconfig:
+    - defconfig
+    - CONFIG_LTO_CLANG_FULL=y
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: riscv
+    toolchain: clang-17
+    kconfig:
+    - defconfig
+    - CONFIG_LTO_CLANG_THIN=y
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
   - target_arch: s390
     toolchain: clang-17
     kconfig: defconfig
@@ -604,6 +626,19 @@ jobs:
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
+    targets:
+    - default
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: riscv
+    toolchain: clang-17
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
+    - CONFIG_GCOV_KERNEL=n
+    - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
     kernel_image: Image

--- a/tuxsuite/next-clang-19.tux.yml
+++ b/tuxsuite/next-clang-19.tux.yml
@@ -276,6 +276,28 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: riscv
+    toolchain: clang-nightly
+    kconfig:
+    - defconfig
+    - CONFIG_LTO_CLANG_FULL=y
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: riscv
+    toolchain: clang-nightly
+    kconfig:
+    - defconfig
+    - CONFIG_LTO_CLANG_THIN=y
+    targets:
+    - kernel
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
   - target_arch: s390
     toolchain: clang-nightly
     kconfig: defconfig
@@ -662,6 +684,19 @@ jobs:
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
+    targets:
+    - default
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: riscv
+    toolchain: clang-nightly
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
+    - CONFIG_GCOV_KERNEL=n
+    - CONFIG_LTO_CLANG_THIN=y
     targets:
     - default
     kernel_image: Image


### PR DESCRIPTION
RISC-V selects `CONFIG_ARCH_SUPPORTS_LTO_CLANG{,_THIN}` after https://git.kernel.org/riscv/c/021d23428bdbae032294e8f4a29cb53cb50ae71c, which is now in linux-next. Wire up builds to make sure this does not regress. A problem with linker relaxation in LLVM 15 and 16 prevents testing allmodconfig + ThinLTO with those versions.
