### PR TITLE
Use kernel.org clang whenever possible

### DIFF
--- a/.github/workflows/4.19-clang-13.yml
+++ b/.github/workflows/4.19-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-4.19.y

--- a/.github/workflows/4.19-clang-14.yml
+++ b/.github/workflows/4.19-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-4.19.y

--- a/.github/workflows/4.19-clang-15.yml
+++ b/.github/workflows/4.19-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-4.19.y

--- a/.github/workflows/4.19-clang-16.yml
+++ b/.github/workflows/4.19-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-4.19.y

--- a/.github/workflows/4.19-clang-17.yml
+++ b/.github/workflows/4.19-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-4.19.y

--- a/.github/workflows/4.19-clang-18.yml
+++ b/.github/workflows/4.19-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-4.19.y

--- a/.github/workflows/5.10-clang-11.yml
+++ b/.github/workflows/5.10-clang-11.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-11
+    container: tuxmake/x86_64_korg-clang-11
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.10.y

--- a/.github/workflows/5.10-clang-12.yml
+++ b/.github/workflows/5.10-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.10.y

--- a/.github/workflows/5.10-clang-13.yml
+++ b/.github/workflows/5.10-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.10.y

--- a/.github/workflows/5.10-clang-14.yml
+++ b/.github/workflows/5.10-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.10.y

--- a/.github/workflows/5.10-clang-15.yml
+++ b/.github/workflows/5.10-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.10.y

--- a/.github/workflows/5.10-clang-16.yml
+++ b/.github/workflows/5.10-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.10.y

--- a/.github/workflows/5.10-clang-17.yml
+++ b/.github/workflows/5.10-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.10.y

--- a/.github/workflows/5.10-clang-18.yml
+++ b/.github/workflows/5.10-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.10.y

--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-11
+    container: tuxmake/x86_64_korg-clang-11
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.15.y

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.15.y

--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.15.y

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.15.y

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.15.y

--- a/.github/workflows/5.15-clang-16.yml
+++ b/.github/workflows/5.15-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.15.y

--- a/.github/workflows/5.15-clang-17.yml
+++ b/.github/workflows/5.15-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.15.y

--- a/.github/workflows/5.15-clang-18.yml
+++ b/.github/workflows/5.15-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.15.y

--- a/.github/workflows/5.4-clang-13.yml
+++ b/.github/workflows/5.4-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.4.y

--- a/.github/workflows/5.4-clang-14.yml
+++ b/.github/workflows/5.4-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.4.y

--- a/.github/workflows/5.4-clang-15.yml
+++ b/.github/workflows/5.4-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.4.y

--- a/.github/workflows/5.4-clang-16.yml
+++ b/.github/workflows/5.4-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.4.y

--- a/.github/workflows/5.4-clang-17.yml
+++ b/.github/workflows/5.4-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.4.y

--- a/.github/workflows/5.4-clang-18.yml
+++ b/.github/workflows/5.4-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.4.y

--- a/.github/workflows/6.1-clang-11.yml
+++ b/.github/workflows/6.1-clang-11.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-11
+    container: tuxmake/x86_64_korg-clang-11
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.1.y

--- a/.github/workflows/6.1-clang-12.yml
+++ b/.github/workflows/6.1-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.1.y

--- a/.github/workflows/6.1-clang-13.yml
+++ b/.github/workflows/6.1-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.1.y

--- a/.github/workflows/6.1-clang-14.yml
+++ b/.github/workflows/6.1-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.1.y

--- a/.github/workflows/6.1-clang-15.yml
+++ b/.github/workflows/6.1-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.1.y

--- a/.github/workflows/6.1-clang-16.yml
+++ b/.github/workflows/6.1-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.1.y

--- a/.github/workflows/6.1-clang-17.yml
+++ b/.github/workflows/6.1-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.1.y

--- a/.github/workflows/6.1-clang-18.yml
+++ b/.github/workflows/6.1-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.1.y

--- a/.github/workflows/6.6-clang-11.yml
+++ b/.github/workflows/6.6-clang-11.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-11
+    container: tuxmake/x86_64_korg-clang-11
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.6.y

--- a/.github/workflows/6.6-clang-12.yml
+++ b/.github/workflows/6.6-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.6.y

--- a/.github/workflows/6.6-clang-13.yml
+++ b/.github/workflows/6.6-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.6.y

--- a/.github/workflows/6.6-clang-14.yml
+++ b/.github/workflows/6.6-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.6.y

--- a/.github/workflows/6.6-clang-15.yml
+++ b/.github/workflows/6.6-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.6.y

--- a/.github/workflows/6.6-clang-16.yml
+++ b/.github/workflows/6.6-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.6.y

--- a/.github/workflows/6.6-clang-17.yml
+++ b/.github/workflows/6.6-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.6.y

--- a/.github/workflows/6.6-clang-18.yml
+++ b/.github/workflows/6.6-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.6.y

--- a/.github/workflows/android-4.19-clang-12.yml
+++ b/.github/workflows/android-4.19-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable

--- a/.github/workflows/android-4.19-clang-13.yml
+++ b/.github/workflows/android-4.19-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable

--- a/.github/workflows/android-4.19-clang-14.yml
+++ b/.github/workflows/android-4.19-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable

--- a/.github/workflows/android-4.19-clang-15.yml
+++ b/.github/workflows/android-4.19-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable

--- a/.github/workflows/android-4.19-clang-16.yml
+++ b/.github/workflows/android-4.19-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable

--- a/.github/workflows/android-4.19-clang-17.yml
+++ b/.github/workflows/android-4.19-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable

--- a/.github/workflows/android-4.19-clang-18.yml
+++ b/.github/workflows/android-4.19-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable

--- a/.github/workflows/android-4.19-clang-android.yml
+++ b/.github/workflows/android-4.19-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-android
+    container: tuxmake/x86_64_korg-clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable

--- a/.github/workflows/android-mainline-clang-12.yml
+++ b/.github/workflows/android-mainline-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-mainline

--- a/.github/workflows/android-mainline-clang-13.yml
+++ b/.github/workflows/android-mainline-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-mainline

--- a/.github/workflows/android-mainline-clang-14.yml
+++ b/.github/workflows/android-mainline-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-mainline

--- a/.github/workflows/android-mainline-clang-15.yml
+++ b/.github/workflows/android-mainline-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-mainline

--- a/.github/workflows/android-mainline-clang-16.yml
+++ b/.github/workflows/android-mainline-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-mainline

--- a/.github/workflows/android-mainline-clang-17.yml
+++ b/.github/workflows/android-mainline-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-mainline

--- a/.github/workflows/android-mainline-clang-18.yml
+++ b/.github/workflows/android-mainline-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-mainline

--- a/.github/workflows/android-mainline-clang-android.yml
+++ b/.github/workflows/android-mainline-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-android
+    container: tuxmake/x86_64_korg-clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-mainline

--- a/.github/workflows/android12-5.10-clang-12.yml
+++ b/.github/workflows/android12-5.10-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10

--- a/.github/workflows/android12-5.10-clang-13.yml
+++ b/.github/workflows/android12-5.10-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10

--- a/.github/workflows/android12-5.10-clang-14.yml
+++ b/.github/workflows/android12-5.10-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10

--- a/.github/workflows/android12-5.10-clang-15.yml
+++ b/.github/workflows/android12-5.10-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10

--- a/.github/workflows/android12-5.10-clang-16.yml
+++ b/.github/workflows/android12-5.10-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10

--- a/.github/workflows/android12-5.10-clang-17.yml
+++ b/.github/workflows/android12-5.10-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10

--- a/.github/workflows/android12-5.10-clang-18.yml
+++ b/.github/workflows/android12-5.10-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10

--- a/.github/workflows/android12-5.10-clang-android.yml
+++ b/.github/workflows/android12-5.10-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-android
+    container: tuxmake/x86_64_korg-clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10

--- a/.github/workflows/android12-5.4-clang-12.yml
+++ b/.github/workflows/android12-5.4-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4

--- a/.github/workflows/android12-5.4-clang-13.yml
+++ b/.github/workflows/android12-5.4-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4

--- a/.github/workflows/android12-5.4-clang-14.yml
+++ b/.github/workflows/android12-5.4-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4

--- a/.github/workflows/android12-5.4-clang-15.yml
+++ b/.github/workflows/android12-5.4-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4

--- a/.github/workflows/android12-5.4-clang-16.yml
+++ b/.github/workflows/android12-5.4-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4

--- a/.github/workflows/android12-5.4-clang-17.yml
+++ b/.github/workflows/android12-5.4-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4

--- a/.github/workflows/android12-5.4-clang-18.yml
+++ b/.github/workflows/android12-5.4-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4

--- a/.github/workflows/android12-5.4-clang-android.yml
+++ b/.github/workflows/android12-5.4-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-android
+    container: tuxmake/x86_64_korg-clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4

--- a/.github/workflows/android13-5.10-clang-12.yml
+++ b/.github/workflows/android13-5.10-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10

--- a/.github/workflows/android13-5.10-clang-13.yml
+++ b/.github/workflows/android13-5.10-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10

--- a/.github/workflows/android13-5.10-clang-14.yml
+++ b/.github/workflows/android13-5.10-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10

--- a/.github/workflows/android13-5.10-clang-15.yml
+++ b/.github/workflows/android13-5.10-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10

--- a/.github/workflows/android13-5.10-clang-16.yml
+++ b/.github/workflows/android13-5.10-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10

--- a/.github/workflows/android13-5.10-clang-17.yml
+++ b/.github/workflows/android13-5.10-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10

--- a/.github/workflows/android13-5.10-clang-18.yml
+++ b/.github/workflows/android13-5.10-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10

--- a/.github/workflows/android13-5.10-clang-android.yml
+++ b/.github/workflows/android13-5.10-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-android
+    container: tuxmake/x86_64_korg-clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10

--- a/.github/workflows/android13-5.15-clang-12.yml
+++ b/.github/workflows/android13-5.15-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15

--- a/.github/workflows/android13-5.15-clang-13.yml
+++ b/.github/workflows/android13-5.15-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15

--- a/.github/workflows/android13-5.15-clang-14.yml
+++ b/.github/workflows/android13-5.15-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15

--- a/.github/workflows/android13-5.15-clang-15.yml
+++ b/.github/workflows/android13-5.15-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15

--- a/.github/workflows/android13-5.15-clang-16.yml
+++ b/.github/workflows/android13-5.15-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15

--- a/.github/workflows/android13-5.15-clang-17.yml
+++ b/.github/workflows/android13-5.15-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15

--- a/.github/workflows/android13-5.15-clang-18.yml
+++ b/.github/workflows/android13-5.15-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15

--- a/.github/workflows/android13-5.15-clang-android.yml
+++ b/.github/workflows/android13-5.15-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-android
+    container: tuxmake/x86_64_korg-clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15

--- a/.github/workflows/android14-5.15-clang-12.yml
+++ b/.github/workflows/android14-5.15-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15

--- a/.github/workflows/android14-5.15-clang-13.yml
+++ b/.github/workflows/android14-5.15-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15

--- a/.github/workflows/android14-5.15-clang-14.yml
+++ b/.github/workflows/android14-5.15-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15

--- a/.github/workflows/android14-5.15-clang-15.yml
+++ b/.github/workflows/android14-5.15-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15

--- a/.github/workflows/android14-5.15-clang-16.yml
+++ b/.github/workflows/android14-5.15-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15

--- a/.github/workflows/android14-5.15-clang-17.yml
+++ b/.github/workflows/android14-5.15-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15

--- a/.github/workflows/android14-5.15-clang-18.yml
+++ b/.github/workflows/android14-5.15-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15

--- a/.github/workflows/android14-5.15-clang-android.yml
+++ b/.github/workflows/android14-5.15-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-android
+    container: tuxmake/x86_64_korg-clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15

--- a/.github/workflows/android14-6.1-clang-12.yml
+++ b/.github/workflows/android14-6.1-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1

--- a/.github/workflows/android14-6.1-clang-13.yml
+++ b/.github/workflows/android14-6.1-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1

--- a/.github/workflows/android14-6.1-clang-14.yml
+++ b/.github/workflows/android14-6.1-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1

--- a/.github/workflows/android14-6.1-clang-15.yml
+++ b/.github/workflows/android14-6.1-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1

--- a/.github/workflows/android14-6.1-clang-16.yml
+++ b/.github/workflows/android14-6.1-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1

--- a/.github/workflows/android14-6.1-clang-17.yml
+++ b/.github/workflows/android14-6.1-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1

--- a/.github/workflows/android14-6.1-clang-18.yml
+++ b/.github/workflows/android14-6.1-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1

--- a/.github/workflows/android14-6.1-clang-android.yml
+++ b/.github/workflows/android14-6.1-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-android
+    container: tuxmake/x86_64_korg-clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1

--- a/.github/workflows/android15-6.1-clang-12.yml
+++ b/.github/workflows/android15-6.1-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.1

--- a/.github/workflows/android15-6.1-clang-13.yml
+++ b/.github/workflows/android15-6.1-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.1

--- a/.github/workflows/android15-6.1-clang-14.yml
+++ b/.github/workflows/android15-6.1-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.1

--- a/.github/workflows/android15-6.1-clang-15.yml
+++ b/.github/workflows/android15-6.1-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.1

--- a/.github/workflows/android15-6.1-clang-16.yml
+++ b/.github/workflows/android15-6.1-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.1

--- a/.github/workflows/android15-6.1-clang-17.yml
+++ b/.github/workflows/android15-6.1-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.1

--- a/.github/workflows/android15-6.1-clang-18.yml
+++ b/.github/workflows/android15-6.1-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.1

--- a/.github/workflows/android15-6.1-clang-android.yml
+++ b/.github/workflows/android15-6.1-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-android
+    container: tuxmake/x86_64_korg-clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.1

--- a/.github/workflows/android15-6.6-clang-12.yml
+++ b/.github/workflows/android15-6.6-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6

--- a/.github/workflows/android15-6.6-clang-13.yml
+++ b/.github/workflows/android15-6.6-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6

--- a/.github/workflows/android15-6.6-clang-14.yml
+++ b/.github/workflows/android15-6.6-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6

--- a/.github/workflows/android15-6.6-clang-15.yml
+++ b/.github/workflows/android15-6.6-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6

--- a/.github/workflows/android15-6.6-clang-16.yml
+++ b/.github/workflows/android15-6.6-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6

--- a/.github/workflows/android15-6.6-clang-17.yml
+++ b/.github/workflows/android15-6.6-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6

--- a/.github/workflows/android15-6.6-clang-18.yml
+++ b/.github/workflows/android15-6.6-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6

--- a/.github/workflows/android15-6.6-clang-android.yml
+++ b/.github/workflows/android15-6.6-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-android
+    container: tuxmake/x86_64_korg-clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6

--- a/.github/workflows/arm64-clang-12.yml
+++ b/.github/workflows/arm64-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/core

--- a/.github/workflows/arm64-clang-13.yml
+++ b/.github/workflows/arm64-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/core

--- a/.github/workflows/arm64-clang-14.yml
+++ b/.github/workflows/arm64-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/core

--- a/.github/workflows/arm64-clang-15.yml
+++ b/.github/workflows/arm64-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/core

--- a/.github/workflows/arm64-clang-16.yml
+++ b/.github/workflows/arm64-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/core

--- a/.github/workflows/arm64-clang-17.yml
+++ b/.github/workflows/arm64-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/core

--- a/.github/workflows/arm64-clang-18.yml
+++ b/.github/workflows/arm64-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/core

--- a/.github/workflows/arm64-fixes-clang-12.yml
+++ b/.github/workflows/arm64-fixes-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/fixes

--- a/.github/workflows/arm64-fixes-clang-13.yml
+++ b/.github/workflows/arm64-fixes-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/fixes

--- a/.github/workflows/arm64-fixes-clang-14.yml
+++ b/.github/workflows/arm64-fixes-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/fixes

--- a/.github/workflows/arm64-fixes-clang-15.yml
+++ b/.github/workflows/arm64-fixes-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/fixes

--- a/.github/workflows/arm64-fixes-clang-16.yml
+++ b/.github/workflows/arm64-fixes-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/fixes

--- a/.github/workflows/arm64-fixes-clang-17.yml
+++ b/.github/workflows/arm64-fixes-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/fixes

--- a/.github/workflows/arm64-fixes-clang-18.yml
+++ b/.github/workflows/arm64-fixes-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/fixes

--- a/.github/workflows/chromeos-5.10-clang-12.yml
+++ b/.github/workflows/chromeos-5.10-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.10

--- a/.github/workflows/chromeos-5.10-clang-13.yml
+++ b/.github/workflows/chromeos-5.10-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.10

--- a/.github/workflows/chromeos-5.10-clang-14.yml
+++ b/.github/workflows/chromeos-5.10-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.10

--- a/.github/workflows/chromeos-5.10-clang-15.yml
+++ b/.github/workflows/chromeos-5.10-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.10

--- a/.github/workflows/chromeos-5.10-clang-16.yml
+++ b/.github/workflows/chromeos-5.10-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.10

--- a/.github/workflows/chromeos-5.10-clang-17.yml
+++ b/.github/workflows/chromeos-5.10-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.10

--- a/.github/workflows/chromeos-5.10-clang-18.yml
+++ b/.github/workflows/chromeos-5.10-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.10

--- a/.github/workflows/chromeos-5.15-clang-12.yml
+++ b/.github/workflows/chromeos-5.15-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.15

--- a/.github/workflows/chromeos-5.15-clang-13.yml
+++ b/.github/workflows/chromeos-5.15-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.15

--- a/.github/workflows/chromeos-5.15-clang-14.yml
+++ b/.github/workflows/chromeos-5.15-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.15

--- a/.github/workflows/chromeos-5.15-clang-15.yml
+++ b/.github/workflows/chromeos-5.15-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.15

--- a/.github/workflows/chromeos-5.15-clang-16.yml
+++ b/.github/workflows/chromeos-5.15-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.15

--- a/.github/workflows/chromeos-5.15-clang-17.yml
+++ b/.github/workflows/chromeos-5.15-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.15

--- a/.github/workflows/chromeos-5.15-clang-18.yml
+++ b/.github/workflows/chromeos-5.15-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.15

--- a/.github/workflows/chromeos-6.1-clang-12.yml
+++ b/.github/workflows/chromeos-6.1-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.1

--- a/.github/workflows/chromeos-6.1-clang-13.yml
+++ b/.github/workflows/chromeos-6.1-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.1

--- a/.github/workflows/chromeos-6.1-clang-14.yml
+++ b/.github/workflows/chromeos-6.1-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.1

--- a/.github/workflows/chromeos-6.1-clang-15.yml
+++ b/.github/workflows/chromeos-6.1-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.1

--- a/.github/workflows/chromeos-6.1-clang-16.yml
+++ b/.github/workflows/chromeos-6.1-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.1

--- a/.github/workflows/chromeos-6.1-clang-17.yml
+++ b/.github/workflows/chromeos-6.1-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.1

--- a/.github/workflows/chromeos-6.1-clang-18.yml
+++ b/.github/workflows/chromeos-6.1-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.1

--- a/.github/workflows/chromeos-6.6-clang-12.yml
+++ b/.github/workflows/chromeos-6.6-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.6

--- a/.github/workflows/chromeos-6.6-clang-13.yml
+++ b/.github/workflows/chromeos-6.6-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.6

--- a/.github/workflows/chromeos-6.6-clang-14.yml
+++ b/.github/workflows/chromeos-6.6-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.6

--- a/.github/workflows/chromeos-6.6-clang-15.yml
+++ b/.github/workflows/chromeos-6.6-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.6

--- a/.github/workflows/chromeos-6.6-clang-16.yml
+++ b/.github/workflows/chromeos-6.6-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.6

--- a/.github/workflows/chromeos-6.6-clang-17.yml
+++ b/.github/workflows/chromeos-6.6-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.6

--- a/.github/workflows/chromeos-6.6-clang-18.yml
+++ b/.github/workflows/chromeos-6.6-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.6

--- a/.github/workflows/mainline-clang-12.yml
+++ b/.github/workflows/mainline-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
       GIT_REF: master

--- a/.github/workflows/mainline-clang-13.yml
+++ b/.github/workflows/mainline-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
       GIT_REF: master

--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
       GIT_REF: master

--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
       GIT_REF: master

--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
       GIT_REF: master

--- a/.github/workflows/mainline-clang-17.yml
+++ b/.github/workflows/mainline-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
       GIT_REF: master

--- a/.github/workflows/mainline-clang-18.yml
+++ b/.github/workflows/mainline-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
       GIT_REF: master

--- a/.github/workflows/next-clang-13.yml
+++ b/.github/workflows/next-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
       GIT_REF: master

--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
       GIT_REF: master

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
       GIT_REF: master

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
       GIT_REF: master

--- a/.github/workflows/next-clang-17.yml
+++ b/.github/workflows/next-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
       GIT_REF: master

--- a/.github/workflows/next-clang-18.yml
+++ b/.github/workflows/next-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
       GIT_REF: master

--- a/.github/workflows/next-clang-android.yml
+++ b/.github/workflows/next-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-android
+    container: tuxmake/x86_64_korg-clang-android
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
       GIT_REF: master

--- a/.github/workflows/stable-clang-11.yml
+++ b/.github/workflows/stable-clang-11.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-11
+    container: tuxmake/x86_64_korg-clang-11
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.7.y

--- a/.github/workflows/stable-clang-12.yml
+++ b/.github/workflows/stable-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.7.y

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.7.y

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.7.y

--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.7.y

--- a/.github/workflows/stable-clang-16.yml
+++ b/.github/workflows/stable-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.7.y

--- a/.github/workflows/stable-clang-17.yml
+++ b/.github/workflows/stable-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.7.y

--- a/.github/workflows/stable-clang-18.yml
+++ b/.github/workflows/stable-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.7.y

--- a/.github/workflows/tip-clang-12.yml
+++ b/.github/workflows/tip-clang-12.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-12
+    container: tuxmake/x86_64_korg-clang-12
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
       GIT_REF: master

--- a/.github/workflows/tip-clang-13.yml
+++ b/.github/workflows/tip-clang-13.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-13
+    container: tuxmake/x86_64_korg-clang-13
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
       GIT_REF: master

--- a/.github/workflows/tip-clang-14.yml
+++ b/.github/workflows/tip-clang-14.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-14
+    container: tuxmake/x86_64_korg-clang-14
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
       GIT_REF: master

--- a/.github/workflows/tip-clang-15.yml
+++ b/.github/workflows/tip-clang-15.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-15
+    container: tuxmake/x86_64_korg-clang-15
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
       GIT_REF: master

--- a/.github/workflows/tip-clang-16.yml
+++ b/.github/workflows/tip-clang-16.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-16
+    container: tuxmake/x86_64_korg-clang-16
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
       GIT_REF: master

--- a/.github/workflows/tip-clang-17.yml
+++ b/.github/workflows/tip-clang-17.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-17
+    container: tuxmake/x86_64_korg-clang-17
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
       GIT_REF: master

--- a/.github/workflows/tip-clang-18.yml
+++ b/.github/workflows/tip-clang-18.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_clang-18
+    container: tuxmake/x86_64_korg-clang-18
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
       GIT_REF: master

--- a/generator/generate_tuxsuite.py
+++ b/generator/generate_tuxsuite.py
@@ -73,11 +73,15 @@ def emit_tuxsuite_yml(config, tree, llvm_version):
                build["llvm_version"] == llvm_version:
                 arch = build.get("ARCH", "x86_64")
                 if llvm_version == max_version:
-                    toolchain = "clang-nightly"
+                    tuxsuite_toolchain = "clang-nightly"
+                else:
+                    # We want to use the kernel.org LLVM builds for speed but
+                    # we don't want korg everywhere
+                    tuxsuite_toolchain = f"korg-{toolchain}"
 
                 current_build = {
                     "target_arch": arch,
-                    "toolchain": toolchain,
+                    "toolchain": tuxsuite_toolchain,
                     "kconfig": build["config"],
                     "targets": build["targets"]
                 }

--- a/generator/generate_workflow.py
+++ b/generator/generate_workflow.py
@@ -92,6 +92,8 @@ def check_cache_job_setup(repo, ref, toolchain):
     last_part = toolchain.split("-")[-1]
     if last_part == llvm_tot_version:
         toolchain = "clang-nightly"
+    else:
+        toolchain = f"korg-clang-{last_part}"
 
     return {
         "check_cache": {

--- a/tuxsuite/4.19-clang-13.tux.yml
+++ b/tuxsuite/4.19-clang-13.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -48,7 +48,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel

--- a/tuxsuite/4.19-clang-14.tux.yml
+++ b/tuxsuite/4.19-clang-14.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -48,7 +48,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel

--- a/tuxsuite/4.19-clang-15.tux.yml
+++ b/tuxsuite/4.19-clang-15.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -58,7 +58,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel

--- a/tuxsuite/4.19-clang-16.tux.yml
+++ b/tuxsuite/4.19-clang-16.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -58,7 +58,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel

--- a/tuxsuite/4.19-clang-17.tux.yml
+++ b/tuxsuite/4.19-clang-17.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -58,7 +58,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel

--- a/tuxsuite/4.19-clang-18.tux.yml
+++ b/tuxsuite/4.19-clang-18.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -58,7 +58,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel

--- a/tuxsuite/5.10-clang-11.tux.yml
+++ b/tuxsuite/5.10-clang-11.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -79,7 +79,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: mips
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -90,7 +90,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -99,7 +99,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_EFI=n
@@ -111,7 +111,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -121,7 +121,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -131,7 +131,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allnoconfig
     targets:
     - default
@@ -139,7 +139,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -149,7 +149,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allmodconfig
     targets:
     - default
@@ -157,7 +157,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allnoconfig
     targets:
     - default
@@ -165,7 +165,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allyesconfig
     targets:
     - default
@@ -173,7 +173,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allmodconfig
     targets:
     - default
@@ -181,7 +181,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allnoconfig
     targets:
     - default
@@ -189,7 +189,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/5.10-clang-12.tux.yml
+++ b/tuxsuite/5.10-clang-12.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -79,7 +79,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: mips
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -90,7 +90,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -99,7 +99,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -109,7 +109,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -118,7 +118,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_EFI=n
@@ -130,7 +130,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -140,7 +140,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -150,7 +150,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -158,7 +158,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -168,7 +168,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allmodconfig
     targets:
     - default
@@ -176,7 +176,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -184,7 +184,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allyesconfig
     targets:
     - default
@@ -192,7 +192,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allmodconfig
     targets:
     - default
@@ -200,7 +200,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -208,7 +208,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/5.10-clang-13.tux.yml
+++ b/tuxsuite/5.10-clang-13.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -78,7 +78,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: mips
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -89,7 +89,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -98,7 +98,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -108,7 +108,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -117,7 +117,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -127,14 +127,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -144,7 +144,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -154,7 +154,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -162,7 +162,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -172,7 +172,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allmodconfig
     targets:
     - default
@@ -180,7 +180,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -188,7 +188,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allyesconfig
     targets:
     - default
@@ -196,7 +196,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allmodconfig
     targets:
     - default
@@ -204,7 +204,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -212,7 +212,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/5.10-clang-14.tux.yml
+++ b/tuxsuite/5.10-clang-14.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -78,7 +78,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: mips
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -89,7 +89,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -98,7 +98,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -108,7 +108,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -117,7 +117,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -127,14 +127,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -144,7 +144,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -154,7 +154,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -162,7 +162,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -172,7 +172,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allmodconfig
     targets:
     - default
@@ -180,7 +180,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -188,7 +188,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allyesconfig
     targets:
     - default
@@ -196,7 +196,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allmodconfig
     targets:
     - default
@@ -204,7 +204,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -212,7 +212,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/5.10-clang-15.tux.yml
+++ b/tuxsuite/5.10-clang-15.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -68,7 +68,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -76,7 +76,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -88,7 +88,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: mips
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -99,7 +99,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -108,7 +108,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -118,7 +118,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -127,7 +127,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -137,14 +137,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -154,7 +154,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -172,7 +172,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allmodconfig
     targets:
     - default
@@ -190,7 +190,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -198,7 +198,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allyesconfig
     targets:
     - default
@@ -206,7 +206,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allmodconfig
     targets:
     - default
@@ -214,7 +214,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/5.10-clang-16.tux.yml
+++ b/tuxsuite/5.10-clang-16.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -68,7 +68,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -76,7 +76,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -88,7 +88,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: mips
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -99,7 +99,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -108,7 +108,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -118,7 +118,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -127,7 +127,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -137,14 +137,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -154,7 +154,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -172,7 +172,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allmodconfig
     targets:
     - default
@@ -190,7 +190,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -198,7 +198,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allyesconfig
     targets:
     - default
@@ -206,7 +206,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allmodconfig
     targets:
     - default
@@ -214,7 +214,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/5.10-clang-17.tux.yml
+++ b/tuxsuite/5.10-clang-17.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -68,7 +68,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -76,7 +76,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -88,7 +88,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: mips
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -99,7 +99,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -108,7 +108,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -118,7 +118,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -127,7 +127,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -137,14 +137,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -154,7 +154,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -172,7 +172,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allmodconfig
     targets:
     - default
@@ -190,7 +190,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -198,7 +198,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allyesconfig
     targets:
     - default
@@ -206,7 +206,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allmodconfig
     targets:
     - default
@@ -214,7 +214,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/5.10-clang-18.tux.yml
+++ b/tuxsuite/5.10-clang-18.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -68,7 +68,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -76,7 +76,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -88,7 +88,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: mips
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -99,7 +99,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -108,7 +108,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -118,7 +118,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -127,7 +127,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -137,14 +137,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -154,7 +154,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -172,7 +172,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -190,7 +190,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -198,7 +198,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allyesconfig
     targets:
     - default
@@ -206,7 +206,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -214,7 +214,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/5.15-clang-11.tux.yml
+++ b/tuxsuite/5.15-clang-11.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -119,7 +119,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -133,7 +133,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - default
@@ -151,7 +151,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -159,7 +159,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -172,7 +172,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: mips
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -183,7 +183,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -193,7 +193,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -210,7 +210,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -220,7 +220,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -230,7 +230,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -243,7 +243,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -255,7 +255,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -267,7 +267,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -275,7 +275,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -283,7 +283,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -291,7 +291,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -301,7 +301,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -311,7 +311,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -319,7 +319,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -329,7 +329,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -337,7 +337,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -346,7 +346,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -355,7 +355,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -363,7 +363,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -371,7 +371,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -379,7 +379,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -389,7 +389,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -399,7 +399,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allnoconfig
     targets:
     - default
@@ -407,7 +407,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -417,7 +417,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allmodconfig
     targets:
     - default
@@ -425,7 +425,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -437,7 +437,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allnoconfig
     targets:
     - default
@@ -445,7 +445,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allyesconfig
     targets:
     - default
@@ -453,7 +453,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -464,7 +464,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allmodconfig
     targets:
     - default
@@ -472,7 +472,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -484,7 +484,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allnoconfig
     targets:
     - default
@@ -492,7 +492,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/5.15-clang-12.tux.yml
+++ b/tuxsuite/5.15-clang-12.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -116,7 +116,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -130,7 +130,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -144,7 +144,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -154,7 +154,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - default
@@ -162,7 +162,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -170,7 +170,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -183,7 +183,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -194,7 +194,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -203,7 +203,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -213,7 +213,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -231,7 +231,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -239,7 +239,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -249,7 +249,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -259,7 +259,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -272,7 +272,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -284,7 +284,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -296,7 +296,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -304,7 +304,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -312,7 +312,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -320,7 +320,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -330,7 +330,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -340,7 +340,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -348,7 +348,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -358,7 +358,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -366,7 +366,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -375,7 +375,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -384,7 +384,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -392,7 +392,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -400,7 +400,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -408,7 +408,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -418,7 +418,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -428,7 +428,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -436,7 +436,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -446,7 +446,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allmodconfig
     targets:
     - default
@@ -454,7 +454,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -466,7 +466,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -474,7 +474,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allyesconfig
     targets:
     - default
@@ -482,7 +482,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -493,7 +493,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allmodconfig
     targets:
     - default
@@ -501,7 +501,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -513,7 +513,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -521,7 +521,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/5.15-clang-13.tux.yml
+++ b/tuxsuite/5.15-clang-13.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -116,7 +116,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -130,7 +130,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -144,7 +144,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -154,7 +154,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - default
@@ -162,7 +162,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -170,7 +170,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -193,7 +193,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -212,7 +212,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -221,7 +221,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -230,14 +230,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 0
   - target_arch: s390
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -249,7 +249,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -257,7 +257,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -267,7 +267,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -277,7 +277,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -290,7 +290,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -302,7 +302,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -314,7 +314,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -322,7 +322,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -330,7 +330,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -338,7 +338,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -348,7 +348,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -358,7 +358,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -366,7 +366,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -376,7 +376,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -384,7 +384,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -393,7 +393,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -402,7 +402,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -411,14 +411,14 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: s390
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -426,7 +426,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -434,7 +434,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -442,7 +442,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -452,7 +452,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -462,7 +462,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -470,7 +470,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -480,7 +480,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allmodconfig
     targets:
     - default
@@ -488,7 +488,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -500,7 +500,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -508,7 +508,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allyesconfig
     targets:
     - default
@@ -516,7 +516,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -526,7 +526,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -537,7 +537,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allmodconfig
     targets:
     - default
@@ -545,7 +545,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -557,7 +557,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -565,7 +565,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/5.15-clang-14.tux.yml
+++ b/tuxsuite/5.15-clang-14.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -116,7 +116,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -130,7 +130,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -144,7 +144,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -154,7 +154,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - default
@@ -162,7 +162,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -170,7 +170,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -193,7 +193,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -212,7 +212,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -221,7 +221,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -230,14 +230,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 0
   - target_arch: s390
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -249,7 +249,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -257,7 +257,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -267,7 +267,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -277,7 +277,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -290,7 +290,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -302,7 +302,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -314,7 +314,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -322,7 +322,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -330,7 +330,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -338,7 +338,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -348,7 +348,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -358,7 +358,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -366,7 +366,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -376,7 +376,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -384,7 +384,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -393,7 +393,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -402,7 +402,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -411,14 +411,14 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: s390
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -426,7 +426,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -434,7 +434,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -442,7 +442,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -452,7 +452,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -462,7 +462,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -470,7 +470,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -480,7 +480,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allmodconfig
     targets:
     - default
@@ -488,7 +488,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -500,7 +500,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -508,7 +508,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allyesconfig
     targets:
     - default
@@ -516,7 +516,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -526,7 +526,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -537,7 +537,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allmodconfig
     targets:
     - default
@@ -545,7 +545,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -557,7 +557,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -565,7 +565,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/5.15-clang-15.tux.yml
+++ b/tuxsuite/5.15-clang-15.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -126,7 +126,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -140,7 +140,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -154,7 +154,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - default
@@ -172,7 +172,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -180,7 +180,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -192,7 +192,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -203,7 +203,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -212,7 +212,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -231,7 +231,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -240,14 +240,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 0
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -259,7 +259,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -267,7 +267,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -277,7 +277,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -287,7 +287,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -300,7 +300,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -312,7 +312,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -324,7 +324,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -332,7 +332,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -340,7 +340,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -348,7 +348,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -358,7 +358,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -368,7 +368,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -376,7 +376,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -386,7 +386,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -394,7 +394,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -403,7 +403,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -412,7 +412,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -421,14 +421,14 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -436,7 +436,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -444,7 +444,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -452,7 +452,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -462,7 +462,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -472,7 +472,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -480,7 +480,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -490,7 +490,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allmodconfig
     targets:
     - default
@@ -498,7 +498,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -510,7 +510,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -518,7 +518,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allyesconfig
     targets:
     - default
@@ -526,7 +526,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -536,7 +536,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -547,7 +547,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allmodconfig
     targets:
     - default
@@ -555,7 +555,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -567,7 +567,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -575,7 +575,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/5.15-clang-16.tux.yml
+++ b/tuxsuite/5.15-clang-16.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -126,7 +126,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -140,7 +140,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -154,7 +154,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - default
@@ -172,7 +172,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -180,7 +180,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -192,7 +192,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -203,7 +203,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -212,7 +212,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -231,7 +231,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -240,14 +240,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 0
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -259,7 +259,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -267,7 +267,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -277,7 +277,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -287,7 +287,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -300,7 +300,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -312,7 +312,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -324,7 +324,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -332,7 +332,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -340,7 +340,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -348,7 +348,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -358,7 +358,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -368,7 +368,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -376,7 +376,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -386,7 +386,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -394,7 +394,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -403,7 +403,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -412,7 +412,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -421,14 +421,14 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -436,7 +436,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -444,7 +444,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -452,7 +452,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -462,7 +462,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -472,7 +472,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -480,7 +480,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -490,7 +490,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allmodconfig
     targets:
     - default
@@ -498,7 +498,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -510,7 +510,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -518,7 +518,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allyesconfig
     targets:
     - default
@@ -526,7 +526,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -536,7 +536,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -547,7 +547,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allmodconfig
     targets:
     - default
@@ -555,7 +555,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -567,7 +567,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -575,7 +575,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/5.15-clang-17.tux.yml
+++ b/tuxsuite/5.15-clang-17.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -126,7 +126,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -140,7 +140,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -154,7 +154,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - default
@@ -172,7 +172,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -180,7 +180,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -192,7 +192,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -203,7 +203,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -212,7 +212,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -231,7 +231,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -240,14 +240,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 0
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -259,7 +259,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -267,7 +267,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -277,7 +277,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -287,7 +287,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -300,7 +300,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -312,7 +312,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -324,7 +324,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -332,7 +332,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -340,7 +340,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -348,7 +348,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -358,7 +358,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -368,7 +368,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -376,7 +376,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -386,7 +386,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -394,7 +394,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -403,7 +403,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -412,7 +412,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -421,14 +421,14 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -436,7 +436,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -444,7 +444,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -452,7 +452,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -462,7 +462,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -472,7 +472,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -480,7 +480,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -490,7 +490,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allmodconfig
     targets:
     - default
@@ -498,7 +498,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -510,7 +510,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -518,7 +518,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allyesconfig
     targets:
     - default
@@ -526,7 +526,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -536,7 +536,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -547,7 +547,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allmodconfig
     targets:
     - default
@@ -555,7 +555,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -567,7 +567,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -575,7 +575,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/5.15-clang-18.tux.yml
+++ b/tuxsuite/5.15-clang-18.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -126,7 +126,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -140,7 +140,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -154,7 +154,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - default
@@ -172,7 +172,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -180,7 +180,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -192,7 +192,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -203,7 +203,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -212,7 +212,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -231,7 +231,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -240,14 +240,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 0
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -259,7 +259,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -267,7 +267,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -277,7 +277,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -287,7 +287,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -300,7 +300,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -312,7 +312,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -324,7 +324,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -332,7 +332,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -340,7 +340,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -348,7 +348,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -358,7 +358,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -368,7 +368,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -376,7 +376,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -386,7 +386,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -394,7 +394,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -403,7 +403,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -412,7 +412,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     - CONFIG_BPF_PRELOAD=n
@@ -421,14 +421,14 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -436,7 +436,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -444,7 +444,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -452,7 +452,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -462,7 +462,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -472,7 +472,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -480,7 +480,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -490,7 +490,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -498,7 +498,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -510,7 +510,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -518,7 +518,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allyesconfig
     targets:
     - default
@@ -526,7 +526,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -536,7 +536,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -547,7 +547,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -555,7 +555,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -567,7 +567,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -575,7 +575,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/5.4-clang-13.tux.yml
+++ b/tuxsuite/5.4-clang-13.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_COMPAT_VDSO=n
@@ -42,7 +42,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -54,7 +54,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: mips
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -65,7 +65,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -74,7 +74,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -84,7 +84,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -93,7 +93,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -103,7 +103,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allmodconfig
     targets:
     - default

--- a/tuxsuite/5.4-clang-14.tux.yml
+++ b/tuxsuite/5.4-clang-14.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_COMPAT_VDSO=n
@@ -42,7 +42,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -54,7 +54,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: mips
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -65,7 +65,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -74,7 +74,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -84,7 +84,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -93,7 +93,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -103,7 +103,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allmodconfig
     targets:
     - default

--- a/tuxsuite/5.4-clang-15.tux.yml
+++ b/tuxsuite/5.4-clang-15.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_COMPAT_VDSO=n
@@ -42,7 +42,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -52,7 +52,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -64,7 +64,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: mips
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -75,7 +75,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -84,7 +84,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -94,7 +94,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -103,7 +103,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -113,7 +113,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allmodconfig
     targets:
     - default

--- a/tuxsuite/5.4-clang-16.tux.yml
+++ b/tuxsuite/5.4-clang-16.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_COMPAT_VDSO=n
@@ -42,7 +42,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -52,7 +52,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -64,7 +64,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: mips
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -75,7 +75,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -84,7 +84,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -94,7 +94,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -103,7 +103,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -113,7 +113,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allmodconfig
     targets:
     - default

--- a/tuxsuite/5.4-clang-17.tux.yml
+++ b/tuxsuite/5.4-clang-17.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_COMPAT_VDSO=n
@@ -42,7 +42,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -52,7 +52,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -64,7 +64,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: mips
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -75,7 +75,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -84,7 +84,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -94,7 +94,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -103,7 +103,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -113,7 +113,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allmodconfig
     targets:
     - default

--- a/tuxsuite/5.4-clang-18.tux.yml
+++ b/tuxsuite/5.4-clang-18.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_COMPAT_VDSO=n
@@ -42,7 +42,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -52,7 +52,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -64,7 +64,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: mips
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -75,7 +75,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -84,7 +84,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -94,7 +94,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -103,7 +103,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -113,7 +113,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default

--- a/tuxsuite/6.1-clang-11.tux.yml
+++ b/tuxsuite/6.1-clang-11.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -119,7 +119,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -133,7 +133,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - default
@@ -151,7 +151,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -159,7 +159,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -172,7 +172,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: mips
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -183,7 +183,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -193,7 +193,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: um
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -210,7 +210,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -218,7 +218,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -228,7 +228,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -238,7 +238,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -251,7 +251,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -263,7 +263,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -275,7 +275,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -283,7 +283,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -291,7 +291,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -299,7 +299,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -307,7 +307,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -317,7 +317,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -325,7 +325,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -333,7 +333,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -341,7 +341,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -350,7 +350,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -359,7 +359,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -367,7 +367,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -375,7 +375,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -383,7 +383,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -393,7 +393,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -403,7 +403,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allnoconfig
     targets:
     - default
@@ -411,7 +411,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allmodconfig
     targets:
     - default
@@ -419,7 +419,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -431,7 +431,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allnoconfig
     targets:
     - default
@@ -439,7 +439,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allyesconfig
     targets:
     - default
@@ -447,7 +447,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -458,7 +458,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allmodconfig
     targets:
     - default
@@ -466,7 +466,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -478,7 +478,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allnoconfig
     targets:
     - default
@@ -486,7 +486,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/6.1-clang-12.tux.yml
+++ b/tuxsuite/6.1-clang-12.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -119,7 +119,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -133,7 +133,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - default
@@ -151,7 +151,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -159,7 +159,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -172,7 +172,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -183,7 +183,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - ppc64_guest_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
@@ -195,7 +195,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -204,7 +204,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -213,7 +213,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: um
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -221,7 +221,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -229,7 +229,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -239,7 +239,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -249,7 +249,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -262,7 +262,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -274,7 +274,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -286,7 +286,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -294,7 +294,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -302,7 +302,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -310,7 +310,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -318,7 +318,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -328,7 +328,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -336,7 +336,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -344,7 +344,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -352,7 +352,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -361,7 +361,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -370,7 +370,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -378,7 +378,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -386,7 +386,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -394,7 +394,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -404,7 +404,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -414,7 +414,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -422,7 +422,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allmodconfig
     targets:
     - default
@@ -430,7 +430,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -442,7 +442,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -450,7 +450,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allyesconfig
     targets:
     - default
@@ -458,7 +458,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -469,7 +469,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allmodconfig
     targets:
     - default
@@ -477,7 +477,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -489,7 +489,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -497,7 +497,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/6.1-clang-13.tux.yml
+++ b/tuxsuite/6.1-clang-13.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -119,7 +119,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -133,7 +133,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - default
@@ -151,7 +151,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -159,7 +159,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -171,7 +171,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - ppc64_guest_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
@@ -194,7 +194,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -203,7 +203,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -212,7 +212,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -220,7 +220,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -228,7 +228,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -238,7 +238,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -248,7 +248,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -261,7 +261,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -273,7 +273,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -285,7 +285,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -293,7 +293,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -301,7 +301,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -309,7 +309,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -317,7 +317,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -327,7 +327,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -335,7 +335,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -343,7 +343,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -351,7 +351,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -360,7 +360,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -369,7 +369,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -377,7 +377,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -385,7 +385,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -393,7 +393,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -403,7 +403,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -413,7 +413,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -421,7 +421,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -431,7 +431,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allmodconfig
     targets:
     - default
@@ -439,7 +439,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -451,7 +451,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -459,7 +459,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allyesconfig
     targets:
     - default
@@ -467,7 +467,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -477,7 +477,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -488,7 +488,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allmodconfig
     targets:
     - default
@@ -496,7 +496,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -508,7 +508,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -516,7 +516,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/6.1-clang-14.tux.yml
+++ b/tuxsuite/6.1-clang-14.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -119,7 +119,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -133,7 +133,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - default
@@ -151,7 +151,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -159,7 +159,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -171,7 +171,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -192,7 +192,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -201,7 +201,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -210,7 +210,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -218,7 +218,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -226,7 +226,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -236,7 +236,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -246,7 +246,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -259,7 +259,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -271,7 +271,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -283,7 +283,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -291,7 +291,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -299,7 +299,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -307,7 +307,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -315,7 +315,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -325,7 +325,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -333,7 +333,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -342,7 +342,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -351,7 +351,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -360,7 +360,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -369,7 +369,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -377,7 +377,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -385,7 +385,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -393,7 +393,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -403,7 +403,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -413,7 +413,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -421,7 +421,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -431,7 +431,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allmodconfig
     targets:
     - default
@@ -439,7 +439,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -451,7 +451,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -459,7 +459,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allyesconfig
     targets:
     - default
@@ -467,7 +467,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -477,7 +477,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -488,7 +488,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allmodconfig
     targets:
     - default
@@ -496,7 +496,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -508,7 +508,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -516,7 +516,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/6.1-clang-15.tux.yml
+++ b/tuxsuite/6.1-clang-15.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -129,7 +129,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -153,7 +153,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - default
@@ -161,7 +161,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -169,7 +169,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -181,7 +181,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -192,7 +192,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -211,7 +211,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -220,14 +220,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -239,7 +239,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -247,7 +247,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -255,7 +255,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -265,7 +265,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -275,7 +275,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -288,7 +288,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -300,7 +300,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -312,7 +312,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -320,7 +320,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -328,7 +328,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -336,7 +336,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -344,7 +344,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -354,7 +354,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -362,7 +362,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -371,7 +371,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -380,7 +380,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -389,7 +389,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -398,21 +398,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -420,7 +420,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -428,7 +428,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -436,7 +436,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -446,7 +446,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -456,7 +456,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -464,7 +464,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -474,7 +474,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allmodconfig
     targets:
     - default
@@ -482,7 +482,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -494,7 +494,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -502,7 +502,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allyesconfig
     targets:
     - default
@@ -510,7 +510,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -520,7 +520,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -531,7 +531,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allmodconfig
     targets:
     - default
@@ -539,7 +539,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -551,7 +551,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -559,7 +559,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/6.1-clang-16.tux.yml
+++ b/tuxsuite/6.1-clang-16.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -125,7 +125,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -136,7 +136,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -150,7 +150,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -174,7 +174,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - default
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -190,7 +190,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -213,7 +213,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -232,7 +232,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -241,7 +241,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -250,14 +250,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -269,7 +269,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -277,7 +277,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -285,7 +285,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -295,7 +295,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -305,7 +305,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -315,7 +315,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -326,7 +326,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -339,7 +339,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -351,7 +351,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -363,7 +363,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -371,7 +371,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -379,7 +379,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -387,7 +387,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -395,7 +395,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -405,7 +405,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -413,7 +413,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -422,7 +422,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -431,7 +431,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -440,7 +440,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -449,21 +449,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -471,7 +471,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -479,7 +479,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -487,7 +487,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -497,7 +497,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -507,7 +507,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -515,7 +515,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -525,7 +525,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allmodconfig
     targets:
     - default
@@ -533,7 +533,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -545,7 +545,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -553,7 +553,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allyesconfig
     targets:
     - default
@@ -561,7 +561,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -571,7 +571,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -582,7 +582,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allmodconfig
     targets:
     - default
@@ -590,7 +590,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -602,7 +602,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -610,7 +610,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/6.1-clang-17.tux.yml
+++ b/tuxsuite/6.1-clang-17.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -125,7 +125,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -136,7 +136,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -150,7 +150,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -174,7 +174,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - default
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -190,7 +190,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -213,7 +213,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -232,7 +232,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -241,7 +241,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -250,14 +250,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -269,7 +269,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -277,7 +277,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -285,7 +285,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -295,7 +295,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -305,7 +305,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -315,7 +315,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -326,7 +326,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -339,7 +339,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -351,7 +351,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -363,7 +363,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -371,7 +371,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -379,7 +379,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -387,7 +387,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -395,7 +395,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -405,7 +405,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -413,7 +413,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -422,7 +422,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -431,7 +431,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -440,7 +440,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -449,21 +449,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -471,7 +471,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -479,7 +479,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -487,7 +487,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -497,7 +497,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -507,7 +507,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -515,7 +515,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -525,7 +525,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allmodconfig
     targets:
     - default
@@ -533,7 +533,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -545,7 +545,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -553,7 +553,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allyesconfig
     targets:
     - default
@@ -561,7 +561,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -571,7 +571,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -582,7 +582,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allmodconfig
     targets:
     - default
@@ -590,7 +590,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -602,7 +602,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -610,7 +610,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/6.1-clang-18.tux.yml
+++ b/tuxsuite/6.1-clang-18.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -125,7 +125,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -136,7 +136,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -150,7 +150,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -174,7 +174,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - default
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -190,7 +190,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -213,7 +213,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -232,7 +232,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -241,7 +241,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -250,14 +250,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -269,7 +269,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -277,7 +277,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -285,7 +285,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -295,7 +295,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -305,7 +305,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -315,7 +315,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -326,7 +326,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -339,7 +339,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -351,7 +351,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -363,7 +363,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -371,7 +371,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -379,7 +379,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -387,7 +387,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -395,7 +395,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -405,7 +405,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -413,7 +413,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -422,7 +422,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -431,7 +431,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -440,7 +440,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -449,21 +449,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -471,7 +471,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -479,7 +479,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -487,7 +487,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -497,7 +497,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -507,7 +507,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -515,7 +515,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -525,7 +525,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -533,7 +533,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -545,7 +545,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -553,7 +553,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allyesconfig
     targets:
     - default
@@ -561,7 +561,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -571,7 +571,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -582,7 +582,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -590,7 +590,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -602,7 +602,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -610,7 +610,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/6.6-clang-11.tux.yml
+++ b/tuxsuite/6.6-clang-11.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -119,7 +119,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -133,7 +133,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - default
@@ -151,7 +151,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -159,7 +159,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -172,7 +172,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: mips
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -183,7 +183,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -193,7 +193,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: um
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -210,7 +210,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -218,7 +218,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -228,7 +228,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -238,7 +238,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -251,7 +251,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -263,7 +263,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -275,7 +275,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -283,7 +283,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -291,7 +291,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -299,7 +299,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -307,7 +307,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -317,7 +317,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -325,7 +325,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -333,7 +333,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -341,7 +341,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -350,7 +350,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -359,7 +359,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -367,7 +367,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -375,7 +375,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -383,7 +383,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -393,7 +393,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -403,7 +403,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allnoconfig
     targets:
     - default
@@ -411,7 +411,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allmodconfig
     targets:
     - default
@@ -419,7 +419,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -431,7 +431,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allnoconfig
     targets:
     - default
@@ -439,7 +439,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allyesconfig
     targets:
     - default
@@ -447,7 +447,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -458,7 +458,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allmodconfig
     targets:
     - default
@@ -466,7 +466,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -478,7 +478,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allnoconfig
     targets:
     - default
@@ -486,7 +486,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/6.6-clang-12.tux.yml
+++ b/tuxsuite/6.6-clang-12.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -119,7 +119,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -133,7 +133,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - default
@@ -151,7 +151,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -159,7 +159,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -172,7 +172,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -183,7 +183,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - ppc64_guest_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
@@ -194,7 +194,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -203,7 +203,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -212,7 +212,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: um
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -220,7 +220,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -228,7 +228,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -238,7 +238,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -248,7 +248,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -261,7 +261,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -273,7 +273,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -285,7 +285,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -293,7 +293,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -301,7 +301,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -309,7 +309,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -317,7 +317,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -327,7 +327,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -335,7 +335,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -343,7 +343,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -351,7 +351,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -360,7 +360,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -369,7 +369,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -377,7 +377,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -385,7 +385,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -393,7 +393,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -403,7 +403,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -413,7 +413,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -421,7 +421,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allmodconfig
     targets:
     - default
@@ -429,7 +429,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -441,7 +441,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -449,7 +449,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allyesconfig
     targets:
     - default
@@ -457,7 +457,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -468,7 +468,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allmodconfig
     targets:
     - default
@@ -476,7 +476,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -488,7 +488,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -496,7 +496,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/6.6-clang-13.tux.yml
+++ b/tuxsuite/6.6-clang-13.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -119,7 +119,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -133,7 +133,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - default
@@ -151,7 +151,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -159,7 +159,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -171,7 +171,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - ppc64_guest_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
@@ -193,7 +193,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -211,7 +211,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -219,7 +219,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -227,7 +227,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -237,7 +237,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -247,7 +247,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -260,7 +260,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -272,7 +272,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -284,7 +284,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -292,7 +292,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -300,7 +300,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -308,7 +308,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -316,7 +316,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -326,7 +326,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -334,7 +334,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -342,7 +342,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -350,7 +350,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -359,7 +359,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -368,7 +368,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -376,7 +376,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -384,7 +384,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -392,7 +392,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -402,7 +402,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -412,7 +412,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -420,7 +420,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -430,7 +430,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allmodconfig
     targets:
     - default
@@ -438,7 +438,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -450,7 +450,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -458,7 +458,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allyesconfig
     targets:
     - default
@@ -466,7 +466,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -476,7 +476,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -487,7 +487,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allmodconfig
     targets:
     - default
@@ -495,7 +495,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -507,7 +507,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -515,7 +515,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/6.6-clang-14.tux.yml
+++ b/tuxsuite/6.6-clang-14.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -119,7 +119,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -133,7 +133,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - default
@@ -151,7 +151,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -159,7 +159,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -171,7 +171,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -191,7 +191,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -200,7 +200,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -209,7 +209,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -217,7 +217,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -225,7 +225,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -235,7 +235,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -245,7 +245,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -258,7 +258,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -270,7 +270,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -282,7 +282,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -290,7 +290,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -298,7 +298,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -306,7 +306,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -314,7 +314,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -324,7 +324,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -332,7 +332,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -341,7 +341,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -350,7 +350,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -359,7 +359,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -368,7 +368,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -376,7 +376,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -384,7 +384,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -392,7 +392,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -402,7 +402,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -412,7 +412,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -420,7 +420,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -430,7 +430,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allmodconfig
     targets:
     - default
@@ -438,7 +438,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -450,7 +450,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -458,7 +458,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allyesconfig
     targets:
     - default
@@ -466,7 +466,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -476,7 +476,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -487,7 +487,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allmodconfig
     targets:
     - default
@@ -495,7 +495,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -507,7 +507,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -515,7 +515,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/6.6-clang-15.tux.yml
+++ b/tuxsuite/6.6-clang-15.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -129,7 +129,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -153,7 +153,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - default
@@ -161,7 +161,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -169,7 +169,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -181,7 +181,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -192,7 +192,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -201,7 +201,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -210,7 +210,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -219,14 +219,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -238,7 +238,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -246,7 +246,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -254,7 +254,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -264,7 +264,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -274,7 +274,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -287,7 +287,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -299,7 +299,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -311,7 +311,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -319,7 +319,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -327,7 +327,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -335,7 +335,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -343,7 +343,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -353,7 +353,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -361,7 +361,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -370,7 +370,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -379,7 +379,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -388,7 +388,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -397,21 +397,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -419,7 +419,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -427,7 +427,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -435,7 +435,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -445,7 +445,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -455,7 +455,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -463,7 +463,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -473,7 +473,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allmodconfig
     targets:
     - default
@@ -481,7 +481,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -493,7 +493,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -501,7 +501,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allyesconfig
     targets:
     - default
@@ -509,7 +509,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -519,7 +519,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
@@ -530,7 +530,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -541,7 +541,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allmodconfig
     targets:
     - default
@@ -549,7 +549,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -561,7 +561,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -569,7 +569,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/6.6-clang-16.tux.yml
+++ b/tuxsuite/6.6-clang-16.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -125,7 +125,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -136,7 +136,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -150,7 +150,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -174,7 +174,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - default
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -190,7 +190,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -213,7 +213,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -231,7 +231,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -240,7 +240,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -249,14 +249,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -268,7 +268,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -276,7 +276,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -284,7 +284,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -294,7 +294,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -304,7 +304,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -314,7 +314,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -325,7 +325,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -338,7 +338,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -350,7 +350,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -362,7 +362,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -370,7 +370,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -378,7 +378,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -386,7 +386,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -394,7 +394,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -404,7 +404,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -412,7 +412,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -421,7 +421,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -430,7 +430,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -439,7 +439,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -448,21 +448,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -470,7 +470,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -478,7 +478,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -486,7 +486,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -496,7 +496,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -506,7 +506,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -514,7 +514,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -524,7 +524,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allmodconfig
     targets:
     - default
@@ -532,7 +532,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -544,7 +544,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -552,7 +552,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allyesconfig
     targets:
     - default
@@ -560,7 +560,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: virtconfig
     targets:
     - kernel
@@ -568,7 +568,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -578,7 +578,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
@@ -589,7 +589,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -600,7 +600,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allmodconfig
     targets:
     - default
@@ -608,7 +608,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -620,7 +620,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -628,7 +628,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/6.6-clang-17.tux.yml
+++ b/tuxsuite/6.6-clang-17.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -125,7 +125,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -136,7 +136,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -150,7 +150,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -174,7 +174,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - default
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -190,7 +190,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -213,7 +213,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -231,7 +231,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -240,7 +240,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -249,14 +249,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -268,7 +268,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -276,7 +276,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -284,7 +284,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -294,7 +294,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -304,7 +304,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -314,7 +314,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -325,7 +325,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -338,7 +338,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -350,7 +350,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -362,7 +362,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -370,7 +370,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -378,7 +378,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -386,7 +386,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -394,7 +394,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -404,7 +404,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -412,7 +412,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -421,7 +421,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -430,7 +430,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -439,7 +439,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -448,21 +448,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -470,7 +470,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -478,7 +478,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -486,7 +486,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -496,7 +496,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -506,7 +506,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -514,7 +514,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -524,7 +524,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allmodconfig
     targets:
     - default
@@ -532,7 +532,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -544,7 +544,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -552,7 +552,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allyesconfig
     targets:
     - default
@@ -560,7 +560,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: virtconfig
     targets:
     - kernel
@@ -568,7 +568,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -578,7 +578,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
@@ -589,7 +589,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -600,7 +600,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allmodconfig
     targets:
     - default
@@ -608,7 +608,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -620,7 +620,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -628,7 +628,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/6.6-clang-18.tux.yml
+++ b/tuxsuite/6.6-clang-18.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -125,7 +125,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -136,7 +136,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -150,7 +150,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -174,7 +174,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - default
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -190,7 +190,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: loongarch
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -198,7 +198,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: loongarch
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -208,7 +208,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -220,7 +220,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -231,7 +231,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -240,7 +240,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -249,7 +249,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -258,7 +258,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -267,14 +267,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -286,7 +286,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -294,7 +294,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -302,7 +302,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -312,7 +312,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -322,7 +322,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -332,7 +332,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -343,7 +343,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -356,7 +356,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -368,7 +368,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -380,7 +380,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -388,7 +388,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -396,7 +396,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -404,7 +404,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -412,7 +412,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -422,7 +422,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -430,7 +430,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -439,7 +439,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -448,7 +448,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -457,7 +457,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -466,21 +466,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -488,7 +488,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -496,7 +496,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -504,7 +504,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -514,7 +514,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -524,7 +524,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -532,7 +532,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -542,7 +542,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -550,7 +550,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -562,7 +562,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -570,7 +570,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allyesconfig
     targets:
     - default
@@ -578,7 +578,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: virtconfig
     targets:
     - kernel
@@ -586,7 +586,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -596,7 +596,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: loongarch
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -604,7 +604,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: loongarch
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_FTRACE=n
@@ -616,7 +616,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
@@ -627,7 +627,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -638,7 +638,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -646,7 +646,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -658,7 +658,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -666,7 +666,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/android-4.19-clang-12.tux.yml
+++ b/tuxsuite/android-4.19-clang-12.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n

--- a/tuxsuite/android-4.19-clang-13.tux.yml
+++ b/tuxsuite/android-4.19-clang-13.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n

--- a/tuxsuite/android-4.19-clang-14.tux.yml
+++ b/tuxsuite/android-4.19-clang-14.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n

--- a/tuxsuite/android-4.19-clang-15.tux.yml
+++ b/tuxsuite/android-4.19-clang-15.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n

--- a/tuxsuite/android-4.19-clang-16.tux.yml
+++ b/tuxsuite/android-4.19-clang-16.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n

--- a/tuxsuite/android-4.19-clang-17.tux.yml
+++ b/tuxsuite/android-4.19-clang-17.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n

--- a/tuxsuite/android-4.19-clang-18.tux.yml
+++ b/tuxsuite/android-4.19-clang-18.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n

--- a/tuxsuite/android-4.19-clang-android.tux.yml
+++ b/tuxsuite/android-4.19-clang-android.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n

--- a/tuxsuite/android-mainline-clang-12.tux.yml
+++ b/tuxsuite/android-mainline-clang-12.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -24,7 +24,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -34,7 +34,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: gki_defconfig
     targets:
     - kernel
@@ -43,7 +43,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -55,7 +55,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android-mainline-clang-13.tux.yml
+++ b/tuxsuite/android-mainline-clang-13.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -24,7 +24,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -34,7 +34,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: gki_defconfig
     targets:
     - kernel
@@ -43,7 +43,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -55,7 +55,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android-mainline-clang-14.tux.yml
+++ b/tuxsuite/android-mainline-clang-14.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -24,7 +24,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -34,7 +34,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: gki_defconfig
     targets:
     - kernel
@@ -43,7 +43,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -55,7 +55,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android-mainline-clang-15.tux.yml
+++ b/tuxsuite/android-mainline-clang-15.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -24,7 +24,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -34,7 +34,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -44,7 +44,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: gki_defconfig
     targets:
     - kernel
@@ -55,7 +55,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android-mainline-clang-16.tux.yml
+++ b/tuxsuite/android-mainline-clang-16.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -24,7 +24,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -34,7 +34,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: gki_defconfig
     targets:
     - kernel
@@ -43,7 +43,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -55,7 +55,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android-mainline-clang-17.tux.yml
+++ b/tuxsuite/android-mainline-clang-17.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -24,7 +24,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -34,7 +34,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: gki_defconfig
     targets:
     - kernel
@@ -43,7 +43,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -55,7 +55,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android-mainline-clang-18.tux.yml
+++ b/tuxsuite/android-mainline-clang-18.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -24,7 +24,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -34,7 +34,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: gki_defconfig
     targets:
     - kernel
@@ -43,7 +43,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -55,7 +55,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android-mainline-clang-android.tux.yml
+++ b/tuxsuite/android-mainline-clang-android.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -24,7 +24,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -34,7 +34,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig: gki_defconfig
     targets:
     - kernel
@@ -43,7 +43,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -55,7 +55,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android12-5.10-clang-12.tux.yml
+++ b/tuxsuite/android12-5.10-clang-12.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android12-5.10-clang-13.tux.yml
+++ b/tuxsuite/android12-5.10-clang-13.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android12-5.10-clang-14.tux.yml
+++ b/tuxsuite/android12-5.10-clang-14.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android12-5.10-clang-15.tux.yml
+++ b/tuxsuite/android12-5.10-clang-15.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android12-5.10-clang-16.tux.yml
+++ b/tuxsuite/android12-5.10-clang-16.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android12-5.10-clang-17.tux.yml
+++ b/tuxsuite/android12-5.10-clang-17.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android12-5.10-clang-18.tux.yml
+++ b/tuxsuite/android12-5.10-clang-18.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android12-5.10-clang-android.tux.yml
+++ b/tuxsuite/android12-5.10-clang-android.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android12-5.4-clang-12.tux.yml
+++ b/tuxsuite/android12-5.4-clang-12.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android12-5.4-clang-13.tux.yml
+++ b/tuxsuite/android12-5.4-clang-13.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android12-5.4-clang-14.tux.yml
+++ b/tuxsuite/android12-5.4-clang-14.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android12-5.4-clang-15.tux.yml
+++ b/tuxsuite/android12-5.4-clang-15.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android12-5.4-clang-16.tux.yml
+++ b/tuxsuite/android12-5.4-clang-16.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android12-5.4-clang-17.tux.yml
+++ b/tuxsuite/android12-5.4-clang-17.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android12-5.4-clang-18.tux.yml
+++ b/tuxsuite/android12-5.4-clang-18.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android12-5.4-clang-android.tux.yml
+++ b/tuxsuite/android12-5.4-clang-android.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android13-5.10-clang-12.tux.yml
+++ b/tuxsuite/android13-5.10-clang-12.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android13-5.10-clang-13.tux.yml
+++ b/tuxsuite/android13-5.10-clang-13.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android13-5.10-clang-14.tux.yml
+++ b/tuxsuite/android13-5.10-clang-14.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android13-5.10-clang-15.tux.yml
+++ b/tuxsuite/android13-5.10-clang-15.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android13-5.10-clang-16.tux.yml
+++ b/tuxsuite/android13-5.10-clang-16.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android13-5.10-clang-17.tux.yml
+++ b/tuxsuite/android13-5.10-clang-17.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android13-5.10-clang-18.tux.yml
+++ b/tuxsuite/android13-5.10-clang-18.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android13-5.10-clang-android.tux.yml
+++ b/tuxsuite/android13-5.10-clang-android.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android13-5.15-clang-12.tux.yml
+++ b/tuxsuite/android13-5.15-clang-12.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android13-5.15-clang-13.tux.yml
+++ b/tuxsuite/android13-5.15-clang-13.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android13-5.15-clang-14.tux.yml
+++ b/tuxsuite/android13-5.15-clang-14.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android13-5.15-clang-15.tux.yml
+++ b/tuxsuite/android13-5.15-clang-15.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android13-5.15-clang-16.tux.yml
+++ b/tuxsuite/android13-5.15-clang-16.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android13-5.15-clang-17.tux.yml
+++ b/tuxsuite/android13-5.15-clang-17.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android13-5.15-clang-18.tux.yml
+++ b/tuxsuite/android13-5.15-clang-18.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android13-5.15-clang-android.tux.yml
+++ b/tuxsuite/android13-5.15-clang-android.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android14-5.15-clang-12.tux.yml
+++ b/tuxsuite/android14-5.15-clang-12.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android14-5.15-clang-13.tux.yml
+++ b/tuxsuite/android14-5.15-clang-13.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android14-5.15-clang-14.tux.yml
+++ b/tuxsuite/android14-5.15-clang-14.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android14-5.15-clang-15.tux.yml
+++ b/tuxsuite/android14-5.15-clang-15.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android14-5.15-clang-16.tux.yml
+++ b/tuxsuite/android14-5.15-clang-16.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android14-5.15-clang-17.tux.yml
+++ b/tuxsuite/android14-5.15-clang-17.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android14-5.15-clang-18.tux.yml
+++ b/tuxsuite/android14-5.15-clang-18.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android14-5.15-clang-android.tux.yml
+++ b/tuxsuite/android14-5.15-clang-android.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android14-6.1-clang-12.tux.yml
+++ b/tuxsuite/android14-6.1-clang-12.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android14-6.1-clang-13.tux.yml
+++ b/tuxsuite/android14-6.1-clang-13.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android14-6.1-clang-14.tux.yml
+++ b/tuxsuite/android14-6.1-clang-14.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android14-6.1-clang-15.tux.yml
+++ b/tuxsuite/android14-6.1-clang-15.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android14-6.1-clang-16.tux.yml
+++ b/tuxsuite/android14-6.1-clang-16.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android14-6.1-clang-17.tux.yml
+++ b/tuxsuite/android14-6.1-clang-17.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android14-6.1-clang-18.tux.yml
+++ b/tuxsuite/android14-6.1-clang-18.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android14-6.1-clang-android.tux.yml
+++ b/tuxsuite/android14-6.1-clang-android.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android15-6.1-clang-12.tux.yml
+++ b/tuxsuite/android15-6.1-clang-12.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android15-6.1-clang-13.tux.yml
+++ b/tuxsuite/android15-6.1-clang-13.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android15-6.1-clang-14.tux.yml
+++ b/tuxsuite/android15-6.1-clang-14.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android15-6.1-clang-15.tux.yml
+++ b/tuxsuite/android15-6.1-clang-15.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android15-6.1-clang-16.tux.yml
+++ b/tuxsuite/android15-6.1-clang-16.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android15-6.1-clang-17.tux.yml
+++ b/tuxsuite/android15-6.1-clang-17.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android15-6.1-clang-18.tux.yml
+++ b/tuxsuite/android15-6.1-clang-18.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android15-6.1-clang-android.tux.yml
+++ b/tuxsuite/android15-6.1-clang-android.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android15-6.6-clang-12.tux.yml
+++ b/tuxsuite/android15-6.6-clang-12.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -24,7 +24,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -34,7 +34,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -46,7 +46,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android15-6.6-clang-13.tux.yml
+++ b/tuxsuite/android15-6.6-clang-13.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -24,7 +24,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -34,7 +34,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -46,7 +46,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android15-6.6-clang-14.tux.yml
+++ b/tuxsuite/android15-6.6-clang-14.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -24,7 +24,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -34,7 +34,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -46,7 +46,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android15-6.6-clang-15.tux.yml
+++ b/tuxsuite/android15-6.6-clang-15.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -24,7 +24,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -34,7 +34,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -46,7 +46,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android15-6.6-clang-16.tux.yml
+++ b/tuxsuite/android15-6.6-clang-16.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -24,7 +24,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -34,7 +34,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -46,7 +46,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android15-6.6-clang-17.tux.yml
+++ b/tuxsuite/android15-6.6-clang-17.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -24,7 +24,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -34,7 +34,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -46,7 +46,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android15-6.6-clang-18.tux.yml
+++ b/tuxsuite/android15-6.6-clang-18.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -24,7 +24,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -34,7 +34,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -46,7 +46,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android15-6.6-clang-android.tux.yml
+++ b/tuxsuite/android15-6.6-clang-android.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -24,7 +24,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -34,7 +34,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -46,7 +46,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/arm64-clang-12.tux.yml
+++ b/tuxsuite/arm64-clang-12.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -24,7 +24,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allmodconfig
     targets:
     - default
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/arm64-clang-13.tux.yml
+++ b/tuxsuite/arm64-clang-13.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -24,7 +24,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allmodconfig
     targets:
     - default
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/arm64-clang-14.tux.yml
+++ b/tuxsuite/arm64-clang-14.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -24,7 +24,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allmodconfig
     targets:
     - default
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/arm64-clang-15.tux.yml
+++ b/tuxsuite/arm64-clang-15.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -34,7 +34,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allmodconfig
     targets:
     - default
@@ -42,7 +42,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/arm64-clang-16.tux.yml
+++ b/tuxsuite/arm64-clang-16.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -34,7 +34,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allmodconfig
     targets:
     - default
@@ -42,7 +42,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/arm64-clang-17.tux.yml
+++ b/tuxsuite/arm64-clang-17.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -34,7 +34,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allmodconfig
     targets:
     - default
@@ -42,7 +42,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/arm64-clang-18.tux.yml
+++ b/tuxsuite/arm64-clang-18.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -34,7 +34,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -42,7 +42,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/arm64-fixes-clang-12.tux.yml
+++ b/tuxsuite/arm64-fixes-clang-12.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -24,7 +24,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allmodconfig
     targets:
     - default
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/arm64-fixes-clang-13.tux.yml
+++ b/tuxsuite/arm64-fixes-clang-13.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -24,7 +24,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allmodconfig
     targets:
     - default
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/arm64-fixes-clang-14.tux.yml
+++ b/tuxsuite/arm64-fixes-clang-14.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -24,7 +24,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allmodconfig
     targets:
     - default
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/arm64-fixes-clang-15.tux.yml
+++ b/tuxsuite/arm64-fixes-clang-15.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -34,7 +34,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allmodconfig
     targets:
     - default
@@ -42,7 +42,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/arm64-fixes-clang-16.tux.yml
+++ b/tuxsuite/arm64-fixes-clang-16.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -34,7 +34,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allmodconfig
     targets:
     - default
@@ -42,7 +42,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/arm64-fixes-clang-17.tux.yml
+++ b/tuxsuite/arm64-fixes-clang-17.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -34,7 +34,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allmodconfig
     targets:
     - default
@@ -42,7 +42,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/arm64-fixes-clang-18.tux.yml
+++ b/tuxsuite/arm64-fixes-clang-18.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -34,7 +34,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -42,7 +42,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/chromeos-5.10-clang-12.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-12.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-5.10-clang-13.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-13.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-5.10-clang-14.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-14.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-5.10-clang-15.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-15.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-5.10-clang-16.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-16.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-5.10-clang-17.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-17.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-5.10-clang-18.tux.yml
+++ b/tuxsuite/chromeos-5.10-clang-18.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-5.15-clang-12.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-12.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-5.15-clang-13.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-13.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-5.15-clang-14.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-14.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-5.15-clang-15.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-15.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-5.15-clang-16.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-16.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-5.15-clang-17.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-17.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-5.15-clang-18.tux.yml
+++ b/tuxsuite/chromeos-5.15-clang-18.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-6.1-clang-12.tux.yml
+++ b/tuxsuite/chromeos-6.1-clang-12.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-6.1-clang-13.tux.yml
+++ b/tuxsuite/chromeos-6.1-clang-13.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-6.1-clang-14.tux.yml
+++ b/tuxsuite/chromeos-6.1-clang-14.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-6.1-clang-15.tux.yml
+++ b/tuxsuite/chromeos-6.1-clang-15.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-6.1-clang-16.tux.yml
+++ b/tuxsuite/chromeos-6.1-clang-16.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-6.1-clang-17.tux.yml
+++ b/tuxsuite/chromeos-6.1-clang-17.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-6.1-clang-18.tux.yml
+++ b/tuxsuite/chromeos-6.1-clang-18.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-6.6-clang-12.tux.yml
+++ b/tuxsuite/chromeos-6.6-clang-12.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-6.6-clang-13.tux.yml
+++ b/tuxsuite/chromeos-6.6-clang-13.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-6.6-clang-14.tux.yml
+++ b/tuxsuite/chromeos-6.6-clang-14.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-6.6-clang-15.tux.yml
+++ b/tuxsuite/chromeos-6.6-clang-15.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-6.6-clang-16.tux.yml
+++ b/tuxsuite/chromeos-6.6-clang-16.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-6.6-clang-17.tux.yml
+++ b/tuxsuite/chromeos-6.6-clang-17.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/chromeos-6.6-clang-18.tux.yml
+++ b/tuxsuite/chromeos-6.6-clang-18.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/arm64/common.config
@@ -25,7 +25,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - chromeos/config/chromeos/base.config
     - chromeos/config/chromeos/x86_64/common.config

--- a/tuxsuite/mainline-clang-12.tux.yml
+++ b/tuxsuite/mainline-clang-12.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -119,7 +119,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -133,7 +133,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - default
@@ -151,7 +151,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -159,7 +159,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -172,7 +172,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -183,7 +183,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - ppc64_guest_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
@@ -194,7 +194,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -203,7 +203,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -212,7 +212,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: um
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -220,7 +220,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -228,7 +228,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -238,7 +238,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -248,7 +248,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -261,7 +261,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -273,7 +273,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -285,7 +285,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -293,7 +293,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -301,7 +301,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -309,7 +309,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -317,7 +317,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -327,7 +327,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -335,7 +335,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -343,7 +343,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -351,7 +351,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -360,7 +360,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -369,7 +369,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -377,7 +377,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -385,7 +385,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -393,7 +393,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -403,7 +403,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -413,7 +413,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -421,7 +421,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allmodconfig
     targets:
     - default
@@ -429,7 +429,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -441,7 +441,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -449,7 +449,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allyesconfig
     targets:
     - default
@@ -457,7 +457,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -468,7 +468,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allmodconfig
     targets:
     - default
@@ -476,7 +476,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -488,7 +488,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -496,7 +496,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/mainline-clang-13.tux.yml
+++ b/tuxsuite/mainline-clang-13.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -119,7 +119,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -133,7 +133,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - default
@@ -151,7 +151,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -159,7 +159,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -171,7 +171,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - ppc64_guest_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
@@ -193,7 +193,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -211,7 +211,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -219,7 +219,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -227,7 +227,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -237,7 +237,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -247,7 +247,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -260,7 +260,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -272,7 +272,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -284,7 +284,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -292,7 +292,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -300,7 +300,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -308,7 +308,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -316,7 +316,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -326,7 +326,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -334,7 +334,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -342,7 +342,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -350,7 +350,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -359,7 +359,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -368,7 +368,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -376,7 +376,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -384,7 +384,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -392,7 +392,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -402,7 +402,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -412,7 +412,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -420,7 +420,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -430,7 +430,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allmodconfig
     targets:
     - default
@@ -438,7 +438,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -450,7 +450,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -458,7 +458,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allyesconfig
     targets:
     - default
@@ -466,7 +466,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -476,7 +476,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -487,7 +487,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allmodconfig
     targets:
     - default
@@ -495,7 +495,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -507,7 +507,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -515,7 +515,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/mainline-clang-14.tux.yml
+++ b/tuxsuite/mainline-clang-14.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -119,7 +119,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -133,7 +133,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - default
@@ -151,7 +151,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -159,7 +159,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -171,7 +171,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -191,7 +191,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -200,7 +200,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -209,7 +209,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -217,7 +217,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -225,7 +225,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -235,7 +235,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -245,7 +245,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -258,7 +258,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -270,7 +270,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -282,7 +282,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -290,7 +290,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -298,7 +298,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -306,7 +306,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -314,7 +314,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -324,7 +324,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -332,7 +332,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -341,7 +341,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -350,7 +350,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -359,7 +359,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -368,7 +368,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -376,7 +376,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -384,7 +384,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -392,7 +392,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -402,7 +402,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -412,7 +412,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -420,7 +420,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -430,7 +430,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allmodconfig
     targets:
     - default
@@ -438,7 +438,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -450,7 +450,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -458,7 +458,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allyesconfig
     targets:
     - default
@@ -466,7 +466,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -476,7 +476,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -487,7 +487,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allmodconfig
     targets:
     - default
@@ -495,7 +495,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -507,7 +507,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -515,7 +515,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/mainline-clang-15.tux.yml
+++ b/tuxsuite/mainline-clang-15.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -129,7 +129,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -153,7 +153,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - default
@@ -161,7 +161,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -169,7 +169,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -181,7 +181,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -192,7 +192,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -201,7 +201,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -210,7 +210,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -219,14 +219,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -238,7 +238,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -246,7 +246,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -254,7 +254,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -264,7 +264,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -274,7 +274,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -287,7 +287,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -299,7 +299,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -311,7 +311,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -319,7 +319,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -327,7 +327,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -335,7 +335,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -343,7 +343,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -353,7 +353,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -361,7 +361,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -370,7 +370,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -379,7 +379,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -388,7 +388,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -397,21 +397,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -419,7 +419,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -427,7 +427,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -435,7 +435,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -445,7 +445,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -455,7 +455,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -463,7 +463,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -473,7 +473,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allmodconfig
     targets:
     - default
@@ -481,7 +481,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -493,7 +493,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -501,7 +501,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allyesconfig
     targets:
     - default
@@ -509,7 +509,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -519,7 +519,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
@@ -530,7 +530,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -541,7 +541,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allmodconfig
     targets:
     - default
@@ -549,7 +549,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -561,7 +561,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -569,7 +569,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/mainline-clang-16.tux.yml
+++ b/tuxsuite/mainline-clang-16.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -125,7 +125,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -136,7 +136,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -150,7 +150,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -174,7 +174,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - default
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -190,7 +190,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -213,7 +213,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -231,7 +231,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -240,7 +240,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -249,14 +249,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -268,7 +268,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -276,7 +276,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -284,7 +284,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -294,7 +294,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -304,7 +304,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -314,7 +314,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -325,7 +325,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -338,7 +338,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -350,7 +350,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -362,7 +362,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -370,7 +370,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -378,7 +378,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -386,7 +386,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -394,7 +394,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -404,7 +404,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -412,7 +412,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -421,7 +421,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -430,7 +430,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -439,7 +439,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -448,21 +448,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -470,7 +470,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -478,7 +478,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -486,7 +486,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -496,7 +496,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -506,7 +506,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -514,7 +514,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -524,7 +524,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allmodconfig
     targets:
     - default
@@ -532,7 +532,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -544,7 +544,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -552,7 +552,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allyesconfig
     targets:
     - default
@@ -560,7 +560,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: virtconfig
     targets:
     - kernel
@@ -568,7 +568,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -578,7 +578,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
@@ -589,7 +589,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -600,7 +600,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allmodconfig
     targets:
     - default
@@ -608,7 +608,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -620,7 +620,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -628,7 +628,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/mainline-clang-17.tux.yml
+++ b/tuxsuite/mainline-clang-17.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -125,7 +125,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -136,7 +136,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -150,7 +150,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -174,7 +174,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - default
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -190,7 +190,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -213,7 +213,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -231,7 +231,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -240,7 +240,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -249,14 +249,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -268,7 +268,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -276,7 +276,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -284,7 +284,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -294,7 +294,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -304,7 +304,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -314,7 +314,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -325,7 +325,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -338,7 +338,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -350,7 +350,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -362,7 +362,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -370,7 +370,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -378,7 +378,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -386,7 +386,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -394,7 +394,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -404,7 +404,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -412,7 +412,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -421,7 +421,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -430,7 +430,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -439,7 +439,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -448,21 +448,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -470,7 +470,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -478,7 +478,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -486,7 +486,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -496,7 +496,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -506,7 +506,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -514,7 +514,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -524,7 +524,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allmodconfig
     targets:
     - default
@@ -532,7 +532,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -544,7 +544,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -552,7 +552,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allyesconfig
     targets:
     - default
@@ -560,7 +560,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: virtconfig
     targets:
     - kernel
@@ -568,7 +568,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -578,7 +578,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
@@ -589,7 +589,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -600,7 +600,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allmodconfig
     targets:
     - default
@@ -608,7 +608,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -620,7 +620,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -628,7 +628,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/mainline-clang-18.tux.yml
+++ b/tuxsuite/mainline-clang-18.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -125,7 +125,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -136,7 +136,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -150,7 +150,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -174,7 +174,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - hardening.config
@@ -184,7 +184,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - default
@@ -192,7 +192,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -200,7 +200,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: loongarch
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -208,7 +208,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: loongarch
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -218,7 +218,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -230,7 +230,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -241,7 +241,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -250,7 +250,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -259,7 +259,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -268,7 +268,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -277,14 +277,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -296,7 +296,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -304,7 +304,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -312,7 +312,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -322,7 +322,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -332,7 +332,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -342,7 +342,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -353,7 +353,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -366,7 +366,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -378,7 +378,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -388,7 +388,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - hardening.config
@@ -400,7 +400,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -408,7 +408,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -416,7 +416,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -424,7 +424,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -432,7 +432,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -442,7 +442,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -450,7 +450,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -459,7 +459,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -468,7 +468,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -477,7 +477,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -486,21 +486,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -508,7 +508,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -516,7 +516,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -524,7 +524,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -534,7 +534,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -544,7 +544,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -552,7 +552,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -562,7 +562,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -570,7 +570,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -582,7 +582,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -590,7 +590,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allyesconfig
     targets:
     - default
@@ -598,7 +598,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: virtconfig
     targets:
     - kernel
@@ -606,7 +606,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -616,7 +616,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: loongarch
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -624,7 +624,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: loongarch
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_FTRACE=n
@@ -636,7 +636,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
@@ -647,7 +647,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -658,7 +658,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -666,7 +666,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -678,7 +678,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -686,7 +686,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/next-clang-13.tux.yml
+++ b/tuxsuite/next-clang-13.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -119,7 +119,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -133,7 +133,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - default
@@ -151,7 +151,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -159,7 +159,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -171,7 +171,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - ppc64_guest_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
@@ -193,7 +193,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -211,7 +211,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -219,7 +219,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -227,7 +227,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -237,7 +237,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -247,7 +247,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -260,7 +260,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -272,7 +272,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -282,7 +282,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_GCOV_KERNEL=y
@@ -295,7 +295,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -303,7 +303,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -311,7 +311,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -319,7 +319,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -327,7 +327,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -337,7 +337,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -345,7 +345,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -353,7 +353,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -361,7 +361,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -370,7 +370,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -379,7 +379,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -387,7 +387,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -395,7 +395,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -403,7 +403,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -413,7 +413,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -423,7 +423,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -431,7 +431,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -441,7 +441,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allmodconfig
     targets:
     - default
@@ -449,7 +449,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -461,7 +461,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -469,7 +469,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allyesconfig
     targets:
     - default
@@ -477,7 +477,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -487,7 +487,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -498,7 +498,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allmodconfig
     targets:
     - default
@@ -506,7 +506,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -518,7 +518,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -526,7 +526,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/next-clang-14.tux.yml
+++ b/tuxsuite/next-clang-14.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -119,7 +119,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -133,7 +133,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - default
@@ -151,7 +151,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -159,7 +159,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -171,7 +171,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -191,7 +191,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -200,7 +200,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -209,7 +209,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -220,7 +220,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -231,7 +231,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -239,7 +239,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -247,7 +247,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -257,7 +257,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -267,7 +267,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -280,7 +280,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -292,7 +292,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -302,7 +302,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_GCOV_KERNEL=y
@@ -315,7 +315,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -323,7 +323,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -331,7 +331,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -339,7 +339,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -347,7 +347,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -357,7 +357,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -365,7 +365,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -374,7 +374,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -383,7 +383,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -392,7 +392,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -401,7 +401,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -409,7 +409,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -417,7 +417,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -425,7 +425,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -435,7 +435,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -445,7 +445,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -453,7 +453,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -463,7 +463,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allmodconfig
     targets:
     - default
@@ -471,7 +471,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -483,7 +483,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -491,7 +491,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allyesconfig
     targets:
     - default
@@ -499,7 +499,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -509,7 +509,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -520,7 +520,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -533,7 +533,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allmodconfig
     targets:
     - default
@@ -541,7 +541,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -553,7 +553,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -561,7 +561,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/next-clang-15.tux.yml
+++ b/tuxsuite/next-clang-15.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -129,7 +129,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -153,7 +153,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - default
@@ -161,7 +161,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -169,7 +169,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -181,7 +181,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -192,7 +192,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -201,7 +201,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -210,7 +210,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -219,7 +219,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -230,7 +230,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -241,14 +241,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -260,7 +260,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -268,7 +268,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -276,7 +276,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -286,7 +286,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -296,7 +296,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -309,7 +309,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -321,7 +321,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -331,7 +331,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_GCOV_KERNEL=y
@@ -344,7 +344,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -352,7 +352,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -360,7 +360,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -368,7 +368,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -376,7 +376,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -386,7 +386,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -394,7 +394,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -403,7 +403,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -412,7 +412,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -421,7 +421,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -430,21 +430,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -452,7 +452,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -460,7 +460,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -468,7 +468,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -478,7 +478,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -488,7 +488,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -496,7 +496,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -506,7 +506,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allmodconfig
     targets:
     - default
@@ -514,7 +514,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -526,7 +526,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -534,7 +534,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allyesconfig
     targets:
     - default
@@ -542,7 +542,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -552,7 +552,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
@@ -563,7 +563,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -574,7 +574,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allmodconfig
     targets:
     - default
@@ -582,7 +582,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -594,7 +594,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -602,7 +602,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/next-clang-16.tux.yml
+++ b/tuxsuite/next-clang-16.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -125,7 +125,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -136,7 +136,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -150,7 +150,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -174,7 +174,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - default
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -190,7 +190,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -213,7 +213,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -231,7 +231,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -240,7 +240,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -249,7 +249,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -260,7 +260,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -271,14 +271,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -290,7 +290,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -298,7 +298,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -306,7 +306,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -316,7 +316,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -326,7 +326,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -336,7 +336,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -347,7 +347,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -360,7 +360,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -372,7 +372,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -382,7 +382,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_GCOV_KERNEL=y
@@ -395,7 +395,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -403,7 +403,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -411,7 +411,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -419,7 +419,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -427,7 +427,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -437,7 +437,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -445,7 +445,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -454,7 +454,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -463,7 +463,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -472,7 +472,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -481,21 +481,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -503,7 +503,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -511,7 +511,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -519,7 +519,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -529,7 +529,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -539,7 +539,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -547,7 +547,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -557,7 +557,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allmodconfig
     targets:
     - default
@@ -565,7 +565,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -577,7 +577,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -585,7 +585,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allyesconfig
     targets:
     - default
@@ -593,7 +593,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: virtconfig
     targets:
     - kernel
@@ -601,7 +601,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -611,7 +611,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
@@ -622,7 +622,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -633,7 +633,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allmodconfig
     targets:
     - default
@@ -641,7 +641,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -653,7 +653,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -661,7 +661,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/next-clang-17.tux.yml
+++ b/tuxsuite/next-clang-17.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -125,7 +125,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -136,7 +136,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -150,7 +150,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -174,7 +174,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - default
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -190,7 +190,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -213,7 +213,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -231,7 +231,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -240,7 +240,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -249,7 +249,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -260,7 +260,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -271,14 +271,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -290,7 +290,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -298,7 +298,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -306,7 +306,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -316,7 +316,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -326,7 +326,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -336,7 +336,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -347,7 +347,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -360,7 +360,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -372,7 +372,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -382,7 +382,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_GCOV_KERNEL=y
@@ -395,7 +395,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -403,7 +403,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -411,7 +411,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -419,7 +419,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -427,7 +427,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -437,7 +437,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -445,7 +445,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -454,7 +454,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -463,7 +463,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -472,7 +472,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -481,21 +481,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -503,7 +503,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -511,7 +511,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -519,7 +519,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -529,7 +529,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -539,7 +539,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -547,7 +547,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -557,7 +557,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allmodconfig
     targets:
     - default
@@ -565,7 +565,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -577,7 +577,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -585,7 +585,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allyesconfig
     targets:
     - default
@@ -593,7 +593,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: virtconfig
     targets:
     - kernel
@@ -601,7 +601,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -611,7 +611,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
@@ -622,7 +622,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -633,7 +633,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -646,7 +646,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allmodconfig
     targets:
     - default
@@ -654,7 +654,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -666,7 +666,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -674,7 +674,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/next-clang-18.tux.yml
+++ b/tuxsuite/next-clang-18.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -125,7 +125,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -136,7 +136,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -150,7 +150,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -174,7 +174,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - hardening.config
@@ -184,7 +184,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - default
@@ -192,7 +192,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -200,7 +200,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: loongarch
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -208,7 +208,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: loongarch
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -218,7 +218,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -230,7 +230,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -241,7 +241,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -250,7 +250,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -259,7 +259,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -268,7 +268,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -277,7 +277,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -288,7 +288,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -299,14 +299,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -318,7 +318,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -326,7 +326,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -334,7 +334,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -344,7 +344,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -354,7 +354,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -364,7 +364,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -375,7 +375,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -388,7 +388,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -400,7 +400,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -410,7 +410,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - hardening.config
@@ -420,7 +420,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_GCOV_KERNEL=y
@@ -433,7 +433,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -441,7 +441,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -449,7 +449,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -457,7 +457,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -465,7 +465,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -475,7 +475,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -483,7 +483,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -492,7 +492,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -501,7 +501,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -510,7 +510,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -519,21 +519,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -541,7 +541,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -549,7 +549,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -557,7 +557,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -567,7 +567,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -577,7 +577,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -585,7 +585,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -595,7 +595,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -603,7 +603,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -615,7 +615,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -623,7 +623,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allyesconfig
     targets:
     - default
@@ -631,7 +631,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: virtconfig
     targets:
     - kernel
@@ -639,7 +639,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -649,7 +649,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: loongarch
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -657,7 +657,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: loongarch
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_FTRACE=n
@@ -669,7 +669,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
@@ -680,7 +680,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -691,7 +691,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -704,7 +704,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -712,7 +712,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -724,7 +724,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -732,7 +732,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/next-clang-android.tux.yml
+++ b/tuxsuite/next-clang-android.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig: defconfig
     targets:
     - kernel
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -68,7 +68,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -78,7 +78,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -88,7 +88,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig: defconfig
     targets:
     - kernel
@@ -96,7 +96,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig: defconfig
     targets:
     - kernel
@@ -104,7 +104,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -114,7 +114,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -124,7 +124,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - defconfig
     - CONFIG_GCOV_KERNEL=y
@@ -137,7 +137,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -147,7 +147,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig: allnoconfig
     targets:
     - default
@@ -155,7 +155,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig: allmodconfig
     targets:
     - default
@@ -163,7 +163,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -175,7 +175,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig: allnoconfig
     targets:
     - default
@@ -183,7 +183,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig: allyesconfig
     targets:
     - default
@@ -191,7 +191,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig: allmodconfig
     targets:
     - default
@@ -199,7 +199,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -211,7 +211,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig: allnoconfig
     targets:
     - default
@@ -219,7 +219,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-android
+    toolchain: korg-clang-android
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/stable-clang-11.tux.yml
+++ b/tuxsuite/stable-clang-11.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -119,7 +119,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -133,7 +133,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - default
@@ -151,7 +151,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -159,7 +159,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -172,7 +172,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: mips
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -183,7 +183,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -193,7 +193,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: um
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -210,7 +210,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: defconfig
     targets:
     - kernel
@@ -218,7 +218,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -228,7 +228,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -238,7 +238,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -251,7 +251,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -263,7 +263,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -275,7 +275,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -283,7 +283,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -291,7 +291,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -299,7 +299,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -307,7 +307,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -317,7 +317,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -325,7 +325,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -333,7 +333,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -341,7 +341,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -350,7 +350,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -359,7 +359,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -367,7 +367,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -375,7 +375,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -383,7 +383,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -393,7 +393,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -403,7 +403,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allnoconfig
     targets:
     - default
@@ -411,7 +411,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allmodconfig
     targets:
     - default
@@ -419,7 +419,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -431,7 +431,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allnoconfig
     targets:
     - default
@@ -439,7 +439,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allyesconfig
     targets:
     - default
@@ -447,7 +447,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -458,7 +458,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allmodconfig
     targets:
     - default
@@ -466,7 +466,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -478,7 +478,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allnoconfig
     targets:
     - default
@@ -486,7 +486,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-11
+    toolchain: korg-clang-11
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/stable-clang-12.tux.yml
+++ b/tuxsuite/stable-clang-12.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -119,7 +119,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -133,7 +133,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - default
@@ -151,7 +151,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -159,7 +159,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -172,7 +172,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -183,7 +183,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - ppc64_guest_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
@@ -194,7 +194,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -203,7 +203,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -212,7 +212,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: um
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -220,7 +220,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -228,7 +228,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -238,7 +238,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -248,7 +248,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -261,7 +261,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -273,7 +273,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -285,7 +285,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -293,7 +293,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -301,7 +301,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -309,7 +309,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -317,7 +317,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -327,7 +327,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -335,7 +335,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -343,7 +343,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -351,7 +351,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -360,7 +360,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -369,7 +369,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -377,7 +377,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -385,7 +385,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -393,7 +393,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -403,7 +403,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -413,7 +413,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -421,7 +421,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allmodconfig
     targets:
     - default
@@ -429,7 +429,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -441,7 +441,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -449,7 +449,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allyesconfig
     targets:
     - default
@@ -457,7 +457,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -468,7 +468,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allmodconfig
     targets:
     - default
@@ -476,7 +476,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -488,7 +488,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -496,7 +496,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/stable-clang-13.tux.yml
+++ b/tuxsuite/stable-clang-13.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -119,7 +119,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -133,7 +133,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - default
@@ -151,7 +151,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -159,7 +159,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -171,7 +171,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - ppc64_guest_defconfig
     - CONFIG_PPC_DISABLE_WERROR=y
@@ -193,7 +193,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -211,7 +211,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -219,7 +219,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -227,7 +227,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -237,7 +237,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -247,7 +247,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -260,7 +260,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -272,7 +272,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -284,7 +284,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -292,7 +292,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -300,7 +300,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -308,7 +308,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -316,7 +316,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -326,7 +326,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -334,7 +334,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -342,7 +342,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -350,7 +350,7 @@ jobs:
     make_variables:
       LLVM_IAS: 0
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -359,7 +359,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -368,7 +368,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -376,7 +376,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -384,7 +384,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -392,7 +392,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -402,7 +402,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -412,7 +412,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -420,7 +420,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -430,7 +430,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allmodconfig
     targets:
     - default
@@ -438,7 +438,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -450,7 +450,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -458,7 +458,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allyesconfig
     targets:
     - default
@@ -466,7 +466,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -476,7 +476,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -487,7 +487,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allmodconfig
     targets:
     - default
@@ -495,7 +495,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -507,7 +507,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -515,7 +515,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/stable-clang-14.tux.yml
+++ b/tuxsuite/stable-clang-14.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -119,7 +119,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -133,7 +133,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - default
@@ -151,7 +151,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -159,7 +159,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -171,7 +171,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -191,7 +191,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -200,7 +200,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -209,7 +209,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -217,7 +217,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -225,7 +225,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -235,7 +235,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -245,7 +245,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -258,7 +258,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -270,7 +270,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -282,7 +282,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -290,7 +290,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -298,7 +298,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -306,7 +306,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -314,7 +314,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -324,7 +324,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -332,7 +332,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -341,7 +341,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -350,7 +350,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -359,7 +359,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -368,7 +368,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -376,7 +376,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -384,7 +384,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -392,7 +392,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -402,7 +402,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -412,7 +412,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -420,7 +420,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -430,7 +430,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allmodconfig
     targets:
     - default
@@ -438,7 +438,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -450,7 +450,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -458,7 +458,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allyesconfig
     targets:
     - default
@@ -466,7 +466,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -476,7 +476,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -487,7 +487,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allmodconfig
     targets:
     - default
@@ -495,7 +495,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -507,7 +507,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -515,7 +515,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/stable-clang-15.tux.yml
+++ b/tuxsuite/stable-clang-15.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -129,7 +129,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -143,7 +143,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -153,7 +153,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - default
@@ -161,7 +161,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -169,7 +169,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -181,7 +181,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -192,7 +192,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -201,7 +201,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -210,7 +210,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -219,14 +219,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -238,7 +238,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -246,7 +246,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -254,7 +254,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -264,7 +264,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -274,7 +274,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -287,7 +287,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -299,7 +299,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -311,7 +311,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -319,7 +319,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -327,7 +327,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -335,7 +335,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -343,7 +343,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -353,7 +353,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -361,7 +361,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -370,7 +370,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -379,7 +379,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -388,7 +388,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -397,21 +397,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -419,7 +419,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -427,7 +427,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -435,7 +435,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -445,7 +445,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -455,7 +455,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -463,7 +463,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -473,7 +473,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allmodconfig
     targets:
     - default
@@ -481,7 +481,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -493,7 +493,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -501,7 +501,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allyesconfig
     targets:
     - default
@@ -509,7 +509,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -519,7 +519,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
@@ -530,7 +530,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -541,7 +541,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allmodconfig
     targets:
     - default
@@ -549,7 +549,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -561,7 +561,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -569,7 +569,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/stable-clang-16.tux.yml
+++ b/tuxsuite/stable-clang-16.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -125,7 +125,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -136,7 +136,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -150,7 +150,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -174,7 +174,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - default
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -190,7 +190,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -213,7 +213,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -231,7 +231,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -240,7 +240,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -249,14 +249,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -268,7 +268,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -276,7 +276,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -284,7 +284,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -294,7 +294,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -304,7 +304,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -314,7 +314,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -325,7 +325,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -338,7 +338,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -350,7 +350,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -362,7 +362,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -370,7 +370,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -378,7 +378,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -386,7 +386,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -394,7 +394,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -404,7 +404,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -412,7 +412,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -421,7 +421,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -430,7 +430,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -439,7 +439,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -448,21 +448,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -470,7 +470,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -478,7 +478,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -486,7 +486,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -496,7 +496,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -506,7 +506,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -514,7 +514,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -524,7 +524,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allmodconfig
     targets:
     - default
@@ -532,7 +532,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -544,7 +544,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -552,7 +552,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allyesconfig
     targets:
     - default
@@ -560,7 +560,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: virtconfig
     targets:
     - kernel
@@ -568,7 +568,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -578,7 +578,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
@@ -589,7 +589,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -600,7 +600,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allmodconfig
     targets:
     - default
@@ -608,7 +608,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -620,7 +620,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -628,7 +628,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/stable-clang-17.tux.yml
+++ b/tuxsuite/stable-clang-17.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -125,7 +125,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -136,7 +136,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -150,7 +150,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -174,7 +174,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - default
@@ -182,7 +182,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -190,7 +190,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -202,7 +202,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -213,7 +213,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -222,7 +222,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -231,7 +231,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -240,7 +240,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -249,14 +249,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -268,7 +268,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -276,7 +276,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -284,7 +284,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -294,7 +294,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -304,7 +304,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -314,7 +314,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -325,7 +325,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -338,7 +338,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -350,7 +350,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -362,7 +362,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -370,7 +370,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -378,7 +378,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -386,7 +386,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -394,7 +394,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -404,7 +404,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -412,7 +412,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -421,7 +421,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -430,7 +430,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -439,7 +439,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -448,21 +448,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -470,7 +470,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -478,7 +478,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -486,7 +486,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -496,7 +496,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -506,7 +506,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -514,7 +514,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -524,7 +524,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allmodconfig
     targets:
     - default
@@ -532,7 +532,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -544,7 +544,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -552,7 +552,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allyesconfig
     targets:
     - default
@@ -560,7 +560,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: virtconfig
     targets:
     - kernel
@@ -568,7 +568,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -578,7 +578,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
@@ -589,7 +589,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -600,7 +600,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allmodconfig
     targets:
     - default
@@ -608,7 +608,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -620,7 +620,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -628,7 +628,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/stable-clang-18.tux.yml
+++ b/tuxsuite/stable-clang-18.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: imx_v4_v5_defconfig
     targets:
     - default
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: omap2plus_defconfig
     targets:
     - default
@@ -66,7 +66,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
     - CONFIG_ARM_LPAE=y
@@ -77,7 +77,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -85,7 +85,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -95,7 +95,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -105,7 +105,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -115,7 +115,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -125,7 +125,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -136,7 +136,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -150,7 +150,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_FTRACE=y
@@ -164,7 +164,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -174,7 +174,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - hardening.config
@@ -184,7 +184,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - default
@@ -192,7 +192,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -200,7 +200,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: loongarch
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -208,7 +208,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: loongarch
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -218,7 +218,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -230,7 +230,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: mips
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
@@ -241,7 +241,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: ppc44x_defconfig
     targets:
     - kernel
@@ -250,7 +250,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: ppc64_guest_defconfig
     targets:
     - kernel
@@ -259,7 +259,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: powernv_defconfig
     targets:
     - kernel
@@ -268,7 +268,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -277,14 +277,14 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -296,7 +296,7 @@ jobs:
     make_variables:
       LLVM_IAS: 1
   - target_arch: um
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -304,7 +304,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -312,7 +312,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -322,7 +322,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -332,7 +332,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -342,7 +342,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_CFI_CLANG=y
@@ -353,7 +353,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_KASAN=y
@@ -366,7 +366,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_KCSAN=y
@@ -378,7 +378,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - CONFIG_UBSAN=y
@@ -388,7 +388,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - defconfig
     - hardening.config
@@ -400,7 +400,7 @@ jobs:
 - name: distribution_configs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     targets:
     - kernel
@@ -408,7 +408,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     targets:
     - kernel
@@ -416,7 +416,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     targets:
     - kernel
@@ -424,7 +424,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     targets:
     - kernel
@@ -432,7 +432,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
@@ -442,7 +442,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     targets:
     - default
@@ -450,7 +450,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
     targets:
     - kernel
@@ -459,7 +459,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     targets:
     - kernel
@@ -468,7 +468,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     targets:
     - kernel
@@ -477,7 +477,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     targets:
     - kernel
@@ -486,21 +486,21 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: s390
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     targets:
     - kernel
     make_variables:
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     targets:
     - kernel
@@ -508,7 +508,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     targets:
     - kernel
@@ -516,7 +516,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     targets:
     - kernel
@@ -524,7 +524,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     targets:
     - kernel
@@ -534,7 +534,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -544,7 +544,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -552,7 +552,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allyesconfig
     - CONFIG_WERROR=n
@@ -562,7 +562,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -570,7 +570,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -582,7 +582,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -590,7 +590,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allyesconfig
     targets:
     - default
@@ -598,7 +598,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: virtconfig
     targets:
     - kernel
@@ -606,7 +606,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: hexagon
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -616,7 +616,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: loongarch
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -624,7 +624,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: loongarch
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_FTRACE=n
@@ -636,7 +636,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: powerpc
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y
@@ -647,7 +647,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -658,7 +658,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -666,7 +666,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -678,7 +678,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -686,7 +686,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/tip-clang-12.tux.yml
+++ b/tuxsuite/tip-clang-12.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: i386
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allmodconfig
     targets:
     - default
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allnoconfig
     targets:
     - default
@@ -48,7 +48,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-12
+    toolchain: korg-clang-12
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/tip-clang-13.tux.yml
+++ b/tuxsuite/tip-clang-13.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: i386
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allmodconfig
     targets:
     - default
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allnoconfig
     targets:
     - default
@@ -48,7 +48,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-13
+    toolchain: korg-clang-13
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/tip-clang-14.tux.yml
+++ b/tuxsuite/tip-clang-14.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: i386
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allmodconfig
     targets:
     - default
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allnoconfig
     targets:
     - default
@@ -48,7 +48,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-14
+    toolchain: korg-clang-14
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/tip-clang-15.tux.yml
+++ b/tuxsuite/tip-clang-15.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: i386
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allmodconfig
     targets:
     - default
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allnoconfig
     targets:
     - default
@@ -48,7 +48,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-15
+    toolchain: korg-clang-15
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/tip-clang-16.tux.yml
+++ b/tuxsuite/tip-clang-16.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: i386
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allmodconfig
     targets:
     - default
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allnoconfig
     targets:
     - default
@@ -48,7 +48,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-16
+    toolchain: korg-clang-16
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/tip-clang-17.tux.yml
+++ b/tuxsuite/tip-clang-17.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: i386
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allmodconfig
     targets:
     - default
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allnoconfig
     targets:
     - default
@@ -48,7 +48,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-17
+    toolchain: korg-clang-17
     kconfig: allyesconfig
     targets:
     - default

--- a/tuxsuite/tip-clang-18.tux.yml
+++ b/tuxsuite/tip-clang-18.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: i386
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -22,7 +22,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allmodconfig
     targets:
     - default
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allnoconfig
     targets:
     - default
@@ -48,7 +48,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: clang-18
+    toolchain: korg-clang-18
     kconfig: allyesconfig
     targets:
     - default

--- a/utils.py
+++ b/utils.py
@@ -141,14 +141,16 @@ def get_requested_llvm_version():
     ver = os.environ["LLVM_VERSION"]
     with LLVM_TOT_VERSION.open(encoding='utf-8') as file:
         llvm_tot_version = str(int(file.read())).strip()
-    return "clang-" + ("nightly" if ver == llvm_tot_version else ver)
+    if ver == llvm_tot_version:
+        return 'clang-nightly'
+    return f"korg-clang-{ver}"
 
 
 def show_builds():
     print_yellow("Available builds:")
     for build in _read_builds():
         arch_val = build['target_arch']
-        llvm_version_val = build['toolchain'].split('-', 1)[1]
+        llvm_version_val = build['toolchain'].rsplit('-', 1)[-1]
         config_val = "+".join(build["kconfig"])
         print_yellow(
             f"\tARCH={arch_val} LLVM_VERSION={llvm_version_val} CONFIG={config_val}"


### PR DESCRIPTION
This moves our builds away from Debian's LLVM to the kernel.org LLVM builds I maintain, which are faster and within our control for updates.

I would like to do this for `clang-nightly` eventually but I have to make sure it is maintainable before doing so, so this just does the stable LLVM builds for now.
