### PR TITLE
Switch s390 builds on mainline with LLVM 18+ over to LLVM=1

### DIFF
--- a/.github/workflows/mainline-clang-18.yml
+++ b/.github/workflows/mainline-clang-18.yml
@@ -834,12 +834,12 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b44d869d20f1498db69bd2c10feadaa2:
+  _af7afd080e56e2a68964f8b20c8612b4:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 defconfig
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
@@ -862,12 +862,12 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7636ef53313fa166fbc1b97829a3868c:
+  _54c2f672a2b4383c29636e94d6280c0e:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
@@ -1491,12 +1491,12 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _85c021aa7070a43cffc70e8eb749333d:
+  _b09613e175e3f625085032870643e265:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
@@ -1519,12 +1519,12 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _1adfaf7b63bac61bf2e8db5bac4fb007:
+  _64b02c22430661ba14a8e1de6f0ef689:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390

--- a/.github/workflows/mainline-clang-19.yml
+++ b/.github/workflows/mainline-clang-19.yml
@@ -834,12 +834,12 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _a7016a4f3a73a508d1b00dd9b9dfa168:
+  _f97d7f8efcb2c842d35f0e22f01a52bf:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 defconfig
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
@@ -862,12 +862,12 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _741fec04d7e30991d0973b88ecd844fa:
+  _268ceb735866a8f5bfa89ffa2e2bf60b:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
@@ -1491,12 +1491,12 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b2fe3d92de2f9c8f3356bd83602f25a7:
+  _fa1e0cf8480f115830476f059cbe53bb:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
@@ -1519,12 +1519,12 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _2daf6d97d5a05d1700d0631278bd2f7e:
+  _5728b554151279ef568b7d449268dd62:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -33,7 +33,7 @@ def update_llvm_tot_version():
     # Avoids pulling in an extra Python package dependency
     curl_cmd = [
         'curl', '-fLSs',
-        'https://raw.githubusercontent.com/llvm/llvm-project/main/llvm/CMakeLists.txt'
+        'https://raw.githubusercontent.com/llvm/llvm-project/main/cmake/Modules/LLVMVersion.cmake'
     ]
     cmakelists = subprocess.run(curl_cmd,
                                 capture_output=True,

--- a/generator/yml/0009-llvm-latest.yml
+++ b/generator/yml/0009-llvm-latest.yml
@@ -56,10 +56,10 @@
   - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *riscv_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *riscv_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *s390,              << : *mainline,         << : *clang_ias,       boot: true,  << : *llvm_latest}
-  - {<< : *s390_kasan,        << : *mainline,         << : *clang_ias,       boot: true,  << : *llvm_latest}
-  - {<< : *s390_fedora,       << : *mainline,         << : *clang_ias,       boot: true,  << : *llvm_latest}
-  - {<< : *s390_suse,         << : *mainline,         << : *clang_ias,       boot: true,  << : *llvm_latest}
+  - {<< : *s390,              << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *s390_kasan,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *s390_fedora,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *s390_suse,         << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *um,                << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}

--- a/generator/yml/0009-llvm-tot.yml
+++ b/generator/yml/0009-llvm-tot.yml
@@ -56,10 +56,10 @@
   - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *riscv_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *riscv_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *s390,              << : *mainline,         << : *clang_ias,       boot: true,  << : *llvm_tot}
-  - {<< : *s390_kasan,        << : *mainline,         << : *clang_ias,       boot: true,  << : *llvm_tot}
-  - {<< : *s390_fedora,       << : *mainline,         << : *clang_ias,       boot: true,  << : *llvm_tot}
-  - {<< : *s390_suse,         << : *mainline,         << : *clang_ias,       boot: true,  << : *llvm_tot}
+  - {<< : *s390,              << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *s390_kasan,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *s390_fedora,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *s390_suse,         << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *um,                << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}

--- a/tuxsuite/mainline-clang-18.tux.yml
+++ b/tuxsuite/mainline-clang-18.tux.yml
@@ -282,6 +282,7 @@ jobs:
     targets:
     - kernel
     make_variables:
+      LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-18
@@ -294,6 +295,7 @@ jobs:
     targets:
     - kernel
     make_variables:
+      LLVM: 1
       LLVM_IAS: 1
   - target_arch: um
     toolchain: korg-clang-18
@@ -491,6 +493,7 @@ jobs:
     targets:
     - kernel
     make_variables:
+      LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-18
@@ -498,6 +501,7 @@ jobs:
     targets:
     - kernel
     make_variables:
+      LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-18

--- a/tuxsuite/mainline-clang-19.tux.yml
+++ b/tuxsuite/mainline-clang-19.tux.yml
@@ -282,6 +282,7 @@ jobs:
     targets:
     - kernel
     make_variables:
+      LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: clang-nightly
@@ -294,6 +295,7 @@ jobs:
     targets:
     - kernel
     make_variables:
+      LLVM: 1
       LLVM_IAS: 1
   - target_arch: um
     toolchain: clang-nightly
@@ -491,6 +493,7 @@ jobs:
     targets:
     - kernel
     make_variables:
+      LLVM: 1
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: clang-nightly
@@ -498,6 +501,7 @@ jobs:
     targets:
     - kernel
     make_variables:
+      LLVM: 1
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly


### PR DESCRIPTION
For the same reason as commit 47f006b ("generator: yml: Switch s390 builds on -next with LLVM 18 over to LLVM=1"), as the kernel side fixes are now in Linus's tree.

The first change in this PR is needed to fix running `generator/generate.py`, which is required to apply the changes from this pull request, hence why it was included.
