### PR TITLE
Attempt to rebalance builds

### DIFF
--- a/.github/workflows/4.19-clang-13.yml
+++ b/.github/workflows/4.19-clang-13.yml
@@ -12,7 +12,7 @@ name: 4.19 (clang-13)
     - tuxsuite/4.19-clang-13.tux.yml
     - .github/workflows/4.19-clang-13.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 12 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/4.19-clang-14.yml
+++ b/.github/workflows/4.19-clang-14.yml
@@ -12,7 +12,7 @@ name: 4.19 (clang-14)
     - tuxsuite/4.19-clang-14.tux.yml
     - .github/workflows/4.19-clang-14.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 12 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/4.19-clang-15.yml
+++ b/.github/workflows/4.19-clang-15.yml
@@ -12,7 +12,7 @@ name: 4.19 (clang-15)
     - tuxsuite/4.19-clang-15.tux.yml
     - .github/workflows/4.19-clang-15.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 6 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/4.19-clang-16.yml
+++ b/.github/workflows/4.19-clang-16.yml
@@ -12,7 +12,7 @@ name: 4.19 (clang-16)
     - tuxsuite/4.19-clang-16.tux.yml
     - .github/workflows/4.19-clang-16.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 6 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/4.19-clang-17.yml
+++ b/.github/workflows/4.19-clang-17.yml
@@ -12,7 +12,7 @@ name: 4.19 (clang-17)
     - tuxsuite/4.19-clang-17.tux.yml
     - .github/workflows/4.19-clang-17.yml
   schedule:
-  - cron: 0 0 * * 1,5
+  - cron: 0 12 * * 1,5
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/4.19-clang-19.yml
+++ b/.github/workflows/4.19-clang-19.yml
@@ -12,7 +12,7 @@ name: 4.19 (clang-19)
     - tuxsuite/4.19-clang-19.tux.yml
     - .github/workflows/4.19-clang-19.yml
   schedule:
-  - cron: 0 0 * * 1,5
+  - cron: 0 18 * * 1,5
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/5.10-clang-11.yml
+++ b/.github/workflows/5.10-clang-11.yml
@@ -12,7 +12,7 @@ name: 5.10 (clang-11)
     - tuxsuite/5.10-clang-11.tux.yml
     - .github/workflows/5.10-clang-11.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 12 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/5.10-clang-12.yml
+++ b/.github/workflows/5.10-clang-12.yml
@@ -12,7 +12,7 @@ name: 5.10 (clang-12)
     - tuxsuite/5.10-clang-12.tux.yml
     - .github/workflows/5.10-clang-12.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 12 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/5.10-clang-13.yml
+++ b/.github/workflows/5.10-clang-13.yml
@@ -12,7 +12,7 @@ name: 5.10 (clang-13)
     - tuxsuite/5.10-clang-13.tux.yml
     - .github/workflows/5.10-clang-13.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 6 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/5.10-clang-14.yml
+++ b/.github/workflows/5.10-clang-14.yml
@@ -12,7 +12,7 @@ name: 5.10 (clang-14)
     - tuxsuite/5.10-clang-14.tux.yml
     - .github/workflows/5.10-clang-14.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 6 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/5.10-clang-17.yml
+++ b/.github/workflows/5.10-clang-17.yml
@@ -12,7 +12,7 @@ name: 5.10 (clang-17)
     - tuxsuite/5.10-clang-17.tux.yml
     - .github/workflows/5.10-clang-17.yml
   schedule:
-  - cron: 0 0 * * 1,5
+  - cron: 0 12 * * 1,5
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/5.10-clang-19.yml
+++ b/.github/workflows/5.10-clang-19.yml
@@ -12,7 +12,7 @@ name: 5.10 (clang-19)
     - tuxsuite/5.10-clang-19.tux.yml
     - .github/workflows/5.10-clang-19.yml
   schedule:
-  - cron: 0 0 * * 1,5
+  - cron: 0 18 * * 1,5
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -12,7 +12,7 @@ name: 5.15 (clang-11)
     - tuxsuite/5.15-clang-11.tux.yml
     - .github/workflows/5.15-clang-11.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 6 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -12,7 +12,7 @@ name: 5.15 (clang-12)
     - tuxsuite/5.15-clang-12.tux.yml
     - .github/workflows/5.15-clang-12.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 6 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -12,7 +12,7 @@ name: 5.15 (clang-15)
     - tuxsuite/5.15-clang-15.tux.yml
     - .github/workflows/5.15-clang-15.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 18 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/5.15-clang-16.yml
+++ b/.github/workflows/5.15-clang-16.yml
@@ -12,7 +12,7 @@ name: 5.15 (clang-16)
     - tuxsuite/5.15-clang-16.tux.yml
     - .github/workflows/5.15-clang-16.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 18 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/5.15-clang-19.yml
+++ b/.github/workflows/5.15-clang-19.yml
@@ -12,7 +12,7 @@ name: 5.15 (clang-19)
     - tuxsuite/5.15-clang-19.tux.yml
     - .github/workflows/5.15-clang-19.yml
   schedule:
-  - cron: 0 0 * * 1,5
+  - cron: 0 6 * * 1,5
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/5.4-clang-15.yml
+++ b/.github/workflows/5.4-clang-15.yml
@@ -12,7 +12,7 @@ name: 5.4 (clang-15)
     - tuxsuite/5.4-clang-15.tux.yml
     - .github/workflows/5.4-clang-15.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 18 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/5.4-clang-16.yml
+++ b/.github/workflows/5.4-clang-16.yml
@@ -12,7 +12,7 @@ name: 5.4 (clang-16)
     - tuxsuite/5.4-clang-16.tux.yml
     - .github/workflows/5.4-clang-16.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 18 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/5.4-clang-19.yml
+++ b/.github/workflows/5.4-clang-19.yml
@@ -12,7 +12,7 @@ name: 5.4 (clang-19)
     - tuxsuite/5.4-clang-19.tux.yml
     - .github/workflows/5.4-clang-19.yml
   schedule:
-  - cron: 0 0 * * 1,5
+  - cron: 0 6 * * 1,5
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/6.1-clang-11.yml
+++ b/.github/workflows/6.1-clang-11.yml
@@ -12,7 +12,7 @@ name: 6.1 (clang-11)
     - tuxsuite/6.1-clang-11.tux.yml
     - .github/workflows/6.1-clang-11.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 6 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/6.1-clang-12.yml
+++ b/.github/workflows/6.1-clang-12.yml
@@ -12,7 +12,7 @@ name: 6.1 (clang-12)
     - tuxsuite/6.1-clang-12.tux.yml
     - .github/workflows/6.1-clang-12.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 6 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/6.1-clang-15.yml
+++ b/.github/workflows/6.1-clang-15.yml
@@ -12,7 +12,7 @@ name: 6.1 (clang-15)
     - tuxsuite/6.1-clang-15.tux.yml
     - .github/workflows/6.1-clang-15.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 18 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/6.1-clang-16.yml
+++ b/.github/workflows/6.1-clang-16.yml
@@ -12,7 +12,7 @@ name: 6.1 (clang-16)
     - tuxsuite/6.1-clang-16.tux.yml
     - .github/workflows/6.1-clang-16.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 18 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/6.1-clang-19.yml
+++ b/.github/workflows/6.1-clang-19.yml
@@ -12,7 +12,7 @@ name: 6.1 (clang-19)
     - tuxsuite/6.1-clang-19.tux.yml
     - .github/workflows/6.1-clang-19.yml
   schedule:
-  - cron: 0 0 * * 1,5
+  - cron: 0 6 * * 1,5
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/6.6-clang-11.yml
+++ b/.github/workflows/6.6-clang-11.yml
@@ -12,7 +12,7 @@ name: 6.6 (clang-11)
     - tuxsuite/6.6-clang-11.tux.yml
     - .github/workflows/6.6-clang-11.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 12 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/6.6-clang-12.yml
+++ b/.github/workflows/6.6-clang-12.yml
@@ -12,7 +12,7 @@ name: 6.6 (clang-12)
     - tuxsuite/6.6-clang-12.tux.yml
     - .github/workflows/6.6-clang-12.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 12 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/6.6-clang-13.yml
+++ b/.github/workflows/6.6-clang-13.yml
@@ -12,7 +12,7 @@ name: 6.6 (clang-13)
     - tuxsuite/6.6-clang-13.tux.yml
     - .github/workflows/6.6-clang-13.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 6 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/6.6-clang-14.yml
+++ b/.github/workflows/6.6-clang-14.yml
@@ -12,7 +12,7 @@ name: 6.6 (clang-14)
     - tuxsuite/6.6-clang-14.tux.yml
     - .github/workflows/6.6-clang-14.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 6 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/6.6-clang-17.yml
+++ b/.github/workflows/6.6-clang-17.yml
@@ -12,7 +12,7 @@ name: 6.6 (clang-17)
     - tuxsuite/6.6-clang-17.tux.yml
     - .github/workflows/6.6-clang-17.yml
   schedule:
-  - cron: 0 0 * * 1,5
+  - cron: 0 12 * * 1,5
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/6.6-clang-19.yml
+++ b/.github/workflows/6.6-clang-19.yml
@@ -12,7 +12,7 @@ name: 6.6 (clang-19)
     - tuxsuite/6.6-clang-19.tux.yml
     - .github/workflows/6.6-clang-19.yml
   schedule:
-  - cron: 0 0 * * 1,5
+  - cron: 0 18 * * 1,5
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android-4.19-clang-12.yml
+++ b/.github/workflows/android-4.19-clang-12.yml
@@ -12,7 +12,7 @@ name: android-4.19 (clang-12)
     - tuxsuite/android-4.19-clang-12.tux.yml
     - .github/workflows/android-4.19-clang-12.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 18 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android-4.19-clang-13.yml
+++ b/.github/workflows/android-4.19-clang-13.yml
@@ -12,7 +12,7 @@ name: android-4.19 (clang-13)
     - tuxsuite/android-4.19-clang-13.tux.yml
     - .github/workflows/android-4.19-clang-13.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 12 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android-4.19-clang-14.yml
+++ b/.github/workflows/android-4.19-clang-14.yml
@@ -12,7 +12,7 @@ name: android-4.19 (clang-14)
     - tuxsuite/android-4.19-clang-14.tux.yml
     - .github/workflows/android-4.19-clang-14.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 6 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android-4.19-clang-16.yml
+++ b/.github/workflows/android-4.19-clang-16.yml
@@ -12,7 +12,7 @@ name: android-4.19 (clang-16)
     - tuxsuite/android-4.19-clang-16.tux.yml
     - .github/workflows/android-4.19-clang-16.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 18 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android-mainline-clang-13.yml
+++ b/.github/workflows/android-mainline-clang-13.yml
@@ -12,7 +12,7 @@ name: android-mainline (clang-13)
     - tuxsuite/android-mainline-clang-13.tux.yml
     - .github/workflows/android-mainline-clang-13.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 18 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android-mainline-clang-14.yml
+++ b/.github/workflows/android-mainline-clang-14.yml
@@ -12,7 +12,7 @@ name: android-mainline (clang-14)
     - tuxsuite/android-mainline-clang-14.tux.yml
     - .github/workflows/android-mainline-clang-14.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 12 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android-mainline-clang-15.yml
+++ b/.github/workflows/android-mainline-clang-15.yml
@@ -12,7 +12,7 @@ name: android-mainline (clang-15)
     - tuxsuite/android-mainline-clang-15.tux.yml
     - .github/workflows/android-mainline-clang-15.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 6 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android12-5.10-clang-12.yml
+++ b/.github/workflows/android12-5.10-clang-12.yml
@@ -12,7 +12,7 @@ name: android12-5.10 (clang-12)
     - tuxsuite/android12-5.10-clang-12.tux.yml
     - .github/workflows/android12-5.10-clang-12.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 6 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android12-5.10-clang-14.yml
+++ b/.github/workflows/android12-5.10-clang-14.yml
@@ -12,7 +12,7 @@ name: android12-5.10 (clang-14)
     - tuxsuite/android12-5.10-clang-14.tux.yml
     - .github/workflows/android12-5.10-clang-14.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 18 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android12-5.10-clang-15.yml
+++ b/.github/workflows/android12-5.10-clang-15.yml
@@ -12,7 +12,7 @@ name: android12-5.10 (clang-15)
     - tuxsuite/android12-5.10-clang-15.tux.yml
     - .github/workflows/android12-5.10-clang-15.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 12 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android12-5.10-clang-16.yml
+++ b/.github/workflows/android12-5.10-clang-16.yml
@@ -12,7 +12,7 @@ name: android12-5.10 (clang-16)
     - tuxsuite/android12-5.10-clang-16.tux.yml
     - .github/workflows/android12-5.10-clang-16.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 6 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android12-5.4-clang-12.yml
+++ b/.github/workflows/android12-5.4-clang-12.yml
@@ -12,7 +12,7 @@ name: android12-5.4 (clang-12)
     - tuxsuite/android12-5.4-clang-12.tux.yml
     - .github/workflows/android12-5.4-clang-12.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 12 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android12-5.4-clang-13.yml
+++ b/.github/workflows/android12-5.4-clang-13.yml
@@ -12,7 +12,7 @@ name: android12-5.4 (clang-13)
     - tuxsuite/android12-5.4-clang-13.tux.yml
     - .github/workflows/android12-5.4-clang-13.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 6 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android12-5.4-clang-15.yml
+++ b/.github/workflows/android12-5.4-clang-15.yml
@@ -12,7 +12,7 @@ name: android12-5.4 (clang-15)
     - tuxsuite/android12-5.4-clang-15.tux.yml
     - .github/workflows/android12-5.4-clang-15.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 18 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android12-5.4-clang-16.yml
+++ b/.github/workflows/android12-5.4-clang-16.yml
@@ -12,7 +12,7 @@ name: android12-5.4 (clang-16)
     - tuxsuite/android12-5.4-clang-16.tux.yml
     - .github/workflows/android12-5.4-clang-16.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 12 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android13-5.10-clang-13.yml
+++ b/.github/workflows/android13-5.10-clang-13.yml
@@ -12,7 +12,7 @@ name: android13-5.10 (clang-13)
     - tuxsuite/android13-5.10-clang-13.tux.yml
     - .github/workflows/android13-5.10-clang-13.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 18 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android13-5.10-clang-14.yml
+++ b/.github/workflows/android13-5.10-clang-14.yml
@@ -12,7 +12,7 @@ name: android13-5.10 (clang-14)
     - tuxsuite/android13-5.10-clang-14.tux.yml
     - .github/workflows/android13-5.10-clang-14.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 12 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android13-5.10-clang-15.yml
+++ b/.github/workflows/android13-5.10-clang-15.yml
@@ -12,7 +12,7 @@ name: android13-5.10 (clang-15)
     - tuxsuite/android13-5.10-clang-15.tux.yml
     - .github/workflows/android13-5.10-clang-15.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 6 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android13-5.15-clang-12.yml
+++ b/.github/workflows/android13-5.15-clang-12.yml
@@ -12,7 +12,7 @@ name: android13-5.15 (clang-12)
     - tuxsuite/android13-5.15-clang-12.tux.yml
     - .github/workflows/android13-5.15-clang-12.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 18 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android13-5.15-clang-13.yml
+++ b/.github/workflows/android13-5.15-clang-13.yml
@@ -12,7 +12,7 @@ name: android13-5.15 (clang-13)
     - tuxsuite/android13-5.15-clang-13.tux.yml
     - .github/workflows/android13-5.15-clang-13.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 12 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android13-5.15-clang-14.yml
+++ b/.github/workflows/android13-5.15-clang-14.yml
@@ -12,7 +12,7 @@ name: android13-5.15 (clang-14)
     - tuxsuite/android13-5.15-clang-14.tux.yml
     - .github/workflows/android13-5.15-clang-14.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 6 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android13-5.15-clang-16.yml
+++ b/.github/workflows/android13-5.15-clang-16.yml
@@ -12,7 +12,7 @@ name: android13-5.15 (clang-16)
     - tuxsuite/android13-5.15-clang-16.tux.yml
     - .github/workflows/android13-5.15-clang-16.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 18 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android14-5.15-clang-12.yml
+++ b/.github/workflows/android14-5.15-clang-12.yml
@@ -12,7 +12,7 @@ name: android14-5.15 (clang-12)
     - tuxsuite/android14-5.15-clang-12.tux.yml
     - .github/workflows/android14-5.15-clang-12.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 12 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android14-5.15-clang-13.yml
+++ b/.github/workflows/android14-5.15-clang-13.yml
@@ -12,7 +12,7 @@ name: android14-5.15 (clang-13)
     - tuxsuite/android14-5.15-clang-13.tux.yml
     - .github/workflows/android14-5.15-clang-13.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 6 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android14-5.15-clang-15.yml
+++ b/.github/workflows/android14-5.15-clang-15.yml
@@ -12,7 +12,7 @@ name: android14-5.15 (clang-15)
     - tuxsuite/android14-5.15-clang-15.tux.yml
     - .github/workflows/android14-5.15-clang-15.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 18 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android14-5.15-clang-16.yml
+++ b/.github/workflows/android14-5.15-clang-16.yml
@@ -12,7 +12,7 @@ name: android14-5.15 (clang-16)
     - tuxsuite/android14-5.15-clang-16.tux.yml
     - .github/workflows/android14-5.15-clang-16.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 12 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android14-6.1-clang-12.yml
+++ b/.github/workflows/android14-6.1-clang-12.yml
@@ -12,7 +12,7 @@ name: android14-6.1 (clang-12)
     - tuxsuite/android14-6.1-clang-12.tux.yml
     - .github/workflows/android14-6.1-clang-12.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 6 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android14-6.1-clang-14.yml
+++ b/.github/workflows/android14-6.1-clang-14.yml
@@ -12,7 +12,7 @@ name: android14-6.1 (clang-14)
     - tuxsuite/android14-6.1-clang-14.tux.yml
     - .github/workflows/android14-6.1-clang-14.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 18 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android14-6.1-clang-15.yml
+++ b/.github/workflows/android14-6.1-clang-15.yml
@@ -12,7 +12,7 @@ name: android14-6.1 (clang-15)
     - tuxsuite/android14-6.1-clang-15.tux.yml
     - .github/workflows/android14-6.1-clang-15.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 12 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android14-6.1-clang-16.yml
+++ b/.github/workflows/android14-6.1-clang-16.yml
@@ -12,7 +12,7 @@ name: android14-6.1 (clang-16)
     - tuxsuite/android14-6.1-clang-16.tux.yml
     - .github/workflows/android14-6.1-clang-16.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 6 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android15-6.1-clang-13.yml
+++ b/.github/workflows/android15-6.1-clang-13.yml
@@ -12,7 +12,7 @@ name: android15-6.1 (clang-13)
     - tuxsuite/android15-6.1-clang-13.tux.yml
     - .github/workflows/android15-6.1-clang-13.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 18 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android15-6.1-clang-14.yml
+++ b/.github/workflows/android15-6.1-clang-14.yml
@@ -12,7 +12,7 @@ name: android15-6.1 (clang-14)
     - tuxsuite/android15-6.1-clang-14.tux.yml
     - .github/workflows/android15-6.1-clang-14.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 12 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android15-6.1-clang-15.yml
+++ b/.github/workflows/android15-6.1-clang-15.yml
@@ -12,7 +12,7 @@ name: android15-6.1 (clang-15)
     - tuxsuite/android15-6.1-clang-15.tux.yml
     - .github/workflows/android15-6.1-clang-15.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 6 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android15-6.6-clang-13.yml
+++ b/.github/workflows/android15-6.6-clang-13.yml
@@ -12,7 +12,7 @@ name: android15-6.6 (clang-13)
     - tuxsuite/android15-6.6-clang-13.tux.yml
     - .github/workflows/android15-6.6-clang-13.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 18 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android15-6.6-clang-14.yml
+++ b/.github/workflows/android15-6.6-clang-14.yml
@@ -12,7 +12,7 @@ name: android15-6.6 (clang-14)
     - tuxsuite/android15-6.6-clang-14.tux.yml
     - .github/workflows/android15-6.6-clang-14.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 12 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/android15-6.6-clang-15.yml
+++ b/.github/workflows/android15-6.6-clang-15.yml
@@ -12,7 +12,7 @@ name: android15-6.6 (clang-15)
     - tuxsuite/android15-6.6-clang-15.tux.yml
     - .github/workflows/android15-6.6-clang-15.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 6 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/chromeos-5.10-clang-12.yml
+++ b/.github/workflows/chromeos-5.10-clang-12.yml
@@ -12,7 +12,7 @@ name: chromeos-5.10 (clang-12)
     - tuxsuite/chromeos-5.10-clang-12.tux.yml
     - .github/workflows/chromeos-5.10-clang-12.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 18 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/chromeos-5.10-clang-13.yml
+++ b/.github/workflows/chromeos-5.10-clang-13.yml
@@ -12,7 +12,7 @@ name: chromeos-5.10 (clang-13)
     - tuxsuite/chromeos-5.10-clang-13.tux.yml
     - .github/workflows/chromeos-5.10-clang-13.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 12 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/chromeos-5.10-clang-14.yml
+++ b/.github/workflows/chromeos-5.10-clang-14.yml
@@ -12,7 +12,7 @@ name: chromeos-5.10 (clang-14)
     - tuxsuite/chromeos-5.10-clang-14.tux.yml
     - .github/workflows/chromeos-5.10-clang-14.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 6 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/chromeos-5.10-clang-16.yml
+++ b/.github/workflows/chromeos-5.10-clang-16.yml
@@ -12,7 +12,7 @@ name: chromeos-5.10 (clang-16)
     - tuxsuite/chromeos-5.10-clang-16.tux.yml
     - .github/workflows/chromeos-5.10-clang-16.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 18 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/chromeos-5.15-clang-12.yml
+++ b/.github/workflows/chromeos-5.15-clang-12.yml
@@ -12,7 +12,7 @@ name: chromeos-5.15 (clang-12)
     - tuxsuite/chromeos-5.15-clang-12.tux.yml
     - .github/workflows/chromeos-5.15-clang-12.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 12 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/chromeos-5.15-clang-13.yml
+++ b/.github/workflows/chromeos-5.15-clang-13.yml
@@ -12,7 +12,7 @@ name: chromeos-5.15 (clang-13)
     - tuxsuite/chromeos-5.15-clang-13.tux.yml
     - .github/workflows/chromeos-5.15-clang-13.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 6 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/chromeos-5.15-clang-15.yml
+++ b/.github/workflows/chromeos-5.15-clang-15.yml
@@ -12,7 +12,7 @@ name: chromeos-5.15 (clang-15)
     - tuxsuite/chromeos-5.15-clang-15.tux.yml
     - .github/workflows/chromeos-5.15-clang-15.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 18 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/chromeos-5.15-clang-16.yml
+++ b/.github/workflows/chromeos-5.15-clang-16.yml
@@ -12,7 +12,7 @@ name: chromeos-5.15 (clang-16)
     - tuxsuite/chromeos-5.15-clang-16.tux.yml
     - .github/workflows/chromeos-5.15-clang-16.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 12 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/chromeos-6.1-clang-12.yml
+++ b/.github/workflows/chromeos-6.1-clang-12.yml
@@ -12,7 +12,7 @@ name: chromeos-6.1 (clang-12)
     - tuxsuite/chromeos-6.1-clang-12.tux.yml
     - .github/workflows/chromeos-6.1-clang-12.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 6 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/chromeos-6.1-clang-14.yml
+++ b/.github/workflows/chromeos-6.1-clang-14.yml
@@ -12,7 +12,7 @@ name: chromeos-6.1 (clang-14)
     - tuxsuite/chromeos-6.1-clang-14.tux.yml
     - .github/workflows/chromeos-6.1-clang-14.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 18 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/chromeos-6.1-clang-15.yml
+++ b/.github/workflows/chromeos-6.1-clang-15.yml
@@ -12,7 +12,7 @@ name: chromeos-6.1 (clang-15)
     - tuxsuite/chromeos-6.1-clang-15.tux.yml
     - .github/workflows/chromeos-6.1-clang-15.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 12 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/chromeos-6.1-clang-16.yml
+++ b/.github/workflows/chromeos-6.1-clang-16.yml
@@ -12,7 +12,7 @@ name: chromeos-6.1 (clang-16)
     - tuxsuite/chromeos-6.1-clang-16.tux.yml
     - .github/workflows/chromeos-6.1-clang-16.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 6 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/chromeos-6.6-clang-13.yml
+++ b/.github/workflows/chromeos-6.6-clang-13.yml
@@ -12,7 +12,7 @@ name: chromeos-6.6 (clang-13)
     - tuxsuite/chromeos-6.6-clang-13.tux.yml
     - .github/workflows/chromeos-6.6-clang-13.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 18 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/chromeos-6.6-clang-14.yml
+++ b/.github/workflows/chromeos-6.6-clang-14.yml
@@ -12,7 +12,7 @@ name: chromeos-6.6 (clang-14)
     - tuxsuite/chromeos-6.6-clang-14.tux.yml
     - .github/workflows/chromeos-6.6-clang-14.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 12 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/chromeos-6.6-clang-15.yml
+++ b/.github/workflows/chromeos-6.6-clang-15.yml
@@ -12,7 +12,7 @@ name: chromeos-6.6 (clang-15)
     - tuxsuite/chromeos-6.6-clang-15.tux.yml
     - .github/workflows/chromeos-6.6-clang-15.yml
   schedule:
-  - cron: 0 0 * * 0
+  - cron: 0 6 * * 0
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/stable-clang-11.yml
+++ b/.github/workflows/stable-clang-11.yml
@@ -12,7 +12,7 @@ name: stable (clang-11)
     - tuxsuite/stable-clang-11.tux.yml
     - .github/workflows/stable-clang-11.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 12 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/stable-clang-12.yml
+++ b/.github/workflows/stable-clang-12.yml
@@ -12,7 +12,7 @@ name: stable (clang-12)
     - tuxsuite/stable-clang-12.tux.yml
     - .github/workflows/stable-clang-12.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 12 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -12,7 +12,7 @@ name: stable (clang-13)
     - tuxsuite/stable-clang-13.tux.yml
     - .github/workflows/stable-clang-13.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 6 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -12,7 +12,7 @@ name: stable (clang-14)
     - tuxsuite/stable-clang-14.tux.yml
     - .github/workflows/stable-clang-14.yml
   schedule:
-  - cron: 0 0 * * 3
+  - cron: 0 6 * * 3
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/stable-clang-17.yml
+++ b/.github/workflows/stable-clang-17.yml
@@ -12,7 +12,7 @@ name: stable (clang-17)
     - tuxsuite/stable-clang-17.tux.yml
     - .github/workflows/stable-clang-17.yml
   schedule:
-  - cron: 0 0 * * 1,5
+  - cron: 0 12 * * 1,5
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/.github/workflows/stable-clang-19.yml
+++ b/.github/workflows/stable-clang-19.yml
@@ -12,7 +12,7 @@ name: stable (clang-19)
     - tuxsuite/stable-clang-19.tux.yml
     - .github/workflows/stable-clang-19.yml
   schedule:
-  - cron: 0 0 * * 1,5
+  - cron: 0 18 * * 1,5
   workflow_dispatch: null
 permissions: read-all
 jobs:

--- a/generator/yml/0003-schedules.yml
+++ b/generator/yml/0003-schedules.yml
@@ -1,9 +1,9 @@
 schedules:
   - &weekdays_every_12    {schedule: "0 0,12 * * 1,2,3,4,5"}
-  - &daily_midnight       {schedule: "0 0 * * 1,2,3,4,5"}
-  - &daily_six            {schedule: "0 6 * * 1,2,3,4,5"}
-  - &daily_noon           {schedule: "0 12 * * 1,2,3,4,5"}
-  - &daily_eighteen       {schedule: "0 18 * * 1,2,3,4,5"}
+  - &weekdays_midnight    {schedule: "0 0 * * 1,2,3,4,5"}
+  - &weekdays_six         {schedule: "0 6 * * 1,2,3,4,5"}
+  - &weekdays_noon        {schedule: "0 12 * * 1,2,3,4,5"}
+  - &weekdays_eighteen    {schedule: "0 18 * * 1,2,3,4,5"}
   - &monday_friday        {schedule: "0 0 * * 1,5"}
   - &sundays              {schedule: "0 0 * * 0"}
   - &wednesdays           {schedule: "0 0 * * 3"}

--- a/generator/yml/0003-schedules.yml
+++ b/generator/yml/0003-schedules.yml
@@ -1,9 +1,9 @@
 schedules:
-  - &twelve_hours   {schedule: "0 0,12 * * 1,2,3,4,5"}
-  - &daily_midnight {schedule: "0 0 * * 1,2,3,4,5"}
-  - &daily_six      {schedule: "0 6 * * 1,2,3,4,5"}
-  - &daily_noon     {schedule: "0 12 * * 1,2,3,4,5"}
-  - &daily_eighteen {schedule: "0 18 * * 1,2,3,4,5"}
-  - &monday_friday  {schedule: "0 0 * * 1,5"}
-  - &sundays        {schedule: "0 0 * * 0"}
-  - &wednesdays     {schedule: "0 0 * * 3"}
+  - &twelve_hours         {schedule: "0 0,12 * * 1,2,3,4,5"}
+  - &daily_midnight       {schedule: "0 0 * * 1,2,3,4,5"}
+  - &daily_six            {schedule: "0 6 * * 1,2,3,4,5"}
+  - &daily_noon           {schedule: "0 12 * * 1,2,3,4,5"}
+  - &daily_eighteen       {schedule: "0 18 * * 1,2,3,4,5"}
+  - &monday_friday        {schedule: "0 0 * * 1,5"}
+  - &sundays              {schedule: "0 0 * * 0"}
+  - &wednesdays           {schedule: "0 0 * * 3"}

--- a/generator/yml/0003-schedules.yml
+++ b/generator/yml/0003-schedules.yml
@@ -1,5 +1,5 @@
 schedules:
-  - &twelve_hours         {schedule: "0 0,12 * * 1,2,3,4,5"}
+  - &weekdays_every_12    {schedule: "0 0,12 * * 1,2,3,4,5"}
   - &daily_midnight       {schedule: "0 0 * * 1,2,3,4,5"}
   - &daily_six            {schedule: "0 6 * * 1,2,3,4,5"}
   - &daily_noon           {schedule: "0 12 * * 1,2,3,4,5"}

--- a/generator/yml/0003-schedules.yml
+++ b/generator/yml/0003-schedules.yml
@@ -4,8 +4,6 @@ schedules:
   - &daily_six      {schedule: "0 6 * * 1,2,3,4,5"}
   - &daily_noon     {schedule: "0 12 * * 1,2,3,4,5"}
   - &daily_eighteen {schedule: "0 18 * * 1,2,3,4,5"}
-  # -next updates M-F in the evening AEST, which is usually around 12:00PM UTC
-  - &weekdays       {schedule: "0 12 * * 1,2,3,4,5"}
   - &monday_friday  {schedule: "0 0 * * 1,5"}
   - &sundays        {schedule: "0 0 * * 0"}
   - &wednesdays     {schedule: "0 0 * * 3"}

--- a/generator/yml/0003-schedules.yml
+++ b/generator/yml/0003-schedules.yml
@@ -4,6 +4,15 @@ schedules:
   - &weekdays_six         {schedule: "0 6 * * 1,2,3,4,5"}
   - &weekdays_noon        {schedule: "0 12 * * 1,2,3,4,5"}
   - &weekdays_eighteen    {schedule: "0 18 * * 1,2,3,4,5"}
-  - &monday_friday        {schedule: "0 0 * * 1,5"}
-  - &sundays              {schedule: "0 0 * * 0"}
-  - &wednesdays           {schedule: "0 0 * * 3"}
+  - &mon_fri_midnight     {schedule: "0 0 * * 1,5"}
+  - &mon_fri_six          {schedule: "0 6 * * 1,5"}
+  - &mon_fri_noon         {schedule: "0 12 * * 1,5"}
+  - &mon_fri_eighteen     {schedule: "0 18 * * 1,5"}
+  - &sun_midnight         {schedule: "0 0 * * 0"}
+  - &sun_six              {schedule: "0 6 * * 0"}
+  - &sun_noon             {schedule: "0 12 * * 0"}
+  - &sun_eighteen         {schedule: "0 18 * * 0"}
+  - &wed_midnight         {schedule: "0 0 * * 3"}
+  - &wed_six              {schedule: "0 6 * * 3"}
+  - &wed_noon             {schedule: "0 12 * * 3"}
+  - &wed_eighteen         {schedule: "0 18 * * 3"}

--- a/generator/yml/0004-trees.yml
+++ b/generator/yml/0004-trees.yml
@@ -41,166 +41,166 @@ tree_schedules:
   - &next_llvm_14                  {<< : *llvm_14,      << : *next,             << : *weekdays_noon}
   - &next_llvm_13                  {<< : *llvm_13,      << : *next,             << : *weekdays_noon}
   - &next_llvm_android             {<< : *llvm_android, << : *next,             << : *weekdays_noon}
-  - &stable_llvm_tot               {<< : *llvm_tot,     << : *stable,           << : *monday_friday}
-  - &stable_llvm_latest            {<< : *llvm_latest,  << : *stable,           << : *monday_friday}
-  - &stable_llvm_16                {<< : *llvm_16,      << : *stable,           << : *wednesdays}
-  - &stable_llvm_15                {<< : *llvm_15,      << : *stable,           << : *wednesdays}
-  - &stable_llvm_14                {<< : *llvm_14,      << : *stable,           << : *wednesdays}
-  - &stable_llvm_13                {<< : *llvm_13,      << : *stable,           << : *wednesdays}
-  - &stable_llvm_12                {<< : *llvm_12,      << : *stable,           << : *wednesdays}
-  - &stable_llvm_11                {<< : *llvm_11,      << : *stable,           << : *wednesdays}
-  - &stable-6_6_llvm_tot           {<< : *llvm_tot,     << : *stable-6_6,       << : *monday_friday}
-  - &stable-6_6_llvm_latest        {<< : *llvm_latest,  << : *stable-6_6,       << : *monday_friday}
-  - &stable-6_6_llvm_16            {<< : *llvm_16,      << : *stable-6_6,       << : *wednesdays}
-  - &stable-6_6_llvm_15            {<< : *llvm_15,      << : *stable-6_6,       << : *wednesdays}
-  - &stable-6_6_llvm_14            {<< : *llvm_14,      << : *stable-6_6,       << : *wednesdays}
-  - &stable-6_6_llvm_13            {<< : *llvm_13,      << : *stable-6_6,       << : *wednesdays}
-  - &stable-6_6_llvm_12            {<< : *llvm_12,      << : *stable-6_6,       << : *wednesdays}
-  - &stable-6_6_llvm_11            {<< : *llvm_11,      << : *stable-6_6,       << : *wednesdays}
-  - &stable-6_1_llvm_tot           {<< : *llvm_tot,     << : *stable-6_1,       << : *monday_friday}
-  - &stable-6_1_llvm_latest        {<< : *llvm_latest,  << : *stable-6_1,       << : *monday_friday}
-  - &stable-6_1_llvm_16            {<< : *llvm_16,      << : *stable-6_1,       << : *wednesdays}
-  - &stable-6_1_llvm_15            {<< : *llvm_15,      << : *stable-6_1,       << : *wednesdays}
-  - &stable-6_1_llvm_14            {<< : *llvm_14,      << : *stable-6_1,       << : *wednesdays}
-  - &stable-6_1_llvm_13            {<< : *llvm_13,      << : *stable-6_1,       << : *wednesdays}
-  - &stable-6_1_llvm_12            {<< : *llvm_12,      << : *stable-6_1,       << : *wednesdays}
-  - &stable-6_1_llvm_11            {<< : *llvm_11,      << : *stable-6_1,       << : *wednesdays}
-  - &stable-5_15_llvm_tot          {<< : *llvm_tot,     << : *stable-5_15,      << : *monday_friday}
-  - &stable-5_15_llvm_latest       {<< : *llvm_latest,  << : *stable-5_15,      << : *monday_friday}
-  - &stable-5_15_llvm_16           {<< : *llvm_16,      << : *stable-5_15,      << : *wednesdays}
-  - &stable-5_15_llvm_15           {<< : *llvm_15,      << : *stable-5_15,      << : *wednesdays}
-  - &stable-5_15_llvm_14           {<< : *llvm_14,      << : *stable-5_15,      << : *wednesdays}
-  - &stable-5_15_llvm_13           {<< : *llvm_13,      << : *stable-5_15,      << : *wednesdays}
-  - &stable-5_15_llvm_12           {<< : *llvm_12,      << : *stable-5_15,      << : *wednesdays}
-  - &stable-5_15_llvm_11           {<< : *llvm_11,      << : *stable-5_15,      << : *wednesdays}
-  - &stable-5_10_llvm_tot          {<< : *llvm_tot,     << : *stable-5_10,      << : *monday_friday}
-  - &stable-5_10_llvm_latest       {<< : *llvm_latest,  << : *stable-5_10,      << : *monday_friday}
-  - &stable-5_10_llvm_16           {<< : *llvm_16,      << : *stable-5_10,      << : *wednesdays}
-  - &stable-5_10_llvm_15           {<< : *llvm_15,      << : *stable-5_10,      << : *wednesdays}
-  - &stable-5_10_llvm_14           {<< : *llvm_14,      << : *stable-5_10,      << : *wednesdays}
-  - &stable-5_10_llvm_13           {<< : *llvm_13,      << : *stable-5_10,      << : *wednesdays}
-  - &stable-5_10_llvm_12           {<< : *llvm_12,      << : *stable-5_10,      << : *wednesdays}
-  - &stable-5_10_llvm_11           {<< : *llvm_11,      << : *stable-5_10,      << : *wednesdays}
-  - &stable-5_4_llvm_tot           {<< : *llvm_tot,     << : *stable-5_4,       << : *monday_friday}
-  - &stable-5_4_llvm_latest        {<< : *llvm_latest,  << : *stable-5_4,       << : *monday_friday}
-  - &stable-5_4_llvm_16            {<< : *llvm_16,      << : *stable-5_4,       << : *wednesdays}
-  - &stable-5_4_llvm_15            {<< : *llvm_15,      << : *stable-5_4,       << : *wednesdays}
-  - &stable-5_4_llvm_14            {<< : *llvm_14,      << : *stable-5_4,       << : *wednesdays}
-  - &stable-5_4_llvm_13            {<< : *llvm_13,      << : *stable-5_4,       << : *wednesdays}
-  - &stable-4_19_llvm_tot          {<< : *llvm_tot,     << : *stable-4_19,      << : *monday_friday}
-  - &stable-4_19_llvm_latest       {<< : *llvm_latest,  << : *stable-4_19,      << : *monday_friday}
-  - &stable-4_19_llvm_16           {<< : *llvm_16,      << : *stable-4_19,      << : *wednesdays}
-  - &stable-4_19_llvm_15           {<< : *llvm_15,      << : *stable-4_19,      << : *wednesdays}
-  - &stable-4_19_llvm_14           {<< : *llvm_14,      << : *stable-4_19,      << : *wednesdays}
-  - &stable-4_19_llvm_13           {<< : *llvm_13,      << : *stable-4_19,      << : *wednesdays}
+  - &stable_llvm_tot               {<< : *llvm_tot,     << : *stable,           << : *mon_fri_eighteen}
+  - &stable_llvm_latest            {<< : *llvm_latest,  << : *stable,           << : *mon_fri_noon}
+  - &stable_llvm_16                {<< : *llvm_16,      << : *stable,           << : *wed_midnight}
+  - &stable_llvm_15                {<< : *llvm_15,      << : *stable,           << : *wed_midnight}
+  - &stable_llvm_14                {<< : *llvm_14,      << : *stable,           << : *wed_six}
+  - &stable_llvm_13                {<< : *llvm_13,      << : *stable,           << : *wed_six}
+  - &stable_llvm_12                {<< : *llvm_12,      << : *stable,           << : *wed_noon}
+  - &stable_llvm_11                {<< : *llvm_11,      << : *stable,           << : *wed_noon}
+  - &stable-6_6_llvm_tot           {<< : *llvm_tot,     << : *stable-6_6,       << : *mon_fri_eighteen}
+  - &stable-6_6_llvm_latest        {<< : *llvm_latest,  << : *stable-6_6,       << : *mon_fri_noon}
+  - &stable-6_6_llvm_16            {<< : *llvm_16,      << : *stable-6_6,       << : *wed_midnight}
+  - &stable-6_6_llvm_15            {<< : *llvm_15,      << : *stable-6_6,       << : *wed_midnight}
+  - &stable-6_6_llvm_14            {<< : *llvm_14,      << : *stable-6_6,       << : *wed_six}
+  - &stable-6_6_llvm_13            {<< : *llvm_13,      << : *stable-6_6,       << : *wed_six}
+  - &stable-6_6_llvm_12            {<< : *llvm_12,      << : *stable-6_6,       << : *wed_noon}
+  - &stable-6_6_llvm_11            {<< : *llvm_11,      << : *stable-6_6,       << : *wed_noon}
+  - &stable-6_1_llvm_tot           {<< : *llvm_tot,     << : *stable-6_1,       << : *mon_fri_six}
+  - &stable-6_1_llvm_latest        {<< : *llvm_latest,  << : *stable-6_1,       << : *mon_fri_midnight}
+  - &stable-6_1_llvm_16            {<< : *llvm_16,      << : *stable-6_1,       << : *wed_eighteen}
+  - &stable-6_1_llvm_15            {<< : *llvm_15,      << : *stable-6_1,       << : *wed_eighteen}
+  - &stable-6_1_llvm_14            {<< : *llvm_14,      << : *stable-6_1,       << : *wed_midnight}
+  - &stable-6_1_llvm_13            {<< : *llvm_13,      << : *stable-6_1,       << : *wed_midnight}
+  - &stable-6_1_llvm_12            {<< : *llvm_12,      << : *stable-6_1,       << : *wed_six}
+  - &stable-6_1_llvm_11            {<< : *llvm_11,      << : *stable-6_1,       << : *wed_six}
+  - &stable-5_15_llvm_tot          {<< : *llvm_tot,     << : *stable-5_15,      << : *mon_fri_six}
+  - &stable-5_15_llvm_latest       {<< : *llvm_latest,  << : *stable-5_15,      << : *mon_fri_midnight}
+  - &stable-5_15_llvm_16           {<< : *llvm_16,      << : *stable-5_15,      << : *wed_eighteen}
+  - &stable-5_15_llvm_15           {<< : *llvm_15,      << : *stable-5_15,      << : *wed_eighteen}
+  - &stable-5_15_llvm_14           {<< : *llvm_14,      << : *stable-5_15,      << : *wed_midnight}
+  - &stable-5_15_llvm_13           {<< : *llvm_13,      << : *stable-5_15,      << : *wed_midnight}
+  - &stable-5_15_llvm_12           {<< : *llvm_12,      << : *stable-5_15,      << : *wed_six}
+  - &stable-5_15_llvm_11           {<< : *llvm_11,      << : *stable-5_15,      << : *wed_six}
+  - &stable-5_10_llvm_tot          {<< : *llvm_tot,     << : *stable-5_10,      << : *mon_fri_eighteen}
+  - &stable-5_10_llvm_latest       {<< : *llvm_latest,  << : *stable-5_10,      << : *mon_fri_noon}
+  - &stable-5_10_llvm_16           {<< : *llvm_16,      << : *stable-5_10,      << : *wed_midnight}
+  - &stable-5_10_llvm_15           {<< : *llvm_15,      << : *stable-5_10,      << : *wed_midnight}
+  - &stable-5_10_llvm_14           {<< : *llvm_14,      << : *stable-5_10,      << : *wed_six}
+  - &stable-5_10_llvm_13           {<< : *llvm_13,      << : *stable-5_10,      << : *wed_six}
+  - &stable-5_10_llvm_12           {<< : *llvm_12,      << : *stable-5_10,      << : *wed_noon}
+  - &stable-5_10_llvm_11           {<< : *llvm_11,      << : *stable-5_10,      << : *wed_noon}
+  - &stable-5_4_llvm_tot           {<< : *llvm_tot,     << : *stable-5_4,       << : *mon_fri_six}
+  - &stable-5_4_llvm_latest        {<< : *llvm_latest,  << : *stable-5_4,       << : *mon_fri_midnight}
+  - &stable-5_4_llvm_16            {<< : *llvm_16,      << : *stable-5_4,       << : *wed_eighteen}
+  - &stable-5_4_llvm_15            {<< : *llvm_15,      << : *stable-5_4,       << : *wed_eighteen}
+  - &stable-5_4_llvm_14            {<< : *llvm_14,      << : *stable-5_4,       << : *wed_midnight}
+  - &stable-5_4_llvm_13            {<< : *llvm_13,      << : *stable-5_4,       << : *wed_midnight}
+  - &stable-4_19_llvm_tot          {<< : *llvm_tot,     << : *stable-4_19,      << : *mon_fri_eighteen}
+  - &stable-4_19_llvm_latest       {<< : *llvm_latest,  << : *stable-4_19,      << : *mon_fri_noon}
+  - &stable-4_19_llvm_16           {<< : *llvm_16,      << : *stable-4_19,      << : *wed_six}
+  - &stable-4_19_llvm_15           {<< : *llvm_15,      << : *stable-4_19,      << : *wed_six}
+  - &stable-4_19_llvm_14           {<< : *llvm_14,      << : *stable-4_19,      << : *wed_noon}
+  - &stable-4_19_llvm_13           {<< : *llvm_13,      << : *stable-4_19,      << : *wed_noon}
   - &android-mainline_llvm_tot     {<< : *llvm_tot,     << : *android-mainline, << : *weekdays_six}
   - &android-mainline_llvm_latest  {<< : *llvm_latest,  << : *android-mainline, << : *weekdays_six}
-  - &android-mainline_llvm_16      {<< : *llvm_16,      << : *android-mainline, << : *sundays}
-  - &android-mainline_llvm_15      {<< : *llvm_15,      << : *android-mainline, << : *sundays}
-  - &android-mainline_llvm_14      {<< : *llvm_14,      << : *android-mainline, << : *sundays}
-  - &android-mainline_llvm_13      {<< : *llvm_13,      << : *android-mainline, << : *sundays}
-  - &android-mainline_llvm_12      {<< : *llvm_12,      << : *android-mainline, << : *sundays}
+  - &android-mainline_llvm_16      {<< : *llvm_16,      << : *android-mainline, << : *sun_midnight}
+  - &android-mainline_llvm_15      {<< : *llvm_15,      << : *android-mainline, << : *sun_six}
+  - &android-mainline_llvm_14      {<< : *llvm_14,      << : *android-mainline, << : *sun_noon}
+  - &android-mainline_llvm_13      {<< : *llvm_13,      << : *android-mainline, << : *sun_eighteen}
+  - &android-mainline_llvm_12      {<< : *llvm_12,      << : *android-mainline, << : *sun_midnight}
   - &android-mainline_llvm_android {<< : *llvm_android, << : *android-mainline, << : *weekdays_six}
   - &android15-6_6_llvm_tot        {<< : *llvm_tot,     << : *android15-6_6,    << : *weekdays_six}
   - &android15-6_6_llvm_latest     {<< : *llvm_latest,  << : *android15-6_6,    << : *weekdays_six}
-  - &android15-6_6_llvm_16         {<< : *llvm_16,      << : *android15-6_6,    << : *sundays}
-  - &android15-6_6_llvm_15         {<< : *llvm_15,      << : *android15-6_6,    << : *sundays}
-  - &android15-6_6_llvm_14         {<< : *llvm_14,      << : *android15-6_6,    << : *sundays}
-  - &android15-6_6_llvm_13         {<< : *llvm_13,      << : *android15-6_6,    << : *sundays}
-  - &android15-6_6_llvm_12         {<< : *llvm_12,      << : *android15-6_6,    << : *sundays}
+  - &android15-6_6_llvm_16         {<< : *llvm_16,      << : *android15-6_6,    << : *sun_midnight}
+  - &android15-6_6_llvm_15         {<< : *llvm_15,      << : *android15-6_6,    << : *sun_six}
+  - &android15-6_6_llvm_14         {<< : *llvm_14,      << : *android15-6_6,    << : *sun_noon}
+  - &android15-6_6_llvm_13         {<< : *llvm_13,      << : *android15-6_6,    << : *sun_eighteen}
+  - &android15-6_6_llvm_12         {<< : *llvm_12,      << : *android15-6_6,    << : *sun_midnight}
   - &android15-6_6_llvm_android    {<< : *llvm_android, << : *android15-6_6,    << : *weekdays_six}
   - &android15-6_1_llvm_tot        {<< : *llvm_tot,     << : *android15-6_1,    << : *weekdays_six}
   - &android15-6_1_llvm_latest     {<< : *llvm_latest,  << : *android15-6_1,    << : *weekdays_six}
-  - &android15-6_1_llvm_16         {<< : *llvm_16,      << : *android15-6_1,    << : *sundays}
-  - &android15-6_1_llvm_15         {<< : *llvm_15,      << : *android15-6_1,    << : *sundays}
-  - &android15-6_1_llvm_14         {<< : *llvm_14,      << : *android15-6_1,    << : *sundays}
-  - &android15-6_1_llvm_13         {<< : *llvm_13,      << : *android15-6_1,    << : *sundays}
-  - &android15-6_1_llvm_12         {<< : *llvm_12,      << : *android15-6_1,    << : *sundays}
+  - &android15-6_1_llvm_16         {<< : *llvm_16,      << : *android15-6_1,    << : *sun_midnight}
+  - &android15-6_1_llvm_15         {<< : *llvm_15,      << : *android15-6_1,    << : *sun_six}
+  - &android15-6_1_llvm_14         {<< : *llvm_14,      << : *android15-6_1,    << : *sun_noon}
+  - &android15-6_1_llvm_13         {<< : *llvm_13,      << : *android15-6_1,    << : *sun_eighteen}
+  - &android15-6_1_llvm_12         {<< : *llvm_12,      << : *android15-6_1,    << : *sun_midnight}
   - &android15-6_1_llvm_android    {<< : *llvm_android, << : *android15-6_1,    << : *weekdays_six}
   - &android14-6_1_llvm_tot        {<< : *llvm_tot,     << : *android14-6_1,    << : *weekdays_six}
   - &android14-6_1_llvm_latest     {<< : *llvm_latest,  << : *android14-6_1,    << : *weekdays_six}
-  - &android14-6_1_llvm_16         {<< : *llvm_16,      << : *android14-6_1,    << : *sundays}
-  - &android14-6_1_llvm_15         {<< : *llvm_15,      << : *android14-6_1,    << : *sundays}
-  - &android14-6_1_llvm_14         {<< : *llvm_14,      << : *android14-6_1,    << : *sundays}
-  - &android14-6_1_llvm_13         {<< : *llvm_13,      << : *android14-6_1,    << : *sundays}
-  - &android14-6_1_llvm_12         {<< : *llvm_12,      << : *android14-6_1,    << : *sundays}
+  - &android14-6_1_llvm_16         {<< : *llvm_16,      << : *android14-6_1,    << : *sun_six}
+  - &android14-6_1_llvm_15         {<< : *llvm_15,      << : *android14-6_1,    << : *sun_noon}
+  - &android14-6_1_llvm_14         {<< : *llvm_14,      << : *android14-6_1,    << : *sun_eighteen}
+  - &android14-6_1_llvm_13         {<< : *llvm_13,      << : *android14-6_1,    << : *sun_midnight}
+  - &android14-6_1_llvm_12         {<< : *llvm_12,      << : *android14-6_1,    << : *sun_six}
   - &android14-6_1_llvm_android    {<< : *llvm_android, << : *android14-6_1,    << : *weekdays_six}
   - &android14-5_15_llvm_tot       {<< : *llvm_tot,     << : *android14-5_15,   << : *weekdays_six}
   - &android14-5_15_llvm_latest    {<< : *llvm_latest,  << : *android14-5_15,   << : *weekdays_six}
-  - &android14-5_15_llvm_16        {<< : *llvm_16,      << : *android14-5_15,   << : *sundays}
-  - &android14-5_15_llvm_15        {<< : *llvm_15,      << : *android14-5_15,   << : *sundays}
-  - &android14-5_15_llvm_14        {<< : *llvm_14,      << : *android14-5_15,   << : *sundays}
-  - &android14-5_15_llvm_13        {<< : *llvm_13,      << : *android14-5_15,   << : *sundays}
-  - &android14-5_15_llvm_12        {<< : *llvm_12,      << : *android14-5_15,   << : *sundays}
+  - &android14-5_15_llvm_16        {<< : *llvm_16,      << : *android14-5_15,   << : *sun_noon}
+  - &android14-5_15_llvm_15        {<< : *llvm_15,      << : *android14-5_15,   << : *sun_eighteen}
+  - &android14-5_15_llvm_14        {<< : *llvm_14,      << : *android14-5_15,   << : *sun_midnight}
+  - &android14-5_15_llvm_13        {<< : *llvm_13,      << : *android14-5_15,   << : *sun_six}
+  - &android14-5_15_llvm_12        {<< : *llvm_12,      << : *android14-5_15,   << : *sun_noon}
   - &android14-5_15_llvm_android   {<< : *llvm_android, << : *android14-5_15,   << : *weekdays_six}
   - &android13-5_15_llvm_tot       {<< : *llvm_tot,     << : *android13-5_15,   << : *weekdays_six}
   - &android13-5_15_llvm_latest    {<< : *llvm_latest,  << : *android13-5_15,   << : *weekdays_six}
-  - &android13-5_15_llvm_16        {<< : *llvm_16,      << : *android13-5_15,   << : *sundays}
-  - &android13-5_15_llvm_15        {<< : *llvm_15,      << : *android13-5_15,   << : *sundays}
-  - &android13-5_15_llvm_14        {<< : *llvm_14,      << : *android13-5_15,   << : *sundays}
-  - &android13-5_15_llvm_13        {<< : *llvm_13,      << : *android13-5_15,   << : *sundays}
-  - &android13-5_15_llvm_12        {<< : *llvm_12,      << : *android13-5_15,   << : *sundays}
+  - &android13-5_15_llvm_16        {<< : *llvm_16,      << : *android13-5_15,   << : *sun_eighteen}
+  - &android13-5_15_llvm_15        {<< : *llvm_15,      << : *android13-5_15,   << : *sun_midnight}
+  - &android13-5_15_llvm_14        {<< : *llvm_14,      << : *android13-5_15,   << : *sun_six}
+  - &android13-5_15_llvm_13        {<< : *llvm_13,      << : *android13-5_15,   << : *sun_noon}
+  - &android13-5_15_llvm_12        {<< : *llvm_12,      << : *android13-5_15,   << : *sun_eighteen}
   - &android13-5_15_llvm_android   {<< : *llvm_android, << : *android13-5_15,   << : *weekdays_six}
   - &android13-5_10_llvm_tot       {<< : *llvm_tot,     << : *android13-5_10,   << : *weekdays_six}
   - &android13-5_10_llvm_latest    {<< : *llvm_latest,  << : *android13-5_10,   << : *weekdays_six}
-  - &android13-5_10_llvm_16        {<< : *llvm_16,      << : *android13-5_10,   << : *sundays}
-  - &android13-5_10_llvm_15        {<< : *llvm_15,      << : *android13-5_10,   << : *sundays}
-  - &android13-5_10_llvm_14        {<< : *llvm_14,      << : *android13-5_10,   << : *sundays}
-  - &android13-5_10_llvm_13        {<< : *llvm_13,      << : *android13-5_10,   << : *sundays}
-  - &android13-5_10_llvm_12        {<< : *llvm_12,      << : *android13-5_10,   << : *sundays}
+  - &android13-5_10_llvm_16        {<< : *llvm_16,      << : *android13-5_10,   << : *sun_midnight}
+  - &android13-5_10_llvm_15        {<< : *llvm_15,      << : *android13-5_10,   << : *sun_six}
+  - &android13-5_10_llvm_14        {<< : *llvm_14,      << : *android13-5_10,   << : *sun_noon}
+  - &android13-5_10_llvm_13        {<< : *llvm_13,      << : *android13-5_10,   << : *sun_eighteen}
+  - &android13-5_10_llvm_12        {<< : *llvm_12,      << : *android13-5_10,   << : *sun_midnight}
   - &android13-5_10_llvm_android   {<< : *llvm_android, << : *android13-5_10,   << : *weekdays_six}
   - &android12-5_10_llvm_tot       {<< : *llvm_tot,     << : *android12-5_10,   << : *weekdays_six}
   - &android12-5_10_llvm_latest    {<< : *llvm_latest,  << : *android12-5_10,   << : *weekdays_six}
-  - &android12-5_10_llvm_16        {<< : *llvm_16,      << : *android12-5_10,   << : *sundays}
-  - &android12-5_10_llvm_15        {<< : *llvm_15,      << : *android12-5_10,   << : *sundays}
-  - &android12-5_10_llvm_14        {<< : *llvm_14,      << : *android12-5_10,   << : *sundays}
-  - &android12-5_10_llvm_13        {<< : *llvm_13,      << : *android12-5_10,   << : *sundays}
-  - &android12-5_10_llvm_12        {<< : *llvm_12,      << : *android12-5_10,   << : *sundays}
+  - &android12-5_10_llvm_16        {<< : *llvm_16,      << : *android12-5_10,   << : *sun_six}
+  - &android12-5_10_llvm_15        {<< : *llvm_15,      << : *android12-5_10,   << : *sun_noon}
+  - &android12-5_10_llvm_14        {<< : *llvm_14,      << : *android12-5_10,   << : *sun_eighteen}
+  - &android12-5_10_llvm_13        {<< : *llvm_13,      << : *android12-5_10,   << : *sun_midnight}
+  - &android12-5_10_llvm_12        {<< : *llvm_12,      << : *android12-5_10,   << : *sun_six}
   - &android12-5_10_llvm_android   {<< : *llvm_android, << : *android12-5_10,   << : *weekdays_six}
   - &android12-5_4_llvm_tot        {<< : *llvm_tot,     << : *android12-5_4,    << : *weekdays_six}
   - &android12-5_4_llvm_latest     {<< : *llvm_latest,  << : *android12-5_4,    << : *weekdays_six}
-  - &android12-5_4_llvm_16         {<< : *llvm_16,      << : *android12-5_4,    << : *sundays}
-  - &android12-5_4_llvm_15         {<< : *llvm_15,      << : *android12-5_4,    << : *sundays}
-  - &android12-5_4_llvm_14         {<< : *llvm_14,      << : *android12-5_4,    << : *sundays}
-  - &android12-5_4_llvm_13         {<< : *llvm_13,      << : *android12-5_4,    << : *sundays}
-  - &android12-5_4_llvm_12         {<< : *llvm_12,      << : *android12-5_4,    << : *sundays}
+  - &android12-5_4_llvm_16         {<< : *llvm_16,      << : *android12-5_4,    << : *sun_noon}
+  - &android12-5_4_llvm_15         {<< : *llvm_15,      << : *android12-5_4,    << : *sun_eighteen}
+  - &android12-5_4_llvm_14         {<< : *llvm_14,      << : *android12-5_4,    << : *sun_midnight}
+  - &android12-5_4_llvm_13         {<< : *llvm_13,      << : *android12-5_4,    << : *sun_six}
+  - &android12-5_4_llvm_12         {<< : *llvm_12,      << : *android12-5_4,    << : *sun_noon}
   - &android12-5_4_llvm_android    {<< : *llvm_android, << : *android12-5_4,    << : *weekdays_six}
   - &android-4_19_llvm_tot         {<< : *llvm_tot,     << : *android-4_19,     << : *weekdays_six}
   - &android-4_19_llvm_latest      {<< : *llvm_latest,  << : *android-4_19,     << : *weekdays_six}
-  - &android-4_19_llvm_16          {<< : *llvm_16,      << : *android-4_19,     << : *sundays}
-  - &android-4_19_llvm_15          {<< : *llvm_15,      << : *android-4_19,     << : *sundays}
-  - &android-4_19_llvm_14          {<< : *llvm_14,      << : *android-4_19,     << : *sundays}
-  - &android-4_19_llvm_13          {<< : *llvm_13,      << : *android-4_19,     << : *sundays}
-  - &android-4_19_llvm_12          {<< : *llvm_12,      << : *android-4_19,     << : *sundays}
+  - &android-4_19_llvm_16          {<< : *llvm_16,      << : *android-4_19,     << : *sun_eighteen}
+  - &android-4_19_llvm_15          {<< : *llvm_15,      << : *android-4_19,     << : *sun_midnight}
+  - &android-4_19_llvm_14          {<< : *llvm_14,      << : *android-4_19,     << : *sun_six}
+  - &android-4_19_llvm_13          {<< : *llvm_13,      << : *android-4_19,     << : *sun_noon}
+  - &android-4_19_llvm_12          {<< : *llvm_12,      << : *android-4_19,     << : *sun_eighteen}
   - &android-4_19_llvm_android     {<< : *llvm_android, << : *android-4_19,     << : *weekdays_six}
   - &chromeos-6_6_llvm_tot         {<< : *llvm_tot,     << : *chromeos-6_6,     << : *weekdays_six}
   - &chromeos-6_6_llvm_latest      {<< : *llvm_latest,  << : *chromeos-6_6,     << : *weekdays_six}
-  - &chromeos-6_6_llvm_16          {<< : *llvm_16,      << : *chromeos-6_6,     << : *sundays}
-  - &chromeos-6_6_llvm_15          {<< : *llvm_15,      << : *chromeos-6_6,     << : *sundays}
-  - &chromeos-6_6_llvm_14          {<< : *llvm_14,      << : *chromeos-6_6,     << : *sundays}
-  - &chromeos-6_6_llvm_13          {<< : *llvm_13,      << : *chromeos-6_6,     << : *sundays}
-  - &chromeos-6_6_llvm_12          {<< : *llvm_12,      << : *chromeos-6_6,     << : *sundays}
+  - &chromeos-6_6_llvm_16          {<< : *llvm_16,      << : *chromeos-6_6,     << : *sun_midnight}
+  - &chromeos-6_6_llvm_15          {<< : *llvm_15,      << : *chromeos-6_6,     << : *sun_six}
+  - &chromeos-6_6_llvm_14          {<< : *llvm_14,      << : *chromeos-6_6,     << : *sun_noon}
+  - &chromeos-6_6_llvm_13          {<< : *llvm_13,      << : *chromeos-6_6,     << : *sun_eighteen}
+  - &chromeos-6_6_llvm_12          {<< : *llvm_12,      << : *chromeos-6_6,     << : *sun_midnight}
   - &chromeos-6_1_llvm_tot         {<< : *llvm_tot,     << : *chromeos-6_1,     << : *weekdays_six}
   - &chromeos-6_1_llvm_latest      {<< : *llvm_latest,  << : *chromeos-6_1,     << : *weekdays_six}
-  - &chromeos-6_1_llvm_16          {<< : *llvm_16,      << : *chromeos-6_1,     << : *sundays}
-  - &chromeos-6_1_llvm_15          {<< : *llvm_15,      << : *chromeos-6_1,     << : *sundays}
-  - &chromeos-6_1_llvm_14          {<< : *llvm_14,      << : *chromeos-6_1,     << : *sundays}
-  - &chromeos-6_1_llvm_13          {<< : *llvm_13,      << : *chromeos-6_1,     << : *sundays}
-  - &chromeos-6_1_llvm_12          {<< : *llvm_12,      << : *chromeos-6_1,     << : *sundays}
+  - &chromeos-6_1_llvm_16          {<< : *llvm_16,      << : *chromeos-6_1,     << : *sun_six}
+  - &chromeos-6_1_llvm_15          {<< : *llvm_15,      << : *chromeos-6_1,     << : *sun_noon}
+  - &chromeos-6_1_llvm_14          {<< : *llvm_14,      << : *chromeos-6_1,     << : *sun_eighteen}
+  - &chromeos-6_1_llvm_13          {<< : *llvm_13,      << : *chromeos-6_1,     << : *sun_midnight}
+  - &chromeos-6_1_llvm_12          {<< : *llvm_12,      << : *chromeos-6_1,     << : *sun_six}
   - &chromeos-5_15_llvm_tot        {<< : *llvm_tot,     << : *chromeos-5_15,    << : *weekdays_six}
   - &chromeos-5_15_llvm_latest     {<< : *llvm_latest,  << : *chromeos-5_15,    << : *weekdays_six}
-  - &chromeos-5_15_llvm_16         {<< : *llvm_16,      << : *chromeos-5_15,    << : *sundays}
-  - &chromeos-5_15_llvm_15         {<< : *llvm_15,      << : *chromeos-5_15,    << : *sundays}
-  - &chromeos-5_15_llvm_14         {<< : *llvm_14,      << : *chromeos-5_15,    << : *sundays}
-  - &chromeos-5_15_llvm_13         {<< : *llvm_13,      << : *chromeos-5_15,    << : *sundays}
-  - &chromeos-5_15_llvm_12         {<< : *llvm_12,      << : *chromeos-5_15,    << : *sundays}
+  - &chromeos-5_15_llvm_16         {<< : *llvm_16,      << : *chromeos-5_15,    << : *sun_noon}
+  - &chromeos-5_15_llvm_15         {<< : *llvm_15,      << : *chromeos-5_15,    << : *sun_eighteen}
+  - &chromeos-5_15_llvm_14         {<< : *llvm_14,      << : *chromeos-5_15,    << : *sun_midnight}
+  - &chromeos-5_15_llvm_13         {<< : *llvm_13,      << : *chromeos-5_15,    << : *sun_six}
+  - &chromeos-5_15_llvm_12         {<< : *llvm_12,      << : *chromeos-5_15,    << : *sun_noon}
   - &chromeos-5_10_llvm_tot        {<< : *llvm_tot,     << : *chromeos-5_10,    << : *weekdays_six}
   - &chromeos-5_10_llvm_latest     {<< : *llvm_latest,  << : *chromeos-5_10,    << : *weekdays_six}
-  - &chromeos-5_10_llvm_16         {<< : *llvm_16,      << : *chromeos-5_10,    << : *sundays}
-  - &chromeos-5_10_llvm_15         {<< : *llvm_15,      << : *chromeos-5_10,    << : *sundays}
-  - &chromeos-5_10_llvm_14         {<< : *llvm_14,      << : *chromeos-5_10,    << : *sundays}
-  - &chromeos-5_10_llvm_13         {<< : *llvm_13,      << : *chromeos-5_10,    << : *sundays}
-  - &chromeos-5_10_llvm_12         {<< : *llvm_12,      << : *chromeos-5_10,    << : *sundays}
+  - &chromeos-5_10_llvm_16         {<< : *llvm_16,      << : *chromeos-5_10,    << : *sun_eighteen}
+  - &chromeos-5_10_llvm_15         {<< : *llvm_15,      << : *chromeos-5_10,    << : *sun_midnight}
+  - &chromeos-5_10_llvm_14         {<< : *llvm_14,      << : *chromeos-5_10,    << : *sun_six}
+  - &chromeos-5_10_llvm_13         {<< : *llvm_13,      << : *chromeos-5_10,    << : *sun_noon}
+  - &chromeos-5_10_llvm_12         {<< : *llvm_12,      << : *chromeos-5_10,    << : *sun_eighteen}
   - &tip_llvm_tot                  {<< : *llvm_tot,     << : *tip,              << : *weekdays_midnight}
   - &tip_llvm_latest               {<< : *llvm_latest,  << : *tip,              << : *weekdays_midnight}
   - &tip_llvm_16                   {<< : *llvm_16,      << : *tip,              << : *weekdays_eighteen}

--- a/generator/yml/0004-trees.yml
+++ b/generator/yml/0004-trees.yml
@@ -26,8 +26,8 @@ trees:
   - &arm64-core       {git_repo: *arm64-url,    git_ref: for-next/core,       name: arm64}
   - &arm64-fixes      {git_repo: *arm64-url,    git_ref: for-next/fixes,      name: arm64-fixes}
 tree_schedules:
-  - &mainline_llvm_tot             {<< : *llvm_tot,     << : *mainline,         << : *twelve_hours}
-  - &mainline_llvm_latest          {<< : *llvm_latest,  << : *mainline,         << : *twelve_hours}
+  - &mainline_llvm_tot             {<< : *llvm_tot,     << : *mainline,         << : *weekdays_every_12}
+  - &mainline_llvm_latest          {<< : *llvm_latest,  << : *mainline,         << : *weekdays_every_12}
   - &mainline_llvm_16              {<< : *llvm_16,      << : *mainline,         << : *daily_eighteen}
   - &mainline_llvm_15              {<< : *llvm_15,      << : *mainline,         << : *daily_midnight}
   - &mainline_llvm_14              {<< : *llvm_14,      << : *mainline,         << : *daily_six}

--- a/generator/yml/0004-trees.yml
+++ b/generator/yml/0004-trees.yml
@@ -28,19 +28,19 @@ trees:
 tree_schedules:
   - &mainline_llvm_tot             {<< : *llvm_tot,     << : *mainline,         << : *weekdays_every_12}
   - &mainline_llvm_latest          {<< : *llvm_latest,  << : *mainline,         << : *weekdays_every_12}
-  - &mainline_llvm_16              {<< : *llvm_16,      << : *mainline,         << : *daily_eighteen}
-  - &mainline_llvm_15              {<< : *llvm_15,      << : *mainline,         << : *daily_midnight}
-  - &mainline_llvm_14              {<< : *llvm_14,      << : *mainline,         << : *daily_six}
-  - &mainline_llvm_13              {<< : *llvm_13,      << : *mainline,         << : *daily_noon}
-  - &mainline_llvm_12              {<< : *llvm_12,      << : *mainline,         << : *daily_eighteen}
+  - &mainline_llvm_16              {<< : *llvm_16,      << : *mainline,         << : *weekdays_eighteen}
+  - &mainline_llvm_15              {<< : *llvm_15,      << : *mainline,         << : *weekdays_midnight}
+  - &mainline_llvm_14              {<< : *llvm_14,      << : *mainline,         << : *weekdays_six}
+  - &mainline_llvm_13              {<< : *llvm_13,      << : *mainline,         << : *weekdays_noon}
+  - &mainline_llvm_12              {<< : *llvm_12,      << : *mainline,         << : *weekdays_eighteen}
   # -next updates M-F in the evening AEST, which is usually around 12:00PM UTC
-  - &next_llvm_tot                 {<< : *llvm_tot,     << : *next,             << : *daily_noon}
-  - &next_llvm_latest              {<< : *llvm_latest,  << : *next,             << : *daily_noon}
-  - &next_llvm_16                  {<< : *llvm_16,      << : *next,             << : *daily_noon}
-  - &next_llvm_15                  {<< : *llvm_15,      << : *next,             << : *daily_noon}
-  - &next_llvm_14                  {<< : *llvm_14,      << : *next,             << : *daily_noon}
-  - &next_llvm_13                  {<< : *llvm_13,      << : *next,             << : *daily_noon}
-  - &next_llvm_android             {<< : *llvm_android, << : *next,             << : *daily_noon}
+  - &next_llvm_tot                 {<< : *llvm_tot,     << : *next,             << : *weekdays_noon}
+  - &next_llvm_latest              {<< : *llvm_latest,  << : *next,             << : *weekdays_noon}
+  - &next_llvm_16                  {<< : *llvm_16,      << : *next,             << : *weekdays_noon}
+  - &next_llvm_15                  {<< : *llvm_15,      << : *next,             << : *weekdays_noon}
+  - &next_llvm_14                  {<< : *llvm_14,      << : *next,             << : *weekdays_noon}
+  - &next_llvm_13                  {<< : *llvm_13,      << : *next,             << : *weekdays_noon}
+  - &next_llvm_android             {<< : *llvm_android, << : *next,             << : *weekdays_noon}
   - &stable_llvm_tot               {<< : *llvm_tot,     << : *stable,           << : *monday_friday}
   - &stable_llvm_latest            {<< : *llvm_latest,  << : *stable,           << : *monday_friday}
   - &stable_llvm_16                {<< : *llvm_16,      << : *stable,           << : *wednesdays}
@@ -93,135 +93,135 @@ tree_schedules:
   - &stable-4_19_llvm_15           {<< : *llvm_15,      << : *stable-4_19,      << : *wednesdays}
   - &stable-4_19_llvm_14           {<< : *llvm_14,      << : *stable-4_19,      << : *wednesdays}
   - &stable-4_19_llvm_13           {<< : *llvm_13,      << : *stable-4_19,      << : *wednesdays}
-  - &android-mainline_llvm_tot     {<< : *llvm_tot,     << : *android-mainline, << : *daily_six}
-  - &android-mainline_llvm_latest  {<< : *llvm_latest,  << : *android-mainline, << : *daily_six}
+  - &android-mainline_llvm_tot     {<< : *llvm_tot,     << : *android-mainline, << : *weekdays_six}
+  - &android-mainline_llvm_latest  {<< : *llvm_latest,  << : *android-mainline, << : *weekdays_six}
   - &android-mainline_llvm_16      {<< : *llvm_16,      << : *android-mainline, << : *sundays}
   - &android-mainline_llvm_15      {<< : *llvm_15,      << : *android-mainline, << : *sundays}
   - &android-mainline_llvm_14      {<< : *llvm_14,      << : *android-mainline, << : *sundays}
   - &android-mainline_llvm_13      {<< : *llvm_13,      << : *android-mainline, << : *sundays}
   - &android-mainline_llvm_12      {<< : *llvm_12,      << : *android-mainline, << : *sundays}
-  - &android-mainline_llvm_android {<< : *llvm_android, << : *android-mainline, << : *daily_six}
-  - &android15-6_6_llvm_tot        {<< : *llvm_tot,     << : *android15-6_6,    << : *daily_six}
-  - &android15-6_6_llvm_latest     {<< : *llvm_latest,  << : *android15-6_6,    << : *daily_six}
+  - &android-mainline_llvm_android {<< : *llvm_android, << : *android-mainline, << : *weekdays_six}
+  - &android15-6_6_llvm_tot        {<< : *llvm_tot,     << : *android15-6_6,    << : *weekdays_six}
+  - &android15-6_6_llvm_latest     {<< : *llvm_latest,  << : *android15-6_6,    << : *weekdays_six}
   - &android15-6_6_llvm_16         {<< : *llvm_16,      << : *android15-6_6,    << : *sundays}
   - &android15-6_6_llvm_15         {<< : *llvm_15,      << : *android15-6_6,    << : *sundays}
   - &android15-6_6_llvm_14         {<< : *llvm_14,      << : *android15-6_6,    << : *sundays}
   - &android15-6_6_llvm_13         {<< : *llvm_13,      << : *android15-6_6,    << : *sundays}
   - &android15-6_6_llvm_12         {<< : *llvm_12,      << : *android15-6_6,    << : *sundays}
-  - &android15-6_6_llvm_android    {<< : *llvm_android, << : *android15-6_6,    << : *daily_six}
-  - &android15-6_1_llvm_tot        {<< : *llvm_tot,     << : *android15-6_1,    << : *daily_six}
-  - &android15-6_1_llvm_latest     {<< : *llvm_latest,  << : *android15-6_1,    << : *daily_six}
+  - &android15-6_6_llvm_android    {<< : *llvm_android, << : *android15-6_6,    << : *weekdays_six}
+  - &android15-6_1_llvm_tot        {<< : *llvm_tot,     << : *android15-6_1,    << : *weekdays_six}
+  - &android15-6_1_llvm_latest     {<< : *llvm_latest,  << : *android15-6_1,    << : *weekdays_six}
   - &android15-6_1_llvm_16         {<< : *llvm_16,      << : *android15-6_1,    << : *sundays}
   - &android15-6_1_llvm_15         {<< : *llvm_15,      << : *android15-6_1,    << : *sundays}
   - &android15-6_1_llvm_14         {<< : *llvm_14,      << : *android15-6_1,    << : *sundays}
   - &android15-6_1_llvm_13         {<< : *llvm_13,      << : *android15-6_1,    << : *sundays}
   - &android15-6_1_llvm_12         {<< : *llvm_12,      << : *android15-6_1,    << : *sundays}
-  - &android15-6_1_llvm_android    {<< : *llvm_android, << : *android15-6_1,    << : *daily_six}
-  - &android14-6_1_llvm_tot        {<< : *llvm_tot,     << : *android14-6_1,    << : *daily_six}
-  - &android14-6_1_llvm_latest     {<< : *llvm_latest,  << : *android14-6_1,    << : *daily_six}
+  - &android15-6_1_llvm_android    {<< : *llvm_android, << : *android15-6_1,    << : *weekdays_six}
+  - &android14-6_1_llvm_tot        {<< : *llvm_tot,     << : *android14-6_1,    << : *weekdays_six}
+  - &android14-6_1_llvm_latest     {<< : *llvm_latest,  << : *android14-6_1,    << : *weekdays_six}
   - &android14-6_1_llvm_16         {<< : *llvm_16,      << : *android14-6_1,    << : *sundays}
   - &android14-6_1_llvm_15         {<< : *llvm_15,      << : *android14-6_1,    << : *sundays}
   - &android14-6_1_llvm_14         {<< : *llvm_14,      << : *android14-6_1,    << : *sundays}
   - &android14-6_1_llvm_13         {<< : *llvm_13,      << : *android14-6_1,    << : *sundays}
   - &android14-6_1_llvm_12         {<< : *llvm_12,      << : *android14-6_1,    << : *sundays}
-  - &android14-6_1_llvm_android    {<< : *llvm_android, << : *android14-6_1,    << : *daily_six}
-  - &android14-5_15_llvm_tot       {<< : *llvm_tot,     << : *android14-5_15,   << : *daily_six}
-  - &android14-5_15_llvm_latest    {<< : *llvm_latest,  << : *android14-5_15,   << : *daily_six}
+  - &android14-6_1_llvm_android    {<< : *llvm_android, << : *android14-6_1,    << : *weekdays_six}
+  - &android14-5_15_llvm_tot       {<< : *llvm_tot,     << : *android14-5_15,   << : *weekdays_six}
+  - &android14-5_15_llvm_latest    {<< : *llvm_latest,  << : *android14-5_15,   << : *weekdays_six}
   - &android14-5_15_llvm_16        {<< : *llvm_16,      << : *android14-5_15,   << : *sundays}
   - &android14-5_15_llvm_15        {<< : *llvm_15,      << : *android14-5_15,   << : *sundays}
   - &android14-5_15_llvm_14        {<< : *llvm_14,      << : *android14-5_15,   << : *sundays}
   - &android14-5_15_llvm_13        {<< : *llvm_13,      << : *android14-5_15,   << : *sundays}
   - &android14-5_15_llvm_12        {<< : *llvm_12,      << : *android14-5_15,   << : *sundays}
-  - &android14-5_15_llvm_android   {<< : *llvm_android, << : *android14-5_15,   << : *daily_six}
-  - &android13-5_15_llvm_tot       {<< : *llvm_tot,     << : *android13-5_15,   << : *daily_six}
-  - &android13-5_15_llvm_latest    {<< : *llvm_latest,  << : *android13-5_15,   << : *daily_six}
+  - &android14-5_15_llvm_android   {<< : *llvm_android, << : *android14-5_15,   << : *weekdays_six}
+  - &android13-5_15_llvm_tot       {<< : *llvm_tot,     << : *android13-5_15,   << : *weekdays_six}
+  - &android13-5_15_llvm_latest    {<< : *llvm_latest,  << : *android13-5_15,   << : *weekdays_six}
   - &android13-5_15_llvm_16        {<< : *llvm_16,      << : *android13-5_15,   << : *sundays}
   - &android13-5_15_llvm_15        {<< : *llvm_15,      << : *android13-5_15,   << : *sundays}
   - &android13-5_15_llvm_14        {<< : *llvm_14,      << : *android13-5_15,   << : *sundays}
   - &android13-5_15_llvm_13        {<< : *llvm_13,      << : *android13-5_15,   << : *sundays}
   - &android13-5_15_llvm_12        {<< : *llvm_12,      << : *android13-5_15,   << : *sundays}
-  - &android13-5_15_llvm_android   {<< : *llvm_android, << : *android13-5_15,   << : *daily_six}
-  - &android13-5_10_llvm_tot       {<< : *llvm_tot,     << : *android13-5_10,   << : *daily_six}
-  - &android13-5_10_llvm_latest    {<< : *llvm_latest,  << : *android13-5_10,   << : *daily_six}
+  - &android13-5_15_llvm_android   {<< : *llvm_android, << : *android13-5_15,   << : *weekdays_six}
+  - &android13-5_10_llvm_tot       {<< : *llvm_tot,     << : *android13-5_10,   << : *weekdays_six}
+  - &android13-5_10_llvm_latest    {<< : *llvm_latest,  << : *android13-5_10,   << : *weekdays_six}
   - &android13-5_10_llvm_16        {<< : *llvm_16,      << : *android13-5_10,   << : *sundays}
   - &android13-5_10_llvm_15        {<< : *llvm_15,      << : *android13-5_10,   << : *sundays}
   - &android13-5_10_llvm_14        {<< : *llvm_14,      << : *android13-5_10,   << : *sundays}
   - &android13-5_10_llvm_13        {<< : *llvm_13,      << : *android13-5_10,   << : *sundays}
   - &android13-5_10_llvm_12        {<< : *llvm_12,      << : *android13-5_10,   << : *sundays}
-  - &android13-5_10_llvm_android   {<< : *llvm_android, << : *android13-5_10,   << : *daily_six}
-  - &android12-5_10_llvm_tot       {<< : *llvm_tot,     << : *android12-5_10,   << : *daily_six}
-  - &android12-5_10_llvm_latest    {<< : *llvm_latest,  << : *android12-5_10,   << : *daily_six}
+  - &android13-5_10_llvm_android   {<< : *llvm_android, << : *android13-5_10,   << : *weekdays_six}
+  - &android12-5_10_llvm_tot       {<< : *llvm_tot,     << : *android12-5_10,   << : *weekdays_six}
+  - &android12-5_10_llvm_latest    {<< : *llvm_latest,  << : *android12-5_10,   << : *weekdays_six}
   - &android12-5_10_llvm_16        {<< : *llvm_16,      << : *android12-5_10,   << : *sundays}
   - &android12-5_10_llvm_15        {<< : *llvm_15,      << : *android12-5_10,   << : *sundays}
   - &android12-5_10_llvm_14        {<< : *llvm_14,      << : *android12-5_10,   << : *sundays}
   - &android12-5_10_llvm_13        {<< : *llvm_13,      << : *android12-5_10,   << : *sundays}
   - &android12-5_10_llvm_12        {<< : *llvm_12,      << : *android12-5_10,   << : *sundays}
-  - &android12-5_10_llvm_android   {<< : *llvm_android, << : *android12-5_10,   << : *daily_six}
-  - &android12-5_4_llvm_tot        {<< : *llvm_tot,     << : *android12-5_4,    << : *daily_six}
-  - &android12-5_4_llvm_latest     {<< : *llvm_latest,  << : *android12-5_4,    << : *daily_six}
+  - &android12-5_10_llvm_android   {<< : *llvm_android, << : *android12-5_10,   << : *weekdays_six}
+  - &android12-5_4_llvm_tot        {<< : *llvm_tot,     << : *android12-5_4,    << : *weekdays_six}
+  - &android12-5_4_llvm_latest     {<< : *llvm_latest,  << : *android12-5_4,    << : *weekdays_six}
   - &android12-5_4_llvm_16         {<< : *llvm_16,      << : *android12-5_4,    << : *sundays}
   - &android12-5_4_llvm_15         {<< : *llvm_15,      << : *android12-5_4,    << : *sundays}
   - &android12-5_4_llvm_14         {<< : *llvm_14,      << : *android12-5_4,    << : *sundays}
   - &android12-5_4_llvm_13         {<< : *llvm_13,      << : *android12-5_4,    << : *sundays}
   - &android12-5_4_llvm_12         {<< : *llvm_12,      << : *android12-5_4,    << : *sundays}
-  - &android12-5_4_llvm_android    {<< : *llvm_android, << : *android12-5_4,    << : *daily_six}
-  - &android-4_19_llvm_tot         {<< : *llvm_tot,     << : *android-4_19,     << : *daily_six}
-  - &android-4_19_llvm_latest      {<< : *llvm_latest,  << : *android-4_19,     << : *daily_six}
+  - &android12-5_4_llvm_android    {<< : *llvm_android, << : *android12-5_4,    << : *weekdays_six}
+  - &android-4_19_llvm_tot         {<< : *llvm_tot,     << : *android-4_19,     << : *weekdays_six}
+  - &android-4_19_llvm_latest      {<< : *llvm_latest,  << : *android-4_19,     << : *weekdays_six}
   - &android-4_19_llvm_16          {<< : *llvm_16,      << : *android-4_19,     << : *sundays}
   - &android-4_19_llvm_15          {<< : *llvm_15,      << : *android-4_19,     << : *sundays}
   - &android-4_19_llvm_14          {<< : *llvm_14,      << : *android-4_19,     << : *sundays}
   - &android-4_19_llvm_13          {<< : *llvm_13,      << : *android-4_19,     << : *sundays}
   - &android-4_19_llvm_12          {<< : *llvm_12,      << : *android-4_19,     << : *sundays}
-  - &android-4_19_llvm_android     {<< : *llvm_android, << : *android-4_19,     << : *daily_six}
-  - &chromeos-6_6_llvm_tot         {<< : *llvm_tot,     << : *chromeos-6_6,     << : *daily_six}
-  - &chromeos-6_6_llvm_latest      {<< : *llvm_latest,  << : *chromeos-6_6,     << : *daily_six}
+  - &android-4_19_llvm_android     {<< : *llvm_android, << : *android-4_19,     << : *weekdays_six}
+  - &chromeos-6_6_llvm_tot         {<< : *llvm_tot,     << : *chromeos-6_6,     << : *weekdays_six}
+  - &chromeos-6_6_llvm_latest      {<< : *llvm_latest,  << : *chromeos-6_6,     << : *weekdays_six}
   - &chromeos-6_6_llvm_16          {<< : *llvm_16,      << : *chromeos-6_6,     << : *sundays}
   - &chromeos-6_6_llvm_15          {<< : *llvm_15,      << : *chromeos-6_6,     << : *sundays}
   - &chromeos-6_6_llvm_14          {<< : *llvm_14,      << : *chromeos-6_6,     << : *sundays}
   - &chromeos-6_6_llvm_13          {<< : *llvm_13,      << : *chromeos-6_6,     << : *sundays}
   - &chromeos-6_6_llvm_12          {<< : *llvm_12,      << : *chromeos-6_6,     << : *sundays}
-  - &chromeos-6_1_llvm_tot         {<< : *llvm_tot,     << : *chromeos-6_1,     << : *daily_six}
-  - &chromeos-6_1_llvm_latest      {<< : *llvm_latest,  << : *chromeos-6_1,     << : *daily_six}
+  - &chromeos-6_1_llvm_tot         {<< : *llvm_tot,     << : *chromeos-6_1,     << : *weekdays_six}
+  - &chromeos-6_1_llvm_latest      {<< : *llvm_latest,  << : *chromeos-6_1,     << : *weekdays_six}
   - &chromeos-6_1_llvm_16          {<< : *llvm_16,      << : *chromeos-6_1,     << : *sundays}
   - &chromeos-6_1_llvm_15          {<< : *llvm_15,      << : *chromeos-6_1,     << : *sundays}
   - &chromeos-6_1_llvm_14          {<< : *llvm_14,      << : *chromeos-6_1,     << : *sundays}
   - &chromeos-6_1_llvm_13          {<< : *llvm_13,      << : *chromeos-6_1,     << : *sundays}
   - &chromeos-6_1_llvm_12          {<< : *llvm_12,      << : *chromeos-6_1,     << : *sundays}
-  - &chromeos-5_15_llvm_tot        {<< : *llvm_tot,     << : *chromeos-5_15,    << : *daily_six}
-  - &chromeos-5_15_llvm_latest     {<< : *llvm_latest,  << : *chromeos-5_15,    << : *daily_six}
+  - &chromeos-5_15_llvm_tot        {<< : *llvm_tot,     << : *chromeos-5_15,    << : *weekdays_six}
+  - &chromeos-5_15_llvm_latest     {<< : *llvm_latest,  << : *chromeos-5_15,    << : *weekdays_six}
   - &chromeos-5_15_llvm_16         {<< : *llvm_16,      << : *chromeos-5_15,    << : *sundays}
   - &chromeos-5_15_llvm_15         {<< : *llvm_15,      << : *chromeos-5_15,    << : *sundays}
   - &chromeos-5_15_llvm_14         {<< : *llvm_14,      << : *chromeos-5_15,    << : *sundays}
   - &chromeos-5_15_llvm_13         {<< : *llvm_13,      << : *chromeos-5_15,    << : *sundays}
   - &chromeos-5_15_llvm_12         {<< : *llvm_12,      << : *chromeos-5_15,    << : *sundays}
-  - &chromeos-5_10_llvm_tot        {<< : *llvm_tot,     << : *chromeos-5_10,    << : *daily_six}
-  - &chromeos-5_10_llvm_latest     {<< : *llvm_latest,  << : *chromeos-5_10,    << : *daily_six}
+  - &chromeos-5_10_llvm_tot        {<< : *llvm_tot,     << : *chromeos-5_10,    << : *weekdays_six}
+  - &chromeos-5_10_llvm_latest     {<< : *llvm_latest,  << : *chromeos-5_10,    << : *weekdays_six}
   - &chromeos-5_10_llvm_16         {<< : *llvm_16,      << : *chromeos-5_10,    << : *sundays}
   - &chromeos-5_10_llvm_15         {<< : *llvm_15,      << : *chromeos-5_10,    << : *sundays}
   - &chromeos-5_10_llvm_14         {<< : *llvm_14,      << : *chromeos-5_10,    << : *sundays}
   - &chromeos-5_10_llvm_13         {<< : *llvm_13,      << : *chromeos-5_10,    << : *sundays}
   - &chromeos-5_10_llvm_12         {<< : *llvm_12,      << : *chromeos-5_10,    << : *sundays}
-  - &tip_llvm_tot                  {<< : *llvm_tot,     << : *tip,              << : *daily_midnight}
-  - &tip_llvm_latest               {<< : *llvm_latest,  << : *tip,              << : *daily_midnight}
-  - &tip_llvm_16                   {<< : *llvm_16,      << : *tip,              << : *daily_eighteen}
-  - &tip_llvm_15                   {<< : *llvm_15,      << : *tip,              << : *daily_eighteen}
-  - &tip_llvm_14                   {<< : *llvm_14,      << : *tip,              << : *daily_eighteen}
-  - &tip_llvm_13                   {<< : *llvm_13,      << : *tip,              << : *daily_eighteen}
-  - &tip_llvm_12                   {<< : *llvm_12,      << : *tip,              << : *daily_eighteen}
-  - &tip_llvm_11                   {<< : *llvm_11,      << : *tip,              << : *daily_eighteen}
-  - &arm64-core_llvm_tot           {<< : *llvm_tot,     << : *arm64-core,       << : *daily_midnight}
-  - &arm64-core_llvm_latest        {<< : *llvm_latest,  << : *arm64-core,       << : *daily_midnight}
-  - &arm64-core_llvm_16            {<< : *llvm_16,      << : *arm64-core,       << : *daily_eighteen}
-  - &arm64-core_llvm_15            {<< : *llvm_15,      << : *arm64-core,       << : *daily_eighteen}
-  - &arm64-core_llvm_14            {<< : *llvm_14,      << : *arm64-core,       << : *daily_eighteen}
-  - &arm64-core_llvm_13            {<< : *llvm_13,      << : *arm64-core,       << : *daily_eighteen}
-  - &arm64-core_llvm_12            {<< : *llvm_12,      << : *arm64-core,       << : *daily_eighteen}
-  - &arm64-core_llvm_11            {<< : *llvm_11,      << : *arm64-core,       << : *daily_eighteen}
-  - &arm64-fixes_llvm_tot          {<< : *llvm_tot,     << : *arm64-fixes,      << : *daily_midnight}
-  - &arm64-fixes_llvm_latest       {<< : *llvm_latest,  << : *arm64-fixes,      << : *daily_midnight}
-  - &arm64-fixes_llvm_16           {<< : *llvm_16,      << : *arm64-fixes,      << : *daily_eighteen}
-  - &arm64-fixes_llvm_15           {<< : *llvm_15,      << : *arm64-fixes,      << : *daily_eighteen}
-  - &arm64-fixes_llvm_14           {<< : *llvm_14,      << : *arm64-fixes,      << : *daily_eighteen}
-  - &arm64-fixes_llvm_13           {<< : *llvm_13,      << : *arm64-fixes,      << : *daily_eighteen}
-  - &arm64-fixes_llvm_12           {<< : *llvm_12,      << : *arm64-fixes,      << : *daily_eighteen}
-  - &arm64-fixes_llvm_11           {<< : *llvm_11,      << : *arm64-fixes,      << : *daily_eighteen}
+  - &tip_llvm_tot                  {<< : *llvm_tot,     << : *tip,              << : *weekdays_midnight}
+  - &tip_llvm_latest               {<< : *llvm_latest,  << : *tip,              << : *weekdays_midnight}
+  - &tip_llvm_16                   {<< : *llvm_16,      << : *tip,              << : *weekdays_eighteen}
+  - &tip_llvm_15                   {<< : *llvm_15,      << : *tip,              << : *weekdays_eighteen}
+  - &tip_llvm_14                   {<< : *llvm_14,      << : *tip,              << : *weekdays_eighteen}
+  - &tip_llvm_13                   {<< : *llvm_13,      << : *tip,              << : *weekdays_eighteen}
+  - &tip_llvm_12                   {<< : *llvm_12,      << : *tip,              << : *weekdays_eighteen}
+  - &tip_llvm_11                   {<< : *llvm_11,      << : *tip,              << : *weekdays_eighteen}
+  - &arm64-core_llvm_tot           {<< : *llvm_tot,     << : *arm64-core,       << : *weekdays_midnight}
+  - &arm64-core_llvm_latest        {<< : *llvm_latest,  << : *arm64-core,       << : *weekdays_midnight}
+  - &arm64-core_llvm_16            {<< : *llvm_16,      << : *arm64-core,       << : *weekdays_eighteen}
+  - &arm64-core_llvm_15            {<< : *llvm_15,      << : *arm64-core,       << : *weekdays_eighteen}
+  - &arm64-core_llvm_14            {<< : *llvm_14,      << : *arm64-core,       << : *weekdays_eighteen}
+  - &arm64-core_llvm_13            {<< : *llvm_13,      << : *arm64-core,       << : *weekdays_eighteen}
+  - &arm64-core_llvm_12            {<< : *llvm_12,      << : *arm64-core,       << : *weekdays_eighteen}
+  - &arm64-core_llvm_11            {<< : *llvm_11,      << : *arm64-core,       << : *weekdays_eighteen}
+  - &arm64-fixes_llvm_tot          {<< : *llvm_tot,     << : *arm64-fixes,      << : *weekdays_midnight}
+  - &arm64-fixes_llvm_latest       {<< : *llvm_latest,  << : *arm64-fixes,      << : *weekdays_midnight}
+  - &arm64-fixes_llvm_16           {<< : *llvm_16,      << : *arm64-fixes,      << : *weekdays_eighteen}
+  - &arm64-fixes_llvm_15           {<< : *llvm_15,      << : *arm64-fixes,      << : *weekdays_eighteen}
+  - &arm64-fixes_llvm_14           {<< : *llvm_14,      << : *arm64-fixes,      << : *weekdays_eighteen}
+  - &arm64-fixes_llvm_13           {<< : *llvm_13,      << : *arm64-fixes,      << : *weekdays_eighteen}
+  - &arm64-fixes_llvm_12           {<< : *llvm_12,      << : *arm64-fixes,      << : *weekdays_eighteen}
+  - &arm64-fixes_llvm_11           {<< : *llvm_11,      << : *arm64-fixes,      << : *weekdays_eighteen}

--- a/generator/yml/0004-trees.yml
+++ b/generator/yml/0004-trees.yml
@@ -33,13 +33,14 @@ tree_schedules:
   - &mainline_llvm_14              {<< : *llvm_14,      << : *mainline,         << : *daily_six}
   - &mainline_llvm_13              {<< : *llvm_13,      << : *mainline,         << : *daily_noon}
   - &mainline_llvm_12              {<< : *llvm_12,      << : *mainline,         << : *daily_eighteen}
-  - &next_llvm_tot                 {<< : *llvm_tot,     << : *next,             << : *weekdays}
-  - &next_llvm_latest              {<< : *llvm_latest,  << : *next,             << : *weekdays}
-  - &next_llvm_16                  {<< : *llvm_16,      << : *next,             << : *weekdays}
-  - &next_llvm_15                  {<< : *llvm_15,      << : *next,             << : *weekdays}
-  - &next_llvm_14                  {<< : *llvm_14,      << : *next,             << : *weekdays}
-  - &next_llvm_13                  {<< : *llvm_13,      << : *next,             << : *weekdays}
-  - &next_llvm_android             {<< : *llvm_android, << : *next,             << : *weekdays}
+  # -next updates M-F in the evening AEST, which is usually around 12:00PM UTC
+  - &next_llvm_tot                 {<< : *llvm_tot,     << : *next,             << : *daily_noon}
+  - &next_llvm_latest              {<< : *llvm_latest,  << : *next,             << : *daily_noon}
+  - &next_llvm_16                  {<< : *llvm_16,      << : *next,             << : *daily_noon}
+  - &next_llvm_15                  {<< : *llvm_15,      << : *next,             << : *daily_noon}
+  - &next_llvm_14                  {<< : *llvm_14,      << : *next,             << : *daily_noon}
+  - &next_llvm_13                  {<< : *llvm_13,      << : *next,             << : *daily_noon}
+  - &next_llvm_android             {<< : *llvm_android, << : *next,             << : *daily_noon}
   - &stable_llvm_tot               {<< : *llvm_tot,     << : *stable,           << : *monday_friday}
   - &stable_llvm_latest            {<< : *llvm_latest,  << : *stable,           << : *monday_friday}
   - &stable_llvm_16                {<< : *llvm_16,      << : *stable,           << : *wednesdays}


### PR DESCRIPTION
As the number of supported trees and toolchain combinations grow, there is a possibility of heavy contention when a large number of builds are started at once.

To help avoid this, start to rebalance the builds by breaking apart certain anchors like the Monday/Friday, Wednesday, and Sunday anchors to have a variety of start times.

I would like to add other days eventually but I figured I would start smaller at first. This lays the groundwork for doing that later.
