### PR TITLE
Update {upload,download}-artifact actions to v4

### DIFF
--- a/.github/workflows/4.19-clang-13.yml
+++ b/.github/workflows/4.19-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/4.19-clang-14.yml
+++ b/.github/workflows/4.19-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/4.19-clang-15.yml
+++ b/.github/workflows/4.19-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/4.19-clang-16.yml
+++ b/.github/workflows/4.19-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/4.19-clang-17.yml
+++ b/.github/workflows/4.19-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/4.19-clang-19.yml
+++ b/.github/workflows/4.19-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.10-clang-11.yml
+++ b/.github/workflows/5.10-clang-11.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -412,7 +412,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -422,7 +422,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -447,10 +447,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -475,10 +475,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -503,10 +503,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -531,10 +531,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -559,10 +559,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -587,10 +587,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -615,10 +615,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -643,10 +643,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -671,10 +671,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.10-clang-12.yml
+++ b/.github/workflows/5.10-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -468,7 +468,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -478,7 +478,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -503,10 +503,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -531,10 +531,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -559,10 +559,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -587,10 +587,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -615,10 +615,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -643,10 +643,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -671,10 +671,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -699,10 +699,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -727,10 +727,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.10-clang-13.yml
+++ b/.github/workflows/5.10-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -496,7 +496,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -506,7 +506,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -531,10 +531,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -559,10 +559,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -587,10 +587,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -615,10 +615,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -643,10 +643,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -671,10 +671,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -699,10 +699,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -727,10 +727,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -755,10 +755,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.10-clang-14.yml
+++ b/.github/workflows/5.10-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -496,7 +496,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -506,7 +506,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -531,10 +531,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -559,10 +559,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -587,10 +587,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -615,10 +615,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -643,10 +643,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -671,10 +671,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -699,10 +699,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -727,10 +727,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -755,10 +755,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.10-clang-15.yml
+++ b/.github/workflows/5.10-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -524,7 +524,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -534,7 +534,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -559,10 +559,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -587,10 +587,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -615,10 +615,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -643,10 +643,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -671,10 +671,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -699,10 +699,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -727,10 +727,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -755,10 +755,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -783,10 +783,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.10-clang-16.yml
+++ b/.github/workflows/5.10-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -524,7 +524,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -534,7 +534,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -559,10 +559,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -587,10 +587,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -615,10 +615,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -643,10 +643,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -671,10 +671,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -699,10 +699,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -727,10 +727,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -755,10 +755,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -783,10 +783,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.10-clang-17.yml
+++ b/.github/workflows/5.10-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -524,7 +524,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -534,7 +534,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -559,10 +559,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -587,10 +587,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -615,10 +615,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -643,10 +643,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -671,10 +671,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -699,10 +699,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -727,10 +727,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -755,10 +755,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -783,10 +783,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.10-clang-19.yml
+++ b/.github/workflows/5.10-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -524,7 +524,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -534,7 +534,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -559,10 +559,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -587,10 +587,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -615,10 +615,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -643,10 +643,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -671,10 +671,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -699,10 +699,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -727,10 +727,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -755,10 +755,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -783,10 +783,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -804,7 +804,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -814,7 +814,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -839,10 +839,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -867,10 +867,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -895,10 +895,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -923,10 +923,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -951,10 +951,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1237,7 +1237,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1247,7 +1247,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1272,10 +1272,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1300,10 +1300,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1328,10 +1328,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1356,10 +1356,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1384,10 +1384,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -888,7 +888,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -898,7 +898,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -923,10 +923,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -951,10 +951,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1321,7 +1321,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1331,7 +1331,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1356,10 +1356,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1384,10 +1384,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -944,7 +944,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -954,7 +954,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1433,7 +1433,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1443,7 +1443,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -944,7 +944,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -954,7 +954,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1433,7 +1433,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1443,7 +1443,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -972,7 +972,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -982,7 +982,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1461,7 +1461,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1471,7 +1471,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.15-clang-16.yml
+++ b/.github/workflows/5.15-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -972,7 +972,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -982,7 +982,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1461,7 +1461,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1471,7 +1471,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.15-clang-17.yml
+++ b/.github/workflows/5.15-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -972,7 +972,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -982,7 +982,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1461,7 +1461,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1471,7 +1471,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.15-clang-19.yml
+++ b/.github/workflows/5.15-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -972,7 +972,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -982,7 +982,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1461,7 +1461,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1471,7 +1471,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.4-clang-13.yml
+++ b/.github/workflows/5.4-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -356,7 +356,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -366,7 +366,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -391,10 +391,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.4-clang-14.yml
+++ b/.github/workflows/5.4-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -356,7 +356,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -366,7 +366,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -391,10 +391,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.4-clang-15.yml
+++ b/.github/workflows/5.4-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -384,7 +384,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -394,7 +394,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -419,10 +419,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.4-clang-16.yml
+++ b/.github/workflows/5.4-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -384,7 +384,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -394,7 +394,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -419,10 +419,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.4-clang-17.yml
+++ b/.github/workflows/5.4-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -384,7 +384,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -394,7 +394,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -419,10 +419,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/5.4-clang-19.yml
+++ b/.github/workflows/5.4-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -384,7 +384,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -394,7 +394,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -419,10 +419,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/6.1-clang-11.yml
+++ b/.github/workflows/6.1-clang-11.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -832,7 +832,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -842,7 +842,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -867,10 +867,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -895,10 +895,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -923,10 +923,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -951,10 +951,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1265,7 +1265,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1275,7 +1275,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1300,10 +1300,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1328,10 +1328,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1356,10 +1356,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1384,10 +1384,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/6.1-clang-12.yml
+++ b/.github/workflows/6.1-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -860,7 +860,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -870,7 +870,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -895,10 +895,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -923,10 +923,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -951,10 +951,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1293,7 +1293,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1303,7 +1303,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1328,10 +1328,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1356,10 +1356,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1384,10 +1384,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/6.1-clang-13.yml
+++ b/.github/workflows/6.1-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -860,7 +860,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -870,7 +870,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -895,10 +895,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -923,10 +923,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -951,10 +951,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1293,7 +1293,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1303,7 +1303,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1328,10 +1328,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1356,10 +1356,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1384,10 +1384,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/6.1-clang-14.yml
+++ b/.github/workflows/6.1-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -860,7 +860,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -870,7 +870,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -895,10 +895,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -923,10 +923,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -951,10 +951,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1293,7 +1293,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1303,7 +1303,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1328,10 +1328,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1356,10 +1356,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1384,10 +1384,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/6.1-clang-15.yml
+++ b/.github/workflows/6.1-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -944,7 +944,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -954,7 +954,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1433,7 +1433,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1443,7 +1443,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/6.1-clang-16.yml
+++ b/.github/workflows/6.1-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -966,10 +966,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -994,10 +994,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1022,10 +1022,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1050,10 +1050,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1084,7 +1084,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -1094,7 +1094,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1455,10 +1455,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1483,10 +1483,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1511,10 +1511,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1539,10 +1539,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1573,7 +1573,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1583,7 +1583,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1860,10 +1860,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1888,10 +1888,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1916,10 +1916,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1944,10 +1944,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/6.1-clang-17.yml
+++ b/.github/workflows/6.1-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -966,10 +966,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -994,10 +994,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1022,10 +1022,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1050,10 +1050,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1084,7 +1084,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -1094,7 +1094,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1455,10 +1455,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1483,10 +1483,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1511,10 +1511,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1539,10 +1539,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1573,7 +1573,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1583,7 +1583,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1860,10 +1860,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1888,10 +1888,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1916,10 +1916,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1944,10 +1944,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/6.1-clang-19.yml
+++ b/.github/workflows/6.1-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -966,10 +966,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -994,10 +994,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1022,10 +1022,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1050,10 +1050,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1084,7 +1084,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -1094,7 +1094,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1455,10 +1455,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1483,10 +1483,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1511,10 +1511,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1539,10 +1539,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1573,7 +1573,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1583,7 +1583,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1860,10 +1860,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1888,10 +1888,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1916,10 +1916,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1944,10 +1944,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/6.6-clang-11.yml
+++ b/.github/workflows/6.6-clang-11.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -832,7 +832,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -842,7 +842,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -867,10 +867,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -895,10 +895,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -923,10 +923,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -951,10 +951,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1265,7 +1265,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1275,7 +1275,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1300,10 +1300,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1328,10 +1328,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1356,10 +1356,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1384,10 +1384,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/6.6-clang-12.yml
+++ b/.github/workflows/6.6-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -860,7 +860,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -870,7 +870,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -895,10 +895,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -923,10 +923,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -951,10 +951,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1293,7 +1293,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1303,7 +1303,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1328,10 +1328,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1356,10 +1356,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1384,10 +1384,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/6.6-clang-13.yml
+++ b/.github/workflows/6.6-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -860,7 +860,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -870,7 +870,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -895,10 +895,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -923,10 +923,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -951,10 +951,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1293,7 +1293,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1303,7 +1303,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1328,10 +1328,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1356,10 +1356,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1384,10 +1384,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/6.6-clang-14.yml
+++ b/.github/workflows/6.6-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -860,7 +860,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -870,7 +870,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -895,10 +895,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -923,10 +923,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -951,10 +951,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1293,7 +1293,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1303,7 +1303,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1328,10 +1328,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1356,10 +1356,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1384,10 +1384,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/6.6-clang-15.yml
+++ b/.github/workflows/6.6-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -944,7 +944,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -954,7 +954,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1433,7 +1433,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1443,7 +1443,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/6.6-clang-16.yml
+++ b/.github/workflows/6.6-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -966,10 +966,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -994,10 +994,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1022,10 +1022,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1050,10 +1050,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1084,7 +1084,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -1094,7 +1094,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1455,10 +1455,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1483,10 +1483,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1511,10 +1511,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1539,10 +1539,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1573,7 +1573,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1583,7 +1583,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1860,10 +1860,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1888,10 +1888,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1916,10 +1916,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1944,10 +1944,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1972,10 +1972,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2000,10 +2000,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/6.6-clang-17.yml
+++ b/.github/workflows/6.6-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -966,10 +966,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -994,10 +994,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1022,10 +1022,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1050,10 +1050,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1084,7 +1084,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -1094,7 +1094,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1455,10 +1455,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1483,10 +1483,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1511,10 +1511,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1539,10 +1539,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1573,7 +1573,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1583,7 +1583,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1860,10 +1860,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1888,10 +1888,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1916,10 +1916,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1944,10 +1944,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1972,10 +1972,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2000,10 +2000,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/6.6-clang-19.yml
+++ b/.github/workflows/6.6-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -966,10 +966,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -994,10 +994,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1022,10 +1022,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1050,10 +1050,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1078,10 +1078,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1106,10 +1106,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1140,7 +1140,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -1150,7 +1150,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1455,10 +1455,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1483,10 +1483,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1511,10 +1511,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1539,10 +1539,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1567,10 +1567,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1595,10 +1595,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1629,7 +1629,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1639,7 +1639,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1860,10 +1860,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1888,10 +1888,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1916,10 +1916,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1944,10 +1944,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1972,10 +1972,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2000,10 +2000,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2028,10 +2028,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2056,10 +2056,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2084,10 +2084,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2112,10 +2112,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android-4.19-clang-12.yml
+++ b/.github/workflows/android-4.19-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android-4.19-clang-13.yml
+++ b/.github/workflows/android-4.19-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android-4.19-clang-14.yml
+++ b/.github/workflows/android-4.19-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android-4.19-clang-15.yml
+++ b/.github/workflows/android-4.19-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android-4.19-clang-16.yml
+++ b/.github/workflows/android-4.19-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android-4.19-clang-17.yml
+++ b/.github/workflows/android-4.19-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android-4.19-clang-19.yml
+++ b/.github/workflows/android-4.19-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android-4.19-clang-android.yml
+++ b/.github/workflows/android-4.19-clang-android.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android-mainline-clang-12.yml
+++ b/.github/workflows/android-mainline-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -216,7 +216,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -226,7 +226,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android-mainline-clang-13.yml
+++ b/.github/workflows/android-mainline-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -216,7 +216,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -226,7 +226,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android-mainline-clang-14.yml
+++ b/.github/workflows/android-mainline-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -216,7 +216,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -226,7 +226,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android-mainline-clang-15.yml
+++ b/.github/workflows/android-mainline-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -216,7 +216,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -226,7 +226,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android-mainline-clang-16.yml
+++ b/.github/workflows/android-mainline-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -216,7 +216,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -226,7 +226,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android-mainline-clang-17.yml
+++ b/.github/workflows/android-mainline-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -216,7 +216,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -226,7 +226,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android-mainline-clang-19.yml
+++ b/.github/workflows/android-mainline-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -216,7 +216,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -226,7 +226,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android-mainline-clang-android.yml
+++ b/.github/workflows/android-mainline-clang-android.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -216,7 +216,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -226,7 +226,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android12-5.10-clang-12.yml
+++ b/.github/workflows/android12-5.10-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android12-5.10-clang-13.yml
+++ b/.github/workflows/android12-5.10-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android12-5.10-clang-14.yml
+++ b/.github/workflows/android12-5.10-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android12-5.10-clang-15.yml
+++ b/.github/workflows/android12-5.10-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android12-5.10-clang-16.yml
+++ b/.github/workflows/android12-5.10-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android12-5.10-clang-17.yml
+++ b/.github/workflows/android12-5.10-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android12-5.10-clang-19.yml
+++ b/.github/workflows/android12-5.10-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android12-5.10-clang-android.yml
+++ b/.github/workflows/android12-5.10-clang-android.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android12-5.4-clang-12.yml
+++ b/.github/workflows/android12-5.4-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android12-5.4-clang-13.yml
+++ b/.github/workflows/android12-5.4-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android12-5.4-clang-14.yml
+++ b/.github/workflows/android12-5.4-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android12-5.4-clang-15.yml
+++ b/.github/workflows/android12-5.4-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android12-5.4-clang-16.yml
+++ b/.github/workflows/android12-5.4-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android12-5.4-clang-17.yml
+++ b/.github/workflows/android12-5.4-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android12-5.4-clang-19.yml
+++ b/.github/workflows/android12-5.4-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android12-5.4-clang-android.yml
+++ b/.github/workflows/android12-5.4-clang-android.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android13-5.10-clang-12.yml
+++ b/.github/workflows/android13-5.10-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android13-5.10-clang-13.yml
+++ b/.github/workflows/android13-5.10-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android13-5.10-clang-14.yml
+++ b/.github/workflows/android13-5.10-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android13-5.10-clang-15.yml
+++ b/.github/workflows/android13-5.10-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android13-5.10-clang-16.yml
+++ b/.github/workflows/android13-5.10-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android13-5.10-clang-17.yml
+++ b/.github/workflows/android13-5.10-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android13-5.10-clang-19.yml
+++ b/.github/workflows/android13-5.10-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android13-5.10-clang-android.yml
+++ b/.github/workflows/android13-5.10-clang-android.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android13-5.15-clang-12.yml
+++ b/.github/workflows/android13-5.15-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android13-5.15-clang-13.yml
+++ b/.github/workflows/android13-5.15-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android13-5.15-clang-14.yml
+++ b/.github/workflows/android13-5.15-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android13-5.15-clang-15.yml
+++ b/.github/workflows/android13-5.15-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android13-5.15-clang-16.yml
+++ b/.github/workflows/android13-5.15-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android13-5.15-clang-17.yml
+++ b/.github/workflows/android13-5.15-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android13-5.15-clang-19.yml
+++ b/.github/workflows/android13-5.15-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android13-5.15-clang-android.yml
+++ b/.github/workflows/android13-5.15-clang-android.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android14-5.15-clang-12.yml
+++ b/.github/workflows/android14-5.15-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android14-5.15-clang-13.yml
+++ b/.github/workflows/android14-5.15-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android14-5.15-clang-14.yml
+++ b/.github/workflows/android14-5.15-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android14-5.15-clang-15.yml
+++ b/.github/workflows/android14-5.15-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android14-5.15-clang-16.yml
+++ b/.github/workflows/android14-5.15-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android14-5.15-clang-17.yml
+++ b/.github/workflows/android14-5.15-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android14-5.15-clang-19.yml
+++ b/.github/workflows/android14-5.15-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android14-5.15-clang-android.yml
+++ b/.github/workflows/android14-5.15-clang-android.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android14-6.1-clang-12.yml
+++ b/.github/workflows/android14-6.1-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android14-6.1-clang-13.yml
+++ b/.github/workflows/android14-6.1-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android14-6.1-clang-14.yml
+++ b/.github/workflows/android14-6.1-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android14-6.1-clang-15.yml
+++ b/.github/workflows/android14-6.1-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android14-6.1-clang-16.yml
+++ b/.github/workflows/android14-6.1-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android14-6.1-clang-17.yml
+++ b/.github/workflows/android14-6.1-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android14-6.1-clang-19.yml
+++ b/.github/workflows/android14-6.1-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android14-6.1-clang-android.yml
+++ b/.github/workflows/android14-6.1-clang-android.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android15-6.1-clang-12.yml
+++ b/.github/workflows/android15-6.1-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android15-6.1-clang-13.yml
+++ b/.github/workflows/android15-6.1-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android15-6.1-clang-14.yml
+++ b/.github/workflows/android15-6.1-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android15-6.1-clang-15.yml
+++ b/.github/workflows/android15-6.1-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android15-6.1-clang-16.yml
+++ b/.github/workflows/android15-6.1-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android15-6.1-clang-17.yml
+++ b/.github/workflows/android15-6.1-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android15-6.1-clang-19.yml
+++ b/.github/workflows/android15-6.1-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android15-6.1-clang-android.yml
+++ b/.github/workflows/android15-6.1-clang-android.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android15-6.6-clang-12.yml
+++ b/.github/workflows/android15-6.6-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android15-6.6-clang-13.yml
+++ b/.github/workflows/android15-6.6-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android15-6.6-clang-14.yml
+++ b/.github/workflows/android15-6.6-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android15-6.6-clang-15.yml
+++ b/.github/workflows/android15-6.6-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android15-6.6-clang-16.yml
+++ b/.github/workflows/android15-6.6-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android15-6.6-clang-17.yml
+++ b/.github/workflows/android15-6.6-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android15-6.6-clang-19.yml
+++ b/.github/workflows/android15-6.6-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/android15-6.6-clang-android.yml
+++ b/.github/workflows/android15-6.6-clang-android.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -188,7 +188,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -198,7 +198,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/arm64-clang-11.yml
+++ b/.github/workflows/arm64-clang-11.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -132,7 +132,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -142,7 +142,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -167,10 +167,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/arm64-clang-12.yml
+++ b/.github/workflows/arm64-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -132,7 +132,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -142,7 +142,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -167,10 +167,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/arm64-clang-13.yml
+++ b/.github/workflows/arm64-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -132,7 +132,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -142,7 +142,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -167,10 +167,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/arm64-clang-14.yml
+++ b/.github/workflows/arm64-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -132,7 +132,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -142,7 +142,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -167,10 +167,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/arm64-clang-15.yml
+++ b/.github/workflows/arm64-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -160,7 +160,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -170,7 +170,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/arm64-clang-16.yml
+++ b/.github/workflows/arm64-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -160,7 +160,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -170,7 +170,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/arm64-clang-17.yml
+++ b/.github/workflows/arm64-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -160,7 +160,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -170,7 +170,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/arm64-clang-19.yml
+++ b/.github/workflows/arm64-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -160,7 +160,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -170,7 +170,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/arm64-fixes-clang-11.yml
+++ b/.github/workflows/arm64-fixes-clang-11.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -132,7 +132,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -142,7 +142,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -167,10 +167,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/arm64-fixes-clang-12.yml
+++ b/.github/workflows/arm64-fixes-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -132,7 +132,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -142,7 +142,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -167,10 +167,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/arm64-fixes-clang-13.yml
+++ b/.github/workflows/arm64-fixes-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -132,7 +132,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -142,7 +142,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -167,10 +167,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/arm64-fixes-clang-14.yml
+++ b/.github/workflows/arm64-fixes-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -132,7 +132,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -142,7 +142,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -167,10 +167,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/arm64-fixes-clang-15.yml
+++ b/.github/workflows/arm64-fixes-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -160,7 +160,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -170,7 +170,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/arm64-fixes-clang-16.yml
+++ b/.github/workflows/arm64-fixes-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -160,7 +160,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -170,7 +170,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/arm64-fixes-clang-17.yml
+++ b/.github/workflows/arm64-fixes-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -160,7 +160,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -170,7 +170,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/arm64-fixes-clang-19.yml
+++ b/.github/workflows/arm64-fixes-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -160,7 +160,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -170,7 +170,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-5.10-clang-12.yml
+++ b/.github/workflows/chromeos-5.10-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-5.10-clang-13.yml
+++ b/.github/workflows/chromeos-5.10-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-5.10-clang-14.yml
+++ b/.github/workflows/chromeos-5.10-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-5.10-clang-15.yml
+++ b/.github/workflows/chromeos-5.10-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-5.10-clang-16.yml
+++ b/.github/workflows/chromeos-5.10-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-5.10-clang-17.yml
+++ b/.github/workflows/chromeos-5.10-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-5.10-clang-19.yml
+++ b/.github/workflows/chromeos-5.10-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-5.15-clang-12.yml
+++ b/.github/workflows/chromeos-5.15-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-5.15-clang-13.yml
+++ b/.github/workflows/chromeos-5.15-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-5.15-clang-14.yml
+++ b/.github/workflows/chromeos-5.15-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-5.15-clang-15.yml
+++ b/.github/workflows/chromeos-5.15-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-5.15-clang-16.yml
+++ b/.github/workflows/chromeos-5.15-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-5.15-clang-17.yml
+++ b/.github/workflows/chromeos-5.15-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-5.15-clang-19.yml
+++ b/.github/workflows/chromeos-5.15-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-6.1-clang-12.yml
+++ b/.github/workflows/chromeos-6.1-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-6.1-clang-13.yml
+++ b/.github/workflows/chromeos-6.1-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-6.1-clang-14.yml
+++ b/.github/workflows/chromeos-6.1-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-6.1-clang-15.yml
+++ b/.github/workflows/chromeos-6.1-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-6.1-clang-16.yml
+++ b/.github/workflows/chromeos-6.1-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-6.1-clang-17.yml
+++ b/.github/workflows/chromeos-6.1-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-6.1-clang-19.yml
+++ b/.github/workflows/chromeos-6.1-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-6.6-clang-12.yml
+++ b/.github/workflows/chromeos-6.6-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-6.6-clang-13.yml
+++ b/.github/workflows/chromeos-6.6-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-6.6-clang-14.yml
+++ b/.github/workflows/chromeos-6.6-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-6.6-clang-15.yml
+++ b/.github/workflows/chromeos-6.6-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-6.6-clang-16.yml
+++ b/.github/workflows/chromeos-6.6-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-6.6-clang-17.yml
+++ b/.github/workflows/chromeos-6.6-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/chromeos-6.6-clang-19.yml
+++ b/.github/workflows/chromeos-6.6-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/mainline-clang-12.yml
+++ b/.github/workflows/mainline-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -860,7 +860,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -870,7 +870,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -895,10 +895,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -923,10 +923,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -951,10 +951,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1293,7 +1293,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1303,7 +1303,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1328,10 +1328,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1356,10 +1356,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1384,10 +1384,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/mainline-clang-13.yml
+++ b/.github/workflows/mainline-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -860,7 +860,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -870,7 +870,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -895,10 +895,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -923,10 +923,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -951,10 +951,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1293,7 +1293,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1303,7 +1303,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1328,10 +1328,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1356,10 +1356,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1384,10 +1384,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -860,7 +860,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -870,7 +870,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -895,10 +895,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -923,10 +923,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -951,10 +951,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1293,7 +1293,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1303,7 +1303,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1328,10 +1328,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1356,10 +1356,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1384,10 +1384,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -944,7 +944,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -954,7 +954,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1433,7 +1433,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1443,7 +1443,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -966,10 +966,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -994,10 +994,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1022,10 +1022,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1050,10 +1050,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1084,7 +1084,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -1094,7 +1094,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1455,10 +1455,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1483,10 +1483,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1511,10 +1511,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1539,10 +1539,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1573,7 +1573,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1583,7 +1583,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1860,10 +1860,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1888,10 +1888,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1916,10 +1916,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1944,10 +1944,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1972,10 +1972,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2000,10 +2000,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/mainline-clang-17.yml
+++ b/.github/workflows/mainline-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -966,10 +966,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -994,10 +994,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1022,10 +1022,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1050,10 +1050,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1084,7 +1084,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -1094,7 +1094,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1455,10 +1455,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1483,10 +1483,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1511,10 +1511,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1539,10 +1539,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1573,7 +1573,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1583,7 +1583,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1860,10 +1860,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1888,10 +1888,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1916,10 +1916,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1944,10 +1944,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1972,10 +1972,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2000,10 +2000,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/mainline-clang-19.yml
+++ b/.github/workflows/mainline-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -966,10 +966,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -994,10 +994,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1022,10 +1022,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1050,10 +1050,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1078,10 +1078,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1106,10 +1106,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1134,10 +1134,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1162,10 +1162,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1196,7 +1196,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -1206,7 +1206,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1455,10 +1455,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1483,10 +1483,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1511,10 +1511,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1539,10 +1539,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1567,10 +1567,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1595,10 +1595,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1623,10 +1623,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1651,10 +1651,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1685,7 +1685,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1695,7 +1695,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1860,10 +1860,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1888,10 +1888,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1916,10 +1916,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1944,10 +1944,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1972,10 +1972,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2000,10 +2000,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2028,10 +2028,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2056,10 +2056,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2084,10 +2084,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2112,10 +2112,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2140,10 +2140,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2168,10 +2168,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/next-clang-13.yml
+++ b/.github/workflows/next-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -888,7 +888,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -898,7 +898,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -923,10 +923,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -951,10 +951,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1321,7 +1321,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1331,7 +1331,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1356,10 +1356,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1384,10 +1384,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -944,7 +944,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -954,7 +954,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1377,7 +1377,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1387,7 +1387,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -966,10 +966,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -994,10 +994,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1028,7 +1028,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -1038,7 +1038,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1455,10 +1455,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1483,10 +1483,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1517,7 +1517,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1527,7 +1527,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1860,10 +1860,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1888,10 +1888,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1916,10 +1916,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -966,10 +966,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -994,10 +994,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1022,10 +1022,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1050,10 +1050,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1078,10 +1078,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1106,10 +1106,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1134,10 +1134,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1168,7 +1168,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -1178,7 +1178,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1455,10 +1455,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1483,10 +1483,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1511,10 +1511,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1539,10 +1539,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1567,10 +1567,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1595,10 +1595,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1623,10 +1623,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1657,7 +1657,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1667,7 +1667,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1860,10 +1860,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1888,10 +1888,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1916,10 +1916,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1944,10 +1944,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1972,10 +1972,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2000,10 +2000,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2028,10 +2028,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2056,10 +2056,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2084,10 +2084,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/next-clang-17.yml
+++ b/.github/workflows/next-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -966,10 +966,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -994,10 +994,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1022,10 +1022,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1050,10 +1050,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1078,10 +1078,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1106,10 +1106,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1134,10 +1134,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1168,7 +1168,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -1178,7 +1178,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1455,10 +1455,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1483,10 +1483,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1511,10 +1511,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1539,10 +1539,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1567,10 +1567,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1595,10 +1595,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1623,10 +1623,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1657,7 +1657,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1667,7 +1667,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1860,10 +1860,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1888,10 +1888,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1916,10 +1916,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1944,10 +1944,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1972,10 +1972,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2000,10 +2000,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2028,10 +2028,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2056,10 +2056,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2084,10 +2084,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2112,10 +2112,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/next-clang-19.yml
+++ b/.github/workflows/next-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -966,10 +966,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -994,10 +994,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1022,10 +1022,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1050,10 +1050,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1078,10 +1078,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1106,10 +1106,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1134,10 +1134,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1162,10 +1162,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1190,10 +1190,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1218,10 +1218,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1246,10 +1246,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1280,7 +1280,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -1290,7 +1290,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1455,10 +1455,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1483,10 +1483,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1511,10 +1511,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1539,10 +1539,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1567,10 +1567,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1595,10 +1595,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1623,10 +1623,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1651,10 +1651,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1679,10 +1679,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1707,10 +1707,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1735,10 +1735,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1769,7 +1769,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1779,7 +1779,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1860,10 +1860,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1888,10 +1888,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1916,10 +1916,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1944,10 +1944,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1972,10 +1972,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2000,10 +2000,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2028,10 +2028,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2056,10 +2056,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2084,10 +2084,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2112,10 +2112,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2140,10 +2140,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2168,10 +2168,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2196,10 +2196,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2224,10 +2224,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2252,10 +2252,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2280,10 +2280,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/next-clang-android.yml
+++ b/.github/workflows/next-clang-android.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -468,7 +468,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -478,7 +478,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -503,10 +503,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -531,10 +531,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -559,10 +559,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -587,10 +587,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -615,10 +615,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -643,10 +643,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -671,10 +671,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -699,10 +699,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -727,10 +727,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -755,10 +755,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/stable-clang-11.yml
+++ b/.github/workflows/stable-clang-11.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -832,7 +832,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -842,7 +842,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -867,10 +867,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -895,10 +895,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -923,10 +923,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -951,10 +951,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1265,7 +1265,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1275,7 +1275,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1300,10 +1300,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1328,10 +1328,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1356,10 +1356,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1384,10 +1384,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/stable-clang-12.yml
+++ b/.github/workflows/stable-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -860,7 +860,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -870,7 +870,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -895,10 +895,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -923,10 +923,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -951,10 +951,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1293,7 +1293,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1303,7 +1303,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1328,10 +1328,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1356,10 +1356,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1384,10 +1384,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -860,7 +860,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -870,7 +870,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -895,10 +895,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -923,10 +923,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -951,10 +951,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1293,7 +1293,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1303,7 +1303,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1328,10 +1328,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1356,10 +1356,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1384,10 +1384,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -860,7 +860,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -870,7 +870,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -895,10 +895,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -923,10 +923,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -951,10 +951,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1293,7 +1293,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1303,7 +1303,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1328,10 +1328,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1356,10 +1356,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1384,10 +1384,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1412,10 +1412,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1440,10 +1440,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -944,7 +944,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -954,7 +954,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -979,10 +979,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1007,10 +1007,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1035,10 +1035,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1063,10 +1063,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1091,10 +1091,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1433,7 +1433,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1443,7 +1443,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1468,10 +1468,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1496,10 +1496,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1524,10 +1524,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1552,10 +1552,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1580,10 +1580,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/stable-clang-16.yml
+++ b/.github/workflows/stable-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -966,10 +966,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -994,10 +994,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1022,10 +1022,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1050,10 +1050,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1084,7 +1084,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -1094,7 +1094,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1455,10 +1455,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1483,10 +1483,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1511,10 +1511,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1539,10 +1539,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1573,7 +1573,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1583,7 +1583,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1860,10 +1860,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1888,10 +1888,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1916,10 +1916,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1944,10 +1944,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1972,10 +1972,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2000,10 +2000,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/stable-clang-17.yml
+++ b/.github/workflows/stable-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -966,10 +966,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -994,10 +994,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1022,10 +1022,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1050,10 +1050,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1084,7 +1084,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -1094,7 +1094,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1119,10 +1119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1147,10 +1147,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1175,10 +1175,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1203,10 +1203,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1455,10 +1455,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1483,10 +1483,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1511,10 +1511,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1539,10 +1539,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1573,7 +1573,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1583,7 +1583,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1608,10 +1608,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1636,10 +1636,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1664,10 +1664,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1692,10 +1692,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1860,10 +1860,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1888,10 +1888,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1916,10 +1916,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1944,10 +1944,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1972,10 +1972,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2000,10 +2000,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/stable-clang-19.yml
+++ b/.github/workflows/stable-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -154,10 +154,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -182,10 +182,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -210,10 +210,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -238,10 +238,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -266,10 +266,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -294,10 +294,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -322,10 +322,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -350,10 +350,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -378,10 +378,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -406,10 +406,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -434,10 +434,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -462,10 +462,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -490,10 +490,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -518,10 +518,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -546,10 +546,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -574,10 +574,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -602,10 +602,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -630,10 +630,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -658,10 +658,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -686,10 +686,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -714,10 +714,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -742,10 +742,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -770,10 +770,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -798,10 +798,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -826,10 +826,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -854,10 +854,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -882,10 +882,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -910,10 +910,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -938,10 +938,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -966,10 +966,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -994,10 +994,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1022,10 +1022,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1050,10 +1050,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1078,10 +1078,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1106,10 +1106,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1134,10 +1134,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1162,10 +1162,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -1196,7 +1196,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_distribution_configs
@@ -1206,7 +1206,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
@@ -1231,10 +1231,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1259,10 +1259,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1287,10 +1287,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1315,10 +1315,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1343,10 +1343,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1371,10 +1371,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1399,10 +1399,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1427,10 +1427,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1455,10 +1455,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1483,10 +1483,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1511,10 +1511,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1539,10 +1539,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1567,10 +1567,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1595,10 +1595,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1623,10 +1623,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1651,10 +1651,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
@@ -1685,7 +1685,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -1695,7 +1695,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -1720,10 +1720,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1748,10 +1748,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1776,10 +1776,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1804,10 +1804,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1832,10 +1832,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1860,10 +1860,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1888,10 +1888,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1916,10 +1916,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1944,10 +1944,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -1972,10 +1972,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2000,10 +2000,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2028,10 +2028,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2056,10 +2056,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2084,10 +2084,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2112,10 +2112,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2140,10 +2140,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -2168,10 +2168,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/tip-clang-11.yml
+++ b/.github/workflows/tip-clang-11.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -160,7 +160,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -170,7 +170,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/tip-clang-12.yml
+++ b/.github/workflows/tip-clang-12.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -160,7 +160,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -170,7 +170,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/tip-clang-13.yml
+++ b/.github/workflows/tip-clang-13.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -160,7 +160,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -170,7 +170,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/tip-clang-14.yml
+++ b/.github/workflows/tip-clang-14.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -160,7 +160,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -170,7 +170,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/tip-clang-15.yml
+++ b/.github/workflows/tip-clang-15.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -160,7 +160,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -170,7 +170,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/tip-clang-16.yml
+++ b/.github/workflows/tip-clang-16.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -160,7 +160,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -170,7 +170,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/tip-clang-17.yml
+++ b/.github/workflows/tip-clang-17.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -160,7 +160,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -170,7 +170,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/.github/workflows/tip-clang-19.yml
+++ b/.github/workflows/tip-clang-19.yml
@@ -63,7 +63,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_defconfigs
@@ -73,7 +73,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
@@ -98,10 +98,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -126,10 +126,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
@@ -160,7 +160,7 @@ jobs:
       run: python caching/update.py
     - name: save builds.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: builds.json
         name: output_artifact_allconfigs
@@ -170,7 +170,7 @@ jobs:
       run: python3 scripts/generate-boot-utils-json.py ${{ secrets.GITHUB_TOKEN }}
     - name: save boot-utils.json
       if: ${{ needs.check_cache.outputs.output == 'failure' || github.event_name == 'workflow_dispatch' }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
@@ -195,10 +195,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -223,10 +223,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
@@ -251,10 +251,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs

--- a/generator/generate_workflow.py
+++ b/generator/generate_workflow.py
@@ -177,7 +177,7 @@ def tuxsuite_setups(job_name, tuxsuite_yml, repo, ref):
                 {
                     "name": "save builds.json",
                     **cond,
-                    "uses": "actions/upload-artifact@v3",
+                    "uses": "actions/upload-artifact@v4",
                     "with": {
                         "path": "builds.json",
                         "name": f"output_artifact_{job_name}",
@@ -192,7 +192,7 @@ def tuxsuite_setups(job_name, tuxsuite_yml, repo, ref):
                 {
                     'name': 'save boot-utils.json',
                     **cond,
-                    'uses': 'actions/upload-artifact@v3',
+                    'uses': 'actions/upload-artifact@v4',
                     'with': {
                         'path': 'boot-utils.json',
                         'name': f"boot_utils_json_{job_name}",
@@ -231,13 +231,13 @@ def get_steps(build, build_set):
                     },
                 },
                 {
-                    "uses": "actions/download-artifact@v3",
+                    "uses": "actions/download-artifact@v4",
                     "with": {
                         "name": f"output_artifact_{build_set}"
                     },
                 },
                 {
-                    "uses": "actions/download-artifact@v3",
+                    "uses": "actions/download-artifact@v4",
                     "with": {
                         "name": f"boot_utils_json_{build_set}"
                     },


### PR DESCRIPTION
This is needed to avoid warnings around Node 16 actions being deprecated.
