### PR TITLE
Fix clang-android builds

### DIFF
--- a/.github/workflows/android-4.19-clang-android.yml
+++ b/.github/workflows/android-4.19-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_korg-clang-android
+    container: tuxmake/x86_64_clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable

--- a/.github/workflows/android-mainline-clang-android.yml
+++ b/.github/workflows/android-mainline-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_korg-clang-android
+    container: tuxmake/x86_64_clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-mainline

--- a/.github/workflows/android12-5.10-clang-android.yml
+++ b/.github/workflows/android12-5.10-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_korg-clang-android
+    container: tuxmake/x86_64_clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10

--- a/.github/workflows/android12-5.4-clang-android.yml
+++ b/.github/workflows/android12-5.4-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_korg-clang-android
+    container: tuxmake/x86_64_clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4

--- a/.github/workflows/android13-5.10-clang-android.yml
+++ b/.github/workflows/android13-5.10-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_korg-clang-android
+    container: tuxmake/x86_64_clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10

--- a/.github/workflows/android13-5.15-clang-android.yml
+++ b/.github/workflows/android13-5.15-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_korg-clang-android
+    container: tuxmake/x86_64_clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15

--- a/.github/workflows/android14-5.15-clang-android.yml
+++ b/.github/workflows/android14-5.15-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_korg-clang-android
+    container: tuxmake/x86_64_clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15

--- a/.github/workflows/android14-6.1-clang-android.yml
+++ b/.github/workflows/android14-6.1-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_korg-clang-android
+    container: tuxmake/x86_64_clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1

--- a/.github/workflows/android15-6.1-clang-android.yml
+++ b/.github/workflows/android15-6.1-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_korg-clang-android
+    container: tuxmake/x86_64_clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.1

--- a/.github/workflows/android15-6.6-clang-android.yml
+++ b/.github/workflows/android15-6.6-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_korg-clang-android
+    container: tuxmake/x86_64_clang-android
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6

--- a/.github/workflows/next-clang-android.yml
+++ b/.github/workflows/next-clang-android.yml
@@ -19,7 +19,7 @@ jobs:
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
-    container: tuxmake/x86_64_korg-clang-android
+    container: tuxmake/x86_64_clang-android
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
       GIT_REF: master

--- a/generator/generate_tuxsuite.py
+++ b/generator/generate_tuxsuite.py
@@ -74,6 +74,8 @@ def emit_tuxsuite_yml(config, tree, llvm_version):
                 arch = build.get("ARCH", "x86_64")
                 if llvm_version == max_version:
                     tuxsuite_toolchain = "clang-nightly"
+                elif llvm_version == "android":
+                    tuxsuite_toolchain = "clang-android"
                 else:
                     # We want to use the kernel.org LLVM builds for speed but
                     # we don't want korg everywhere

--- a/generator/generate_workflow.py
+++ b/generator/generate_workflow.py
@@ -92,6 +92,8 @@ def check_cache_job_setup(repo, ref, toolchain):
     last_part = toolchain.split("-")[-1]
     if last_part == llvm_tot_version:
         toolchain = "clang-nightly"
+    elif last_part == "android":
+        toolchain = "clang-android"
     else:
         toolchain = f"korg-clang-{last_part}"
 

--- a/tuxsuite/android-4.19-clang-android.tux.yml
+++ b/tuxsuite/android-4.19-clang-android.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n

--- a/tuxsuite/android-mainline-clang-android.tux.yml
+++ b/tuxsuite/android-mainline-clang-android.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -24,7 +24,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -34,7 +34,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: riscv
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig: gki_defconfig
     targets:
     - kernel
@@ -43,7 +43,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -55,7 +55,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android12-5.10-clang-android.tux.yml
+++ b/tuxsuite/android12-5.10-clang-android.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android12-5.4-clang-android.tux.yml
+++ b/tuxsuite/android12-5.4-clang-android.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android13-5.10-clang-android.tux.yml
+++ b/tuxsuite/android13-5.10-clang-android.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android13-5.15-clang-android.tux.yml
+++ b/tuxsuite/android13-5.15-clang-android.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android14-5.15-clang-android.tux.yml
+++ b/tuxsuite/android14-5.15-clang-android.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android14-6.1-clang-android.tux.yml
+++ b/tuxsuite/android14-6.1-clang-android.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android15-6.1-clang-android.tux.yml
+++ b/tuxsuite/android15-6.1-clang-android.tux.yml
@@ -13,7 +13,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -33,7 +33,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -45,7 +45,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/android15-6.6-clang-android.tux.yml
+++ b/tuxsuite/android15-6.6-clang-android.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -24,7 +24,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -34,7 +34,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - gki_defconfig
     - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
@@ -46,7 +46,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n

--- a/tuxsuite/next-clang-android.tux.yml
+++ b/tuxsuite/next-clang-android.tux.yml
@@ -14,7 +14,7 @@ jobs:
 - name: defconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig: multi_v5_defconfig
     targets:
     - kernel
@@ -23,7 +23,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig: aspeed_g5_defconfig
     targets:
     - kernel
@@ -32,7 +32,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -40,7 +40,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - multi_v7_defconfig
     - CONFIG_THUMB2_KERNEL=y
@@ -50,7 +50,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig: defconfig
     targets:
     - kernel
@@ -58,7 +58,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - defconfig
     - CONFIG_CPU_BIG_ENDIAN=y
@@ -68,7 +68,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -78,7 +78,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -88,7 +88,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: i386
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig: defconfig
     targets:
     - kernel
@@ -96,7 +96,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig: defconfig
     targets:
     - kernel
@@ -104,7 +104,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_FULL=y
@@ -114,7 +114,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - defconfig
     - CONFIG_LTO_CLANG_THIN=y
@@ -124,7 +124,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - defconfig
     - CONFIG_GCOV_KERNEL=y
@@ -137,7 +137,7 @@ jobs:
 - name: allconfigs
   builds:
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - allmodconfig
     - CONFIG_WERROR=n
@@ -147,7 +147,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 0
   - target_arch: arm
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig: allnoconfig
     targets:
     - default
@@ -155,7 +155,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig: allmodconfig
     targets:
     - default
@@ -163,7 +163,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -175,7 +175,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig: allnoconfig
     targets:
     - default
@@ -183,7 +183,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: arm64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig: allyesconfig
     targets:
     - default
@@ -191,7 +191,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig: allmodconfig
     targets:
     - default
@@ -199,7 +199,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig:
     - allmodconfig
     - CONFIG_GCOV_KERNEL=n
@@ -211,7 +211,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig: allnoconfig
     targets:
     - default
@@ -219,7 +219,7 @@ jobs:
       LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
-    toolchain: korg-clang-android
+    toolchain: clang-android
     kconfig: allyesconfig
     targets:
     - default


### PR DESCRIPTION
This accidentally acquired the `korg-` prefix, which obviously makes no sense since Android is its own toolchain vendor. Add the exception for it so that the correct container is used for both the cache check and the builds themselves.
