### PR TITLE
badge-caching: Use README.md as source of truth

### DIFF
--- a/scripts/badge-caching/refresh.sh
+++ b/scripts/badge-caching/refresh.sh
@@ -4,10 +4,19 @@ set -e
 BASE="/var/www/html/cbl/badges"
 cd "$BASE"
 
-wget -q -N https://clangbuiltlinux.github.io/ -Odump.txt
-for svg in $(sed -e 's/"/\n/g' dump.txt | grep 'actions/workflows.*yml$' | sort -u); do
-	#break
-        wget -q -N -r "$svg"/badge.svg
+rm fetched.stamp
+
+# CBL.github.io
+#wget -q -N https://clangbuiltlinux.github.io/ -Odump.txt
+#for svg in $(sed -e 's/"/\n/g' dump.txt | grep 'actions/workflows.*yml$' | sort -u); do
+
+# README.md
+wget -q -N https://raw.githubusercontent.com/ClangBuiltLinux/continuous-integration2/main/README.md -Odump.txt
+for svg in $(sed -e 's/[()]/\n/g' dump.txt | grep 'yml$' | sort -u); do
+	url="$svg"/badge.svg
+	echo "$url" >> fetched.stamp
+	# Ignore fetch errors.
+	wget -nv -N -r "$url" 2>> fetched.stamp || true
 	sleep 1
 done
 
@@ -18,6 +27,12 @@ for yml in $(cd "$BUILDS" && echo *); do
 	if grep -q passing "$badge"; then
 		ln -sf passing.svg $build.svg
 	else
-		ln -sf failing.svg $build.svg
+		if grep -q failing "$badge"; then
+			ln -sf failing.svg $build.svg
+		else
+			ln -sf unknown.svg $build.svg
+		fi
 	fi
 done
+
+touch parsed.stamp

--- a/scripts/badge-caching/unknown.svg
+++ b/scripts/badge-caching/unknown.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="20">
+  <title>failing</title>
+  <defs>
+    <linearGradient id="workflow-fill" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop stop-color="#444D56" offset="0%"></stop>
+      <stop stop-color="#24292E" offset="100%"></stop>
+    </linearGradient>
+    <linearGradient id="state-fill" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop stop-color="#E97042" offset="0%"></stop>
+      <stop stop-color="#BA5934" offset="100%"></stop>
+    </linearGradient>
+  </defs>
+  <g fill="none" fill-rule="evenodd">
+    <g transform="translate(0)" font-family="&#39;DejaVu Sans&#39;,Verdana,Geneva,sans-serif" font-size="11">
+      <path d="M0 0h46.939C48.629 0 50 1.343 50 3v14c0 1.657-1.37 3-3.061 3H0V0z" id="state-bg" fill="url(#state-fill)" fill-rule="nonzero"></path>
+      <text fill="#010101" fill-opacity=".3" aria-hidden="true">
+        <tspan x="0" y="15">unknown</tspan>
+      </text>
+      <text fill="#FFFFFF">
+        <tspan x="0" y="14">unknown</tspan>
+      </text>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Add an additional "unknown" state for if/when parsing of a fetched SVG fails to find either "passing" nor "failing".

Parse the README.md for yml URLs.

Log SVG scraping and ignore failures.