### PR TITLE
add better error handling for patches that fail to apply

### DIFF
--- a/caching/update.py
+++ b/caching/update.py
@@ -93,17 +93,19 @@ def main():
             build_log_raw = response.read().decode()
 
         failed_pattern = (
-            r"(?<=Apply patch set FAILED\s)[0-9A-Za-z._:/\-\s]*?(?=\serror: )"
-        )
+            r"(?<=Apply patch set FAILED\s)[0-9A-Za-z._:/\-\s]*?(?=\serror: )")
         failed_matches = re.findall(failed_pattern, build_log_raw)
         if len(failed_matches) == 0:
             print(
                 f"No patches failed to apply yet the build status stated there were: {build['status_message']}"
             )
-            sys.exit(0)  # Not sure how we got here but continue the action anyways
+            sys.exit(
+                0)  # Not sure how we got here but continue the action anyways
 
         patches_that_failed_to_apply = failed_matches[0].split('\n')
-        print(f"Error: Some patches failed to apply.\n{patches_that_failed_to_apply}\n")
+        print(
+            f"Error: Some patches failed to apply.\n{patches_that_failed_to_apply}\n"
+        )
         sys.exit(1)
 
     if len(builds_that_are_missing_metadata) == len(builds):


### PR DESCRIPTION
I noticed that when patches fail to apply we don't get the best error message from `caching/update.py`:

```
...
RuntimeError: Could not find a suitable git sha or compiler version in any build
...
```


I wrote about this in #732.

Anyways, now we'll get an error message like this:
```
| Error: Some patches failed to apply.
| ['35f20786c481d5ced9283ff42de5c69b65e5ed13.patch']
```

Then, we can even have issues or PRs created auto-magically https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#create-an-issue.

Following that, it would just take a human reviewer to say "Yep, this patch has already been applied which has caused this failure; time to merge this robot's PR! I love robots 🤖"