### PR TITLE
Switch s390 builds on -next with LLVM 18 over to LLVM=1

### DIFF
--- a/.github/workflows/next-clang-18.yml
+++ b/.github/workflows/next-clang-18.yml
@@ -890,12 +890,12 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b44d869d20f1498db69bd2c10feadaa2:
+  _af7afd080e56e2a68964f8b20c8612b4:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 defconfig
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
@@ -918,12 +918,12 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7636ef53313fa166fbc1b97829a3868c:
+  _54c2f672a2b4383c29636e94d6280c0e:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
@@ -1575,12 +1575,12 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _85c021aa7070a43cffc70e8eb749333d:
+  _b09613e175e3f625085032870643e265:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
@@ -1603,12 +1603,12 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _1adfaf7b63bac61bf2e8db5bac4fb007:
+  _64b02c22430661ba14a8e1de6f0ef689:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390

--- a/generator/yml/0009-llvm-latest.yml
+++ b/generator/yml/0009-llvm-latest.yml
@@ -135,10 +135,10 @@
   - {<< : *riscv_allmod_lto,  << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *riscv_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *riscv_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *s390,              << : *next,             << : *clang_ias,       boot: true,  << : *llvm_latest}
-  - {<< : *s390_kasan,        << : *next,             << : *clang_ias,       boot: true,  << : *llvm_latest}
-  - {<< : *s390_fedora,       << : *next,             << : *clang_ias,       boot: true,  << : *llvm_latest}
-  - {<< : *s390_suse,         << : *next,             << : *clang_ias,       boot: true,  << : *llvm_latest}
+  - {<< : *s390,              << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *s390_kasan,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *s390_fedora,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *s390_suse,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *um,                << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}

--- a/tuxsuite/next-clang-18.tux.yml
+++ b/tuxsuite/next-clang-18.tux.yml
@@ -304,6 +304,7 @@ jobs:
     targets:
     - kernel
     make_variables:
+      LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-18
@@ -316,6 +317,7 @@ jobs:
     targets:
     - kernel
     make_variables:
+      LLVM: 1
       LLVM_IAS: 1
   - target_arch: um
     toolchain: korg-clang-18
@@ -524,6 +526,7 @@ jobs:
     targets:
     - kernel
     make_variables:
+      LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-18
@@ -531,6 +534,7 @@ jobs:
     targets:
     - kernel
     make_variables:
+      LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-18


### PR DESCRIPTION
LLVM 18.1.0-rc4 has all the fixes in LLVM that are needed to enable `LLVM=1` for s390 on -next, which has all the kernel side fixes.
