### PR TITLE
Use LLVM=1 for ARCH=s390 on linux-next with tip of tree LLVM

### DIFF
--- a/.github/workflows/next-clang-19.yml
+++ b/.github/workflows/next-clang-19.yml
@@ -890,12 +890,12 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _a7016a4f3a73a508d1b00dd9b9dfa168:
+  _f97d7f8efcb2c842d35f0e22f01a52bf:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 defconfig
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
@@ -918,12 +918,12 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _741fec04d7e30991d0973b88ecd844fa:
+  _268ceb735866a8f5bfa89ffa2e2bf60b:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
@@ -1575,12 +1575,12 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b2fe3d92de2f9c8f3356bd83602f25a7:
+  _fa1e0cf8480f115830476f059cbe53bb:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
@@ -1603,12 +1603,12 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _2daf6d97d5a05d1700d0631278bd2f7e:
+  _5728b554151279ef568b7d449268dd62:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390

--- a/generator/yml/0009-llvm-tot.yml
+++ b/generator/yml/0009-llvm-tot.yml
@@ -135,10 +135,10 @@
   - {<< : *riscv_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *riscv_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *riscv_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *s390,              << : *next,             << : *clang_ias,       boot: true,  << : *llvm_tot}
-  - {<< : *s390_kasan,        << : *next,             << : *clang_ias,       boot: true,  << : *llvm_tot}
-  - {<< : *s390_fedora,       << : *next,             << : *clang_ias,       boot: true,  << : *llvm_tot}
-  - {<< : *s390_suse,         << : *next,             << : *clang_ias,       boot: true,  << : *llvm_tot}
+  - {<< : *s390,              << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *s390_kasan,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *s390_fedora,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *s390_suse,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *um,                << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}

--- a/tuxsuite/next-clang-19.tux.yml
+++ b/tuxsuite/next-clang-19.tux.yml
@@ -304,6 +304,7 @@ jobs:
     targets:
     - kernel
     make_variables:
+      LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: clang-nightly
@@ -316,6 +317,7 @@ jobs:
     targets:
     - kernel
     make_variables:
+      LLVM: 1
       LLVM_IAS: 1
   - target_arch: um
     toolchain: clang-nightly
@@ -524,6 +526,7 @@ jobs:
     targets:
     - kernel
     make_variables:
+      LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: clang-nightly
@@ -531,6 +534,7 @@ jobs:
     targets:
     - kernel
     make_variables:
+      LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly


### PR DESCRIPTION
With LLVM main, which has the necessary changes to `ld.lld` and `llvm-objcopy` to support s390, and linux-next, which has the necessary changes to the kernel to support these tools, `ARCH=s390` builds cleanly with `LLVM=1`. Cut builds that satisfy these conditions over to `LLVM=1` so that regressions with this working setup do not occur.

Link: https://github.com/llvm/llvm-project/commit/fe3406e349884e4ef61480dd0607f1e237102c74
Link: https://github.com/llvm/llvm-project/commit/3c02cb7492fc78fb678264cebf57ff88e478e14f
Link: https://github.com/ClangBuiltLinux/linux/issues/859
Link: https://github.com/ClangBuiltLinux/linux/issues/1991
Link: https://github.com/ClangBuiltLinux/linux/issues/1992
Link: https://github.com/ClangBuiltLinux/linux/issues/1993
Link: https://github.com/ClangBuiltLinux/linux/issues/1994
Link: https://github.com/ClangBuiltLinux/linux/issues/1995
Link: https://github.com/ClangBuiltLinux/linux/issues/1996

NOTE: linux-next as of next-20240221 does not contain the fix for `llvm-objdump` yet but as far as I am aware, that is only a warning so this should be safe to merge in its current state, but we can also wait for https://lore.kernel.org/linux-s390/20240220-s390-work-around-llvm-objdump-t-j-v1-1-47bb0366a831@kernel.org/ to appear in -next first.
