### PR TITLE
Disable CONFIG_DEBUG_INFO_COMPRESSED_ZSTD for Android for now

### DIFF
--- a/.github/workflows/android-4.19-clang-12.yml
+++ b/.github/workflows/android-4.19-clang-12.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _e2d7c97a744bb18b18038623898956f6:
+  _4cd429c60c49c411bafc8205cac4ff17:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4fb2521d605de5401fc145b2b8a80bc8:
+  _d24ad0cc4a0c9a09c6a8b5f717962455:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-4.19-clang-13.yml
+++ b/.github/workflows/android-4.19-clang-13.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _bf41f851fcdaba3f8ff5598ee5a62c07:
+  _e2318e8e85ff910f296ddaba6906fadf:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _35a5ee570535cd317c3ecd44077c7035:
+  _6597d87a555c679fa00784f2fd6c0f25:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-4.19-clang-14.yml
+++ b/.github/workflows/android-4.19-clang-14.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _b7027adc4194874a4adbc49c0f26629d:
+  _56da186ca8feaa744e67e58d9047e907:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _47edec95bc64a51c97e8a11cc2ed40c2:
+  _7b80abae9889c18319bb557bedc34e57:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-4.19-clang-15.yml
+++ b/.github/workflows/android-4.19-clang-15.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _27913b883a7b3927289cd723c5e6b1c6:
+  _3d1fc31fae1f0825f1b1117687571182:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7b8336846bde11413c4d6dc9a7e31743:
+  _ed8e4c799b40550226233bf3f334f719:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-4.19-clang-16.yml
+++ b/.github/workflows/android-4.19-clang-16.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _8947f485cd634fe1980410d5fd49c0cd:
+  _53704d75048d901235421342a220a3d2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b9c33721b8a30cf8511e236bfd80c819:
+  _0313162a06bb046f4081c817855c8ac1:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-4.19-clang-17.yml
+++ b/.github/workflows/android-4.19-clang-17.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _57225b66c2cca415de91dd060472c53e:
+  _c9a7bb527b7340eacb42c20cbc2ecf43:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _934c8b5199cfd7d563f331608b4aef1d:
+  _c857a5b77f9ff7258c0b914b8ca906cd:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-4.19-clang-18.yml
+++ b/.github/workflows/android-4.19-clang-18.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _ebd88385a017d6a8b6a4d3b1d4bff8f4:
+  _e05cc2bd0d980c406da77866025ae9a6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _1e7e455003c708db13544699bc315515:
+  _c89fe0a8c5057794c34bb22f1b69d33d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-4.19-clang-19.yml
+++ b/.github/workflows/android-4.19-clang-19.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _0913b033bbb90e4af0d1c3e20ba5a03d:
+  _427ad04336d3b729e9f06ac390339c83:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3eb68f215995c2c50b536d2dc8d27755:
+  _69be54e07c0c29096e6473be61b248d6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-4.19-clang-android.yml
+++ b/.github/workflows/android-4.19-clang-android.yml
@@ -78,18 +78,18 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_defconfigs
         if-no-files-found: error
-  _092d18d4defe742a9f23a18a7d2eebc6:
+  _715e50064ab6c7b608bbfde676ee63c3:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e8eaa6c4609c31891f40230b3aa2339f:
+  _54d3fa945b463031f59cd01c1779e62d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-mainline-clang-12.yml
+++ b/.github/workflows/android-mainline-clang-12.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e2d7c97a744bb18b18038623898956f6:
+  _4cd429c60c49c411bafc8205cac4ff17:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -162,18 +162,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4fb2521d605de5401fc145b2b8a80bc8:
+  _d24ad0cc4a0c9a09c6a8b5f717962455:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-mainline-clang-13.yml
+++ b/.github/workflows/android-mainline-clang-13.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _bf41f851fcdaba3f8ff5598ee5a62c07:
+  _e2318e8e85ff910f296ddaba6906fadf:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -162,18 +162,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _35a5ee570535cd317c3ecd44077c7035:
+  _6597d87a555c679fa00784f2fd6c0f25:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-mainline-clang-14.yml
+++ b/.github/workflows/android-mainline-clang-14.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b7027adc4194874a4adbc49c0f26629d:
+  _56da186ca8feaa744e67e58d9047e907:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -162,18 +162,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _47edec95bc64a51c97e8a11cc2ed40c2:
+  _7b80abae9889c18319bb557bedc34e57:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-mainline-clang-15.yml
+++ b/.github/workflows/android-mainline-clang-15.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _27913b883a7b3927289cd723c5e6b1c6:
+  _3d1fc31fae1f0825f1b1117687571182:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7b8336846bde11413c4d6dc9a7e31743:
+  _ed8e4c799b40550226233bf3f334f719:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-mainline-clang-16.yml
+++ b/.github/workflows/android-mainline-clang-16.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _8947f485cd634fe1980410d5fd49c0cd:
+  _53704d75048d901235421342a220a3d2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -162,18 +162,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b9c33721b8a30cf8511e236bfd80c819:
+  _0313162a06bb046f4081c817855c8ac1:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-mainline-clang-17.yml
+++ b/.github/workflows/android-mainline-clang-17.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _57225b66c2cca415de91dd060472c53e:
+  _c9a7bb527b7340eacb42c20cbc2ecf43:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -162,18 +162,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _934c8b5199cfd7d563f331608b4aef1d:
+  _c857a5b77f9ff7258c0b914b8ca906cd:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-mainline-clang-18.yml
+++ b/.github/workflows/android-mainline-clang-18.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _ebd88385a017d6a8b6a4d3b1d4bff8f4:
+  _e05cc2bd0d980c406da77866025ae9a6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -162,18 +162,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _1e7e455003c708db13544699bc315515:
+  _c89fe0a8c5057794c34bb22f1b69d33d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-mainline-clang-19.yml
+++ b/.github/workflows/android-mainline-clang-19.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _0913b033bbb90e4af0d1c3e20ba5a03d:
+  _427ad04336d3b729e9f06ac390339c83:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -162,18 +162,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3eb68f215995c2c50b536d2dc8d27755:
+  _69be54e07c0c29096e6473be61b248d6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-mainline-clang-android.yml
+++ b/.github/workflows/android-mainline-clang-android.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _092d18d4defe742a9f23a18a7d2eebc6:
+  _715e50064ab6c7b608bbfde676ee63c3:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -162,18 +162,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e8eaa6c4609c31891f40230b3aa2339f:
+  _54d3fa945b463031f59cd01c1779e62d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android12-5.10-clang-12.yml
+++ b/.github/workflows/android12-5.10-clang-12.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e2d7c97a744bb18b18038623898956f6:
+  _4cd429c60c49c411bafc8205cac4ff17:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4fb2521d605de5401fc145b2b8a80bc8:
+  _d24ad0cc4a0c9a09c6a8b5f717962455:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android12-5.10-clang-13.yml
+++ b/.github/workflows/android12-5.10-clang-13.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _bf41f851fcdaba3f8ff5598ee5a62c07:
+  _e2318e8e85ff910f296ddaba6906fadf:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _35a5ee570535cd317c3ecd44077c7035:
+  _6597d87a555c679fa00784f2fd6c0f25:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android12-5.10-clang-14.yml
+++ b/.github/workflows/android12-5.10-clang-14.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b7027adc4194874a4adbc49c0f26629d:
+  _56da186ca8feaa744e67e58d9047e907:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _47edec95bc64a51c97e8a11cc2ed40c2:
+  _7b80abae9889c18319bb557bedc34e57:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android12-5.10-clang-15.yml
+++ b/.github/workflows/android12-5.10-clang-15.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _27913b883a7b3927289cd723c5e6b1c6:
+  _3d1fc31fae1f0825f1b1117687571182:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7b8336846bde11413c4d6dc9a7e31743:
+  _ed8e4c799b40550226233bf3f334f719:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android12-5.10-clang-16.yml
+++ b/.github/workflows/android12-5.10-clang-16.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _8947f485cd634fe1980410d5fd49c0cd:
+  _53704d75048d901235421342a220a3d2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b9c33721b8a30cf8511e236bfd80c819:
+  _0313162a06bb046f4081c817855c8ac1:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android12-5.10-clang-17.yml
+++ b/.github/workflows/android12-5.10-clang-17.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _57225b66c2cca415de91dd060472c53e:
+  _c9a7bb527b7340eacb42c20cbc2ecf43:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _934c8b5199cfd7d563f331608b4aef1d:
+  _c857a5b77f9ff7258c0b914b8ca906cd:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android12-5.10-clang-18.yml
+++ b/.github/workflows/android12-5.10-clang-18.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _ebd88385a017d6a8b6a4d3b1d4bff8f4:
+  _e05cc2bd0d980c406da77866025ae9a6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _1e7e455003c708db13544699bc315515:
+  _c89fe0a8c5057794c34bb22f1b69d33d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android12-5.10-clang-19.yml
+++ b/.github/workflows/android12-5.10-clang-19.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _0913b033bbb90e4af0d1c3e20ba5a03d:
+  _427ad04336d3b729e9f06ac390339c83:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3eb68f215995c2c50b536d2dc8d27755:
+  _69be54e07c0c29096e6473be61b248d6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android12-5.10-clang-android.yml
+++ b/.github/workflows/android12-5.10-clang-android.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _092d18d4defe742a9f23a18a7d2eebc6:
+  _715e50064ab6c7b608bbfde676ee63c3:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e8eaa6c4609c31891f40230b3aa2339f:
+  _54d3fa945b463031f59cd01c1779e62d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android12-5.4-clang-12.yml
+++ b/.github/workflows/android12-5.4-clang-12.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e2d7c97a744bb18b18038623898956f6:
+  _4cd429c60c49c411bafc8205cac4ff17:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4fb2521d605de5401fc145b2b8a80bc8:
+  _d24ad0cc4a0c9a09c6a8b5f717962455:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android12-5.4-clang-13.yml
+++ b/.github/workflows/android12-5.4-clang-13.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _bf41f851fcdaba3f8ff5598ee5a62c07:
+  _e2318e8e85ff910f296ddaba6906fadf:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _35a5ee570535cd317c3ecd44077c7035:
+  _6597d87a555c679fa00784f2fd6c0f25:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android12-5.4-clang-14.yml
+++ b/.github/workflows/android12-5.4-clang-14.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b7027adc4194874a4adbc49c0f26629d:
+  _56da186ca8feaa744e67e58d9047e907:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _47edec95bc64a51c97e8a11cc2ed40c2:
+  _7b80abae9889c18319bb557bedc34e57:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android12-5.4-clang-15.yml
+++ b/.github/workflows/android12-5.4-clang-15.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _27913b883a7b3927289cd723c5e6b1c6:
+  _3d1fc31fae1f0825f1b1117687571182:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7b8336846bde11413c4d6dc9a7e31743:
+  _ed8e4c799b40550226233bf3f334f719:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android12-5.4-clang-16.yml
+++ b/.github/workflows/android12-5.4-clang-16.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _8947f485cd634fe1980410d5fd49c0cd:
+  _53704d75048d901235421342a220a3d2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b9c33721b8a30cf8511e236bfd80c819:
+  _0313162a06bb046f4081c817855c8ac1:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android12-5.4-clang-17.yml
+++ b/.github/workflows/android12-5.4-clang-17.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _57225b66c2cca415de91dd060472c53e:
+  _c9a7bb527b7340eacb42c20cbc2ecf43:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _934c8b5199cfd7d563f331608b4aef1d:
+  _c857a5b77f9ff7258c0b914b8ca906cd:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android12-5.4-clang-18.yml
+++ b/.github/workflows/android12-5.4-clang-18.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _ebd88385a017d6a8b6a4d3b1d4bff8f4:
+  _e05cc2bd0d980c406da77866025ae9a6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _1e7e455003c708db13544699bc315515:
+  _c89fe0a8c5057794c34bb22f1b69d33d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android12-5.4-clang-19.yml
+++ b/.github/workflows/android12-5.4-clang-19.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _0913b033bbb90e4af0d1c3e20ba5a03d:
+  _427ad04336d3b729e9f06ac390339c83:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3eb68f215995c2c50b536d2dc8d27755:
+  _69be54e07c0c29096e6473be61b248d6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android12-5.4-clang-android.yml
+++ b/.github/workflows/android12-5.4-clang-android.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _092d18d4defe742a9f23a18a7d2eebc6:
+  _715e50064ab6c7b608bbfde676ee63c3:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e8eaa6c4609c31891f40230b3aa2339f:
+  _54d3fa945b463031f59cd01c1779e62d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android13-5.10-clang-12.yml
+++ b/.github/workflows/android13-5.10-clang-12.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e2d7c97a744bb18b18038623898956f6:
+  _4cd429c60c49c411bafc8205cac4ff17:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4fb2521d605de5401fc145b2b8a80bc8:
+  _d24ad0cc4a0c9a09c6a8b5f717962455:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android13-5.10-clang-13.yml
+++ b/.github/workflows/android13-5.10-clang-13.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _bf41f851fcdaba3f8ff5598ee5a62c07:
+  _e2318e8e85ff910f296ddaba6906fadf:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _35a5ee570535cd317c3ecd44077c7035:
+  _6597d87a555c679fa00784f2fd6c0f25:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android13-5.10-clang-14.yml
+++ b/.github/workflows/android13-5.10-clang-14.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b7027adc4194874a4adbc49c0f26629d:
+  _56da186ca8feaa744e67e58d9047e907:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _47edec95bc64a51c97e8a11cc2ed40c2:
+  _7b80abae9889c18319bb557bedc34e57:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android13-5.10-clang-15.yml
+++ b/.github/workflows/android13-5.10-clang-15.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _27913b883a7b3927289cd723c5e6b1c6:
+  _3d1fc31fae1f0825f1b1117687571182:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7b8336846bde11413c4d6dc9a7e31743:
+  _ed8e4c799b40550226233bf3f334f719:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android13-5.10-clang-16.yml
+++ b/.github/workflows/android13-5.10-clang-16.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _8947f485cd634fe1980410d5fd49c0cd:
+  _53704d75048d901235421342a220a3d2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b9c33721b8a30cf8511e236bfd80c819:
+  _0313162a06bb046f4081c817855c8ac1:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android13-5.10-clang-17.yml
+++ b/.github/workflows/android13-5.10-clang-17.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _57225b66c2cca415de91dd060472c53e:
+  _c9a7bb527b7340eacb42c20cbc2ecf43:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _934c8b5199cfd7d563f331608b4aef1d:
+  _c857a5b77f9ff7258c0b914b8ca906cd:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android13-5.10-clang-18.yml
+++ b/.github/workflows/android13-5.10-clang-18.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _ebd88385a017d6a8b6a4d3b1d4bff8f4:
+  _e05cc2bd0d980c406da77866025ae9a6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _1e7e455003c708db13544699bc315515:
+  _c89fe0a8c5057794c34bb22f1b69d33d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android13-5.10-clang-19.yml
+++ b/.github/workflows/android13-5.10-clang-19.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _0913b033bbb90e4af0d1c3e20ba5a03d:
+  _427ad04336d3b729e9f06ac390339c83:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3eb68f215995c2c50b536d2dc8d27755:
+  _69be54e07c0c29096e6473be61b248d6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android13-5.10-clang-android.yml
+++ b/.github/workflows/android13-5.10-clang-android.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _092d18d4defe742a9f23a18a7d2eebc6:
+  _715e50064ab6c7b608bbfde676ee63c3:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e8eaa6c4609c31891f40230b3aa2339f:
+  _54d3fa945b463031f59cd01c1779e62d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android13-5.15-clang-12.yml
+++ b/.github/workflows/android13-5.15-clang-12.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e2d7c97a744bb18b18038623898956f6:
+  _4cd429c60c49c411bafc8205cac4ff17:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4fb2521d605de5401fc145b2b8a80bc8:
+  _d24ad0cc4a0c9a09c6a8b5f717962455:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android13-5.15-clang-13.yml
+++ b/.github/workflows/android13-5.15-clang-13.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _bf41f851fcdaba3f8ff5598ee5a62c07:
+  _e2318e8e85ff910f296ddaba6906fadf:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _35a5ee570535cd317c3ecd44077c7035:
+  _6597d87a555c679fa00784f2fd6c0f25:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android13-5.15-clang-14.yml
+++ b/.github/workflows/android13-5.15-clang-14.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b7027adc4194874a4adbc49c0f26629d:
+  _56da186ca8feaa744e67e58d9047e907:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _47edec95bc64a51c97e8a11cc2ed40c2:
+  _7b80abae9889c18319bb557bedc34e57:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android13-5.15-clang-15.yml
+++ b/.github/workflows/android13-5.15-clang-15.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _27913b883a7b3927289cd723c5e6b1c6:
+  _3d1fc31fae1f0825f1b1117687571182:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7b8336846bde11413c4d6dc9a7e31743:
+  _ed8e4c799b40550226233bf3f334f719:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android13-5.15-clang-16.yml
+++ b/.github/workflows/android13-5.15-clang-16.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _8947f485cd634fe1980410d5fd49c0cd:
+  _53704d75048d901235421342a220a3d2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b9c33721b8a30cf8511e236bfd80c819:
+  _0313162a06bb046f4081c817855c8ac1:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android13-5.15-clang-17.yml
+++ b/.github/workflows/android13-5.15-clang-17.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _57225b66c2cca415de91dd060472c53e:
+  _c9a7bb527b7340eacb42c20cbc2ecf43:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _934c8b5199cfd7d563f331608b4aef1d:
+  _c857a5b77f9ff7258c0b914b8ca906cd:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android13-5.15-clang-18.yml
+++ b/.github/workflows/android13-5.15-clang-18.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _ebd88385a017d6a8b6a4d3b1d4bff8f4:
+  _e05cc2bd0d980c406da77866025ae9a6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _1e7e455003c708db13544699bc315515:
+  _c89fe0a8c5057794c34bb22f1b69d33d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android13-5.15-clang-19.yml
+++ b/.github/workflows/android13-5.15-clang-19.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _0913b033bbb90e4af0d1c3e20ba5a03d:
+  _427ad04336d3b729e9f06ac390339c83:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3eb68f215995c2c50b536d2dc8d27755:
+  _69be54e07c0c29096e6473be61b248d6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android13-5.15-clang-android.yml
+++ b/.github/workflows/android13-5.15-clang-android.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _092d18d4defe742a9f23a18a7d2eebc6:
+  _715e50064ab6c7b608bbfde676ee63c3:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e8eaa6c4609c31891f40230b3aa2339f:
+  _54d3fa945b463031f59cd01c1779e62d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-5.15-clang-12.yml
+++ b/.github/workflows/android14-5.15-clang-12.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e2d7c97a744bb18b18038623898956f6:
+  _4cd429c60c49c411bafc8205cac4ff17:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4fb2521d605de5401fc145b2b8a80bc8:
+  _d24ad0cc4a0c9a09c6a8b5f717962455:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-5.15-clang-13.yml
+++ b/.github/workflows/android14-5.15-clang-13.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _bf41f851fcdaba3f8ff5598ee5a62c07:
+  _e2318e8e85ff910f296ddaba6906fadf:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _35a5ee570535cd317c3ecd44077c7035:
+  _6597d87a555c679fa00784f2fd6c0f25:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-5.15-clang-14.yml
+++ b/.github/workflows/android14-5.15-clang-14.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b7027adc4194874a4adbc49c0f26629d:
+  _56da186ca8feaa744e67e58d9047e907:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _47edec95bc64a51c97e8a11cc2ed40c2:
+  _7b80abae9889c18319bb557bedc34e57:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-5.15-clang-15.yml
+++ b/.github/workflows/android14-5.15-clang-15.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _27913b883a7b3927289cd723c5e6b1c6:
+  _3d1fc31fae1f0825f1b1117687571182:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7b8336846bde11413c4d6dc9a7e31743:
+  _ed8e4c799b40550226233bf3f334f719:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-5.15-clang-16.yml
+++ b/.github/workflows/android14-5.15-clang-16.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _8947f485cd634fe1980410d5fd49c0cd:
+  _53704d75048d901235421342a220a3d2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b9c33721b8a30cf8511e236bfd80c819:
+  _0313162a06bb046f4081c817855c8ac1:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-5.15-clang-17.yml
+++ b/.github/workflows/android14-5.15-clang-17.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _57225b66c2cca415de91dd060472c53e:
+  _c9a7bb527b7340eacb42c20cbc2ecf43:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _934c8b5199cfd7d563f331608b4aef1d:
+  _c857a5b77f9ff7258c0b914b8ca906cd:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-5.15-clang-18.yml
+++ b/.github/workflows/android14-5.15-clang-18.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _ebd88385a017d6a8b6a4d3b1d4bff8f4:
+  _e05cc2bd0d980c406da77866025ae9a6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _1e7e455003c708db13544699bc315515:
+  _c89fe0a8c5057794c34bb22f1b69d33d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-5.15-clang-19.yml
+++ b/.github/workflows/android14-5.15-clang-19.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _0913b033bbb90e4af0d1c3e20ba5a03d:
+  _427ad04336d3b729e9f06ac390339c83:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3eb68f215995c2c50b536d2dc8d27755:
+  _69be54e07c0c29096e6473be61b248d6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-5.15-clang-android.yml
+++ b/.github/workflows/android14-5.15-clang-android.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _092d18d4defe742a9f23a18a7d2eebc6:
+  _715e50064ab6c7b608bbfde676ee63c3:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e8eaa6c4609c31891f40230b3aa2339f:
+  _54d3fa945b463031f59cd01c1779e62d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-6.1-clang-12.yml
+++ b/.github/workflows/android14-6.1-clang-12.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e2d7c97a744bb18b18038623898956f6:
+  _4cd429c60c49c411bafc8205cac4ff17:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4fb2521d605de5401fc145b2b8a80bc8:
+  _d24ad0cc4a0c9a09c6a8b5f717962455:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-6.1-clang-13.yml
+++ b/.github/workflows/android14-6.1-clang-13.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _bf41f851fcdaba3f8ff5598ee5a62c07:
+  _e2318e8e85ff910f296ddaba6906fadf:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _35a5ee570535cd317c3ecd44077c7035:
+  _6597d87a555c679fa00784f2fd6c0f25:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-6.1-clang-14.yml
+++ b/.github/workflows/android14-6.1-clang-14.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b7027adc4194874a4adbc49c0f26629d:
+  _56da186ca8feaa744e67e58d9047e907:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _47edec95bc64a51c97e8a11cc2ed40c2:
+  _7b80abae9889c18319bb557bedc34e57:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-6.1-clang-15.yml
+++ b/.github/workflows/android14-6.1-clang-15.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _27913b883a7b3927289cd723c5e6b1c6:
+  _3d1fc31fae1f0825f1b1117687571182:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7b8336846bde11413c4d6dc9a7e31743:
+  _ed8e4c799b40550226233bf3f334f719:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-6.1-clang-16.yml
+++ b/.github/workflows/android14-6.1-clang-16.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _8947f485cd634fe1980410d5fd49c0cd:
+  _53704d75048d901235421342a220a3d2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b9c33721b8a30cf8511e236bfd80c819:
+  _0313162a06bb046f4081c817855c8ac1:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-6.1-clang-17.yml
+++ b/.github/workflows/android14-6.1-clang-17.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _57225b66c2cca415de91dd060472c53e:
+  _c9a7bb527b7340eacb42c20cbc2ecf43:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _934c8b5199cfd7d563f331608b4aef1d:
+  _c857a5b77f9ff7258c0b914b8ca906cd:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-6.1-clang-18.yml
+++ b/.github/workflows/android14-6.1-clang-18.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _ebd88385a017d6a8b6a4d3b1d4bff8f4:
+  _e05cc2bd0d980c406da77866025ae9a6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _1e7e455003c708db13544699bc315515:
+  _c89fe0a8c5057794c34bb22f1b69d33d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-6.1-clang-19.yml
+++ b/.github/workflows/android14-6.1-clang-19.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _0913b033bbb90e4af0d1c3e20ba5a03d:
+  _427ad04336d3b729e9f06ac390339c83:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3eb68f215995c2c50b536d2dc8d27755:
+  _69be54e07c0c29096e6473be61b248d6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-6.1-clang-android.yml
+++ b/.github/workflows/android14-6.1-clang-android.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _092d18d4defe742a9f23a18a7d2eebc6:
+  _715e50064ab6c7b608bbfde676ee63c3:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e8eaa6c4609c31891f40230b3aa2339f:
+  _54d3fa945b463031f59cd01c1779e62d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.1-clang-12.yml
+++ b/.github/workflows/android15-6.1-clang-12.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e2d7c97a744bb18b18038623898956f6:
+  _4cd429c60c49c411bafc8205cac4ff17:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4fb2521d605de5401fc145b2b8a80bc8:
+  _d24ad0cc4a0c9a09c6a8b5f717962455:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.1-clang-13.yml
+++ b/.github/workflows/android15-6.1-clang-13.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _bf41f851fcdaba3f8ff5598ee5a62c07:
+  _e2318e8e85ff910f296ddaba6906fadf:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _35a5ee570535cd317c3ecd44077c7035:
+  _6597d87a555c679fa00784f2fd6c0f25:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.1-clang-14.yml
+++ b/.github/workflows/android15-6.1-clang-14.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b7027adc4194874a4adbc49c0f26629d:
+  _56da186ca8feaa744e67e58d9047e907:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _47edec95bc64a51c97e8a11cc2ed40c2:
+  _7b80abae9889c18319bb557bedc34e57:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.1-clang-15.yml
+++ b/.github/workflows/android15-6.1-clang-15.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _27913b883a7b3927289cd723c5e6b1c6:
+  _3d1fc31fae1f0825f1b1117687571182:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7b8336846bde11413c4d6dc9a7e31743:
+  _ed8e4c799b40550226233bf3f334f719:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.1-clang-16.yml
+++ b/.github/workflows/android15-6.1-clang-16.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _8947f485cd634fe1980410d5fd49c0cd:
+  _53704d75048d901235421342a220a3d2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b9c33721b8a30cf8511e236bfd80c819:
+  _0313162a06bb046f4081c817855c8ac1:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.1-clang-17.yml
+++ b/.github/workflows/android15-6.1-clang-17.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _57225b66c2cca415de91dd060472c53e:
+  _c9a7bb527b7340eacb42c20cbc2ecf43:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _934c8b5199cfd7d563f331608b4aef1d:
+  _c857a5b77f9ff7258c0b914b8ca906cd:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.1-clang-18.yml
+++ b/.github/workflows/android15-6.1-clang-18.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _ebd88385a017d6a8b6a4d3b1d4bff8f4:
+  _e05cc2bd0d980c406da77866025ae9a6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _1e7e455003c708db13544699bc315515:
+  _c89fe0a8c5057794c34bb22f1b69d33d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.1-clang-19.yml
+++ b/.github/workflows/android15-6.1-clang-19.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _0913b033bbb90e4af0d1c3e20ba5a03d:
+  _427ad04336d3b729e9f06ac390339c83:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3eb68f215995c2c50b536d2dc8d27755:
+  _69be54e07c0c29096e6473be61b248d6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.1-clang-android.yml
+++ b/.github/workflows/android15-6.1-clang-android.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _092d18d4defe742a9f23a18a7d2eebc6:
+  _715e50064ab6c7b608bbfde676ee63c3:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e8eaa6c4609c31891f40230b3aa2339f:
+  _54d3fa945b463031f59cd01c1779e62d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.6-clang-12.yml
+++ b/.github/workflows/android15-6.6-clang-12.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e2d7c97a744bb18b18038623898956f6:
+  _4cd429c60c49c411bafc8205cac4ff17:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4fb2521d605de5401fc145b2b8a80bc8:
+  _d24ad0cc4a0c9a09c6a8b5f717962455:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.6-clang-13.yml
+++ b/.github/workflows/android15-6.6-clang-13.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _bf41f851fcdaba3f8ff5598ee5a62c07:
+  _e2318e8e85ff910f296ddaba6906fadf:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _35a5ee570535cd317c3ecd44077c7035:
+  _6597d87a555c679fa00784f2fd6c0f25:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.6-clang-14.yml
+++ b/.github/workflows/android15-6.6-clang-14.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b7027adc4194874a4adbc49c0f26629d:
+  _56da186ca8feaa744e67e58d9047e907:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _47edec95bc64a51c97e8a11cc2ed40c2:
+  _7b80abae9889c18319bb557bedc34e57:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.6-clang-15.yml
+++ b/.github/workflows/android15-6.6-clang-15.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _27913b883a7b3927289cd723c5e6b1c6:
+  _3d1fc31fae1f0825f1b1117687571182:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7b8336846bde11413c4d6dc9a7e31743:
+  _ed8e4c799b40550226233bf3f334f719:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.6-clang-16.yml
+++ b/.github/workflows/android15-6.6-clang-16.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _8947f485cd634fe1980410d5fd49c0cd:
+  _53704d75048d901235421342a220a3d2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b9c33721b8a30cf8511e236bfd80c819:
+  _0313162a06bb046f4081c817855c8ac1:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.6-clang-17.yml
+++ b/.github/workflows/android15-6.6-clang-17.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _57225b66c2cca415de91dd060472c53e:
+  _c9a7bb527b7340eacb42c20cbc2ecf43:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _934c8b5199cfd7d563f331608b4aef1d:
+  _c857a5b77f9ff7258c0b914b8ca906cd:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.6-clang-18.yml
+++ b/.github/workflows/android15-6.6-clang-18.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _ebd88385a017d6a8b6a4d3b1d4bff8f4:
+  _e05cc2bd0d980c406da77866025ae9a6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _1e7e455003c708db13544699bc315515:
+  _c89fe0a8c5057794c34bb22f1b69d33d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.6-clang-19.yml
+++ b/.github/workflows/android15-6.6-clang-19.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _0913b033bbb90e4af0d1c3e20ba5a03d:
+  _427ad04336d3b729e9f06ac390339c83:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3eb68f215995c2c50b536d2dc8d27755:
+  _69be54e07c0c29096e6473be61b248d6:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.6-clang-android.yml
+++ b/.github/workflows/android15-6.6-clang-android.yml
@@ -106,18 +106,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _092d18d4defe742a9f23a18a7d2eebc6:
+  _715e50064ab6c7b608bbfde676ee63c3:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -134,18 +134,18 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e8eaa6c4609c31891f40230b3aa2339f:
+  _54d3fa945b463031f59cd01c1779e62d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: android
       BOOT: 1
-      CONFIG: gki_defconfig
+      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/generator/yml/0007-configs.yml
+++ b/generator/yml/0007-configs.yml
@@ -30,7 +30,8 @@ configs:
   - &arm64_kasan       {<< : *arm64-kasan-configs,                                                                                          ARCH: *arm64-arch,      << : *kernel}
   - &arm64_kasan_sw    {<< : *arm64-kasan-sw-configs,                                                                                       ARCH: *arm64-arch,      << : *kernel}
   - &arm64_ubsan       {config: [defconfig, CONFIG_UBSAN=y],                                                                                ARCH: *arm64-arch,      << : *kernel}
-  - &arm64_gki         {config: gki_defconfig,                                                                                              ARCH: *arm64-arch,      << : *kernel}
+  #                                             https://github.com/ClangBuiltLinux/continuous-integration2/issues/716
+  - &arm64_gki         {config: [gki_defconfig, CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n],                                                       ARCH: *arm64-arch,      << : *kernel}
   - &arm64_cut         {config: cuttlefish_defconfig,                                                                                       ARCH: *arm64-arch,      << : *kernel}
   - &arm64_allmod      {config: allmodconfig,                                                                                               ARCH: *arm64-arch,      << : *default}
   - &arm64_allmod_lto  {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_LTO_CLANG_THIN=y],                              ARCH: *arm64-arch,      << : *default}
@@ -87,7 +88,8 @@ configs:
   - &x86_64_cfi        {config: [defconfig, CONFIG_CFI_CLANG=y],                                                                                                    << : *kernel}
   - &x86_64_cfi_lto    {config: [defconfig, CONFIG_CFI_CLANG=y, CONFIG_LTO_CLANG_THIN=y],                                                                           << : *kernel}
   - &x86_64_cros       {<< : *x86_64-cros-configs,                                                                                                                  << : *kernel}
-  - &x86_64_gki        {config: gki_defconfig,                                                                                                                      << : *kernel}
+  #                                             https://github.com/ClangBuiltLinux/continuous-integration2/issues/716
+  - &x86_64_gki        {config: [gki_defconfig, CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n],                                                                               << : *kernel}
   - &x86_64_cut        {config: x86_64_cuttlefish_defconfig,                                                                                                        << : *kernel}
   - &x86_64_allmod     {config: allmodconfig,                                                                                                                       << : *default}
   - &x86_64_allmod_lto {config: [allmodconfig, CONFIG_GCOV_KERNEL=n, CONFIG_KASAN=n, CONFIG_LTO_CLANG_THIN=y],                                                      << : *default}

--- a/tuxsuite/android-4.19-clang-12.tux.yml
+++ b/tuxsuite/android-4.19-clang-12.tux.yml
@@ -14,7 +14,9 @@ jobs:
   builds:
   - target_arch: arm64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -22,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-4.19-clang-13.tux.yml
+++ b/tuxsuite/android-4.19-clang-13.tux.yml
@@ -14,7 +14,9 @@ jobs:
   builds:
   - target_arch: arm64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -22,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-4.19-clang-14.tux.yml
+++ b/tuxsuite/android-4.19-clang-14.tux.yml
@@ -14,7 +14,9 @@ jobs:
   builds:
   - target_arch: arm64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -22,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-4.19-clang-15.tux.yml
+++ b/tuxsuite/android-4.19-clang-15.tux.yml
@@ -14,7 +14,9 @@ jobs:
   builds:
   - target_arch: arm64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -22,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-4.19-clang-16.tux.yml
+++ b/tuxsuite/android-4.19-clang-16.tux.yml
@@ -14,7 +14,9 @@ jobs:
   builds:
   - target_arch: arm64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -22,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-4.19-clang-17.tux.yml
+++ b/tuxsuite/android-4.19-clang-17.tux.yml
@@ -14,7 +14,9 @@ jobs:
   builds:
   - target_arch: arm64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -22,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-4.19-clang-18.tux.yml
+++ b/tuxsuite/android-4.19-clang-18.tux.yml
@@ -14,7 +14,9 @@ jobs:
   builds:
   - target_arch: arm64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -22,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-4.19-clang-19.tux.yml
+++ b/tuxsuite/android-4.19-clang-19.tux.yml
@@ -14,7 +14,9 @@ jobs:
   builds:
   - target_arch: arm64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -22,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-4.19-clang-android.tux.yml
+++ b/tuxsuite/android-4.19-clang-android.tux.yml
@@ -14,7 +14,9 @@ jobs:
   builds:
   - target_arch: arm64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -22,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-mainline-clang-12.tux.yml
+++ b/tuxsuite/android-mainline-clang-12.tux.yml
@@ -25,7 +25,9 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -42,7 +44,9 @@ jobs:
       LLVM_IAS: 0
   - target_arch: x86_64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-mainline-clang-13.tux.yml
+++ b/tuxsuite/android-mainline-clang-13.tux.yml
@@ -25,7 +25,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -42,7 +44,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-mainline-clang-14.tux.yml
+++ b/tuxsuite/android-mainline-clang-14.tux.yml
@@ -25,7 +25,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -42,7 +44,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-mainline-clang-15.tux.yml
+++ b/tuxsuite/android-mainline-clang-15.tux.yml
@@ -25,7 +25,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -33,7 +35,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-mainline-clang-16.tux.yml
+++ b/tuxsuite/android-mainline-clang-16.tux.yml
@@ -25,7 +25,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -42,7 +44,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-mainline-clang-17.tux.yml
+++ b/tuxsuite/android-mainline-clang-17.tux.yml
@@ -25,7 +25,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -42,7 +44,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-mainline-clang-18.tux.yml
+++ b/tuxsuite/android-mainline-clang-18.tux.yml
@@ -25,7 +25,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -42,7 +44,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-mainline-clang-19.tux.yml
+++ b/tuxsuite/android-mainline-clang-19.tux.yml
@@ -25,7 +25,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -42,7 +44,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-mainline-clang-android.tux.yml
+++ b/tuxsuite/android-mainline-clang-android.tux.yml
@@ -25,7 +25,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -42,7 +44,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.10-clang-12.tux.yml
+++ b/tuxsuite/android12-5.10-clang-12.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.10-clang-13.tux.yml
+++ b/tuxsuite/android12-5.10-clang-13.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.10-clang-14.tux.yml
+++ b/tuxsuite/android12-5.10-clang-14.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.10-clang-15.tux.yml
+++ b/tuxsuite/android12-5.10-clang-15.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.10-clang-16.tux.yml
+++ b/tuxsuite/android12-5.10-clang-16.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.10-clang-17.tux.yml
+++ b/tuxsuite/android12-5.10-clang-17.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.10-clang-18.tux.yml
+++ b/tuxsuite/android12-5.10-clang-18.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.10-clang-19.tux.yml
+++ b/tuxsuite/android12-5.10-clang-19.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.10-clang-android.tux.yml
+++ b/tuxsuite/android12-5.10-clang-android.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.4-clang-12.tux.yml
+++ b/tuxsuite/android12-5.4-clang-12.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.4-clang-13.tux.yml
+++ b/tuxsuite/android12-5.4-clang-13.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.4-clang-14.tux.yml
+++ b/tuxsuite/android12-5.4-clang-14.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.4-clang-15.tux.yml
+++ b/tuxsuite/android12-5.4-clang-15.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.4-clang-16.tux.yml
+++ b/tuxsuite/android12-5.4-clang-16.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.4-clang-17.tux.yml
+++ b/tuxsuite/android12-5.4-clang-17.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.4-clang-18.tux.yml
+++ b/tuxsuite/android12-5.4-clang-18.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.4-clang-19.tux.yml
+++ b/tuxsuite/android12-5.4-clang-19.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android12-5.4-clang-android.tux.yml
+++ b/tuxsuite/android12-5.4-clang-android.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.10-clang-12.tux.yml
+++ b/tuxsuite/android13-5.10-clang-12.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.10-clang-13.tux.yml
+++ b/tuxsuite/android13-5.10-clang-13.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.10-clang-14.tux.yml
+++ b/tuxsuite/android13-5.10-clang-14.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.10-clang-15.tux.yml
+++ b/tuxsuite/android13-5.10-clang-15.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.10-clang-16.tux.yml
+++ b/tuxsuite/android13-5.10-clang-16.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.10-clang-17.tux.yml
+++ b/tuxsuite/android13-5.10-clang-17.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.10-clang-18.tux.yml
+++ b/tuxsuite/android13-5.10-clang-18.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.10-clang-19.tux.yml
+++ b/tuxsuite/android13-5.10-clang-19.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.10-clang-android.tux.yml
+++ b/tuxsuite/android13-5.10-clang-android.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.15-clang-12.tux.yml
+++ b/tuxsuite/android13-5.15-clang-12.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.15-clang-13.tux.yml
+++ b/tuxsuite/android13-5.15-clang-13.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.15-clang-14.tux.yml
+++ b/tuxsuite/android13-5.15-clang-14.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.15-clang-15.tux.yml
+++ b/tuxsuite/android13-5.15-clang-15.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.15-clang-16.tux.yml
+++ b/tuxsuite/android13-5.15-clang-16.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.15-clang-17.tux.yml
+++ b/tuxsuite/android13-5.15-clang-17.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.15-clang-18.tux.yml
+++ b/tuxsuite/android13-5.15-clang-18.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.15-clang-19.tux.yml
+++ b/tuxsuite/android13-5.15-clang-19.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android13-5.15-clang-android.tux.yml
+++ b/tuxsuite/android13-5.15-clang-android.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-5.15-clang-12.tux.yml
+++ b/tuxsuite/android14-5.15-clang-12.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-5.15-clang-13.tux.yml
+++ b/tuxsuite/android14-5.15-clang-13.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-5.15-clang-14.tux.yml
+++ b/tuxsuite/android14-5.15-clang-14.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-5.15-clang-15.tux.yml
+++ b/tuxsuite/android14-5.15-clang-15.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-5.15-clang-16.tux.yml
+++ b/tuxsuite/android14-5.15-clang-16.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-5.15-clang-17.tux.yml
+++ b/tuxsuite/android14-5.15-clang-17.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-5.15-clang-18.tux.yml
+++ b/tuxsuite/android14-5.15-clang-18.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-5.15-clang-19.tux.yml
+++ b/tuxsuite/android14-5.15-clang-19.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-5.15-clang-android.tux.yml
+++ b/tuxsuite/android14-5.15-clang-android.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-6.1-clang-12.tux.yml
+++ b/tuxsuite/android14-6.1-clang-12.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-6.1-clang-13.tux.yml
+++ b/tuxsuite/android14-6.1-clang-13.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-6.1-clang-14.tux.yml
+++ b/tuxsuite/android14-6.1-clang-14.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-6.1-clang-15.tux.yml
+++ b/tuxsuite/android14-6.1-clang-15.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-6.1-clang-16.tux.yml
+++ b/tuxsuite/android14-6.1-clang-16.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-6.1-clang-17.tux.yml
+++ b/tuxsuite/android14-6.1-clang-17.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-6.1-clang-18.tux.yml
+++ b/tuxsuite/android14-6.1-clang-18.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-6.1-clang-19.tux.yml
+++ b/tuxsuite/android14-6.1-clang-19.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-6.1-clang-android.tux.yml
+++ b/tuxsuite/android14-6.1-clang-android.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.1-clang-12.tux.yml
+++ b/tuxsuite/android15-6.1-clang-12.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.1-clang-13.tux.yml
+++ b/tuxsuite/android15-6.1-clang-13.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.1-clang-14.tux.yml
+++ b/tuxsuite/android15-6.1-clang-14.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.1-clang-15.tux.yml
+++ b/tuxsuite/android15-6.1-clang-15.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.1-clang-16.tux.yml
+++ b/tuxsuite/android15-6.1-clang-16.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.1-clang-17.tux.yml
+++ b/tuxsuite/android15-6.1-clang-17.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.1-clang-18.tux.yml
+++ b/tuxsuite/android15-6.1-clang-18.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.1-clang-19.tux.yml
+++ b/tuxsuite/android15-6.1-clang-19.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.1-clang-android.tux.yml
+++ b/tuxsuite/android15-6.1-clang-android.tux.yml
@@ -24,7 +24,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -32,7 +34,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.6-clang-12.tux.yml
+++ b/tuxsuite/android15-6.6-clang-12.tux.yml
@@ -25,7 +25,9 @@ jobs:
       LLVM_IAS: 0
   - target_arch: arm64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -33,7 +35,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-12
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.6-clang-13.tux.yml
+++ b/tuxsuite/android15-6.6-clang-13.tux.yml
@@ -25,7 +25,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -33,7 +35,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-13
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.6-clang-14.tux.yml
+++ b/tuxsuite/android15-6.6-clang-14.tux.yml
@@ -25,7 +25,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -33,7 +35,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-14
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.6-clang-15.tux.yml
+++ b/tuxsuite/android15-6.6-clang-15.tux.yml
@@ -25,7 +25,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -33,7 +35,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-15
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.6-clang-16.tux.yml
+++ b/tuxsuite/android15-6.6-clang-16.tux.yml
@@ -25,7 +25,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -33,7 +35,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-16
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.6-clang-17.tux.yml
+++ b/tuxsuite/android15-6.6-clang-17.tux.yml
@@ -25,7 +25,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -33,7 +35,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-17
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.6-clang-18.tux.yml
+++ b/tuxsuite/android15-6.6-clang-18.tux.yml
@@ -25,7 +25,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -33,7 +35,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-18
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.6-clang-19.tux.yml
+++ b/tuxsuite/android15-6.6-clang-19.tux.yml
@@ -25,7 +25,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -33,7 +35,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.6-clang-android.tux.yml
+++ b/tuxsuite/android15-6.6-clang-android.tux.yml
@@ -25,7 +25,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:
@@ -33,7 +35,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-android
-    kconfig: gki_defconfig
+    kconfig:
+    - gki_defconfig
+    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     targets:
     - kernel
     make_variables:


### PR DESCRIPTION
zstd compressed debug info sections were only supported in libelf 0.189 but TuxMake's containers only have libelf 0.183, which causes build breakage with CONFIG_DEBUG_INFO_BTF. Disable CONFIG_DEBUG_INFO_COMPRESSED_ZSTD for Android configs now, it can be re-enabled when TuxMake has a version of libelf that supports these sections.

Link: https://github.com/ClangBuiltLinux/continuous-integration2/issues/716
