### PR TITLE
Disable MIPS builds that use GNU ld

### DIFF
--- a/.github/workflows/5.10-clang-11.yml
+++ b/.github/workflows/5.10-clang-11.yml
@@ -246,34 +246,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _772f9a8c79e52c6ee000b01cab13b4f6:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: mips
-      LLVM_VERSION: 11
-      BOOT: 1
-      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _91bbbe2f66767e2566aad8a1f0e4ada4:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/5.10-clang-12.yml
+++ b/.github/workflows/5.10-clang-12.yml
@@ -246,34 +246,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _0cc3ac6a57d27d3cef575f41babb7262:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: mips
-      LLVM_VERSION: 12
-      BOOT: 1
-      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _9ffc4427d344a9bbd18dbfcfa1e5da53:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -498,34 +498,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _772f9a8c79e52c6ee000b01cab13b4f6:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: mips
-      LLVM_VERSION: 11
-      BOOT: 1
-      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _91bbbe2f66767e2566aad8a1f0e4ada4:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -526,34 +526,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4609cd6605cdb5fcdc499135e04aeefc:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: mips
-      LLVM_VERSION: 12
-      BOOT: 1
-      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _5a7ba1119c304ff5ab69c3d403de55d6:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/6.1-clang-11.yml
+++ b/.github/workflows/6.1-clang-11.yml
@@ -498,34 +498,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _772f9a8c79e52c6ee000b01cab13b4f6:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: mips
-      LLVM_VERSION: 11
-      BOOT: 1
-      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _91bbbe2f66767e2566aad8a1f0e4ada4:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/6.1-clang-12.yml
+++ b/.github/workflows/6.1-clang-12.yml
@@ -498,34 +498,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4609cd6605cdb5fcdc499135e04aeefc:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: mips
-      LLVM_VERSION: 12
-      BOOT: 1
-      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _5a7ba1119c304ff5ab69c3d403de55d6:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/6.6-clang-11.yml
+++ b/.github/workflows/6.6-clang-11.yml
@@ -498,34 +498,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _772f9a8c79e52c6ee000b01cab13b4f6:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: mips
-      LLVM_VERSION: 11
-      BOOT: 1
-      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _91bbbe2f66767e2566aad8a1f0e4ada4:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/6.6-clang-12.yml
+++ b/.github/workflows/6.6-clang-12.yml
@@ -498,34 +498,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4609cd6605cdb5fcdc499135e04aeefc:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: mips
-      LLVM_VERSION: 12
-      BOOT: 1
-      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _5a7ba1119c304ff5ab69c3d403de55d6:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/mainline-clang-12.yml
+++ b/.github/workflows/mainline-clang-12.yml
@@ -498,34 +498,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4609cd6605cdb5fcdc499135e04aeefc:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: mips
-      LLVM_VERSION: 12
-      BOOT: 1
-      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _5a7ba1119c304ff5ab69c3d403de55d6:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/stable-clang-12.yml
+++ b/.github/workflows/stable-clang-12.yml
@@ -498,34 +498,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4609cd6605cdb5fcdc499135e04aeefc:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=mips LLVM=1 LD=mips-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: mips
-      LLVM_VERSION: 12
-      BOOT: 1
-      CONFIG: malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _5a7ba1119c304ff5ab69c3d403de55d6:
     runs-on: ubuntu-latest
     needs:

--- a/generator/yml/0009-llvm-11.yml
+++ b/generator/yml/0009-llvm-11.yml
@@ -33,7 +33,8 @@
   - {<< : *hexagon,           << : *stable-6_6,       << : *llvm_full,       boot: false, << : *llvm_11}
   - {<< : *i386,              << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *i386_suse,         << : *stable-6_6,       << : *llvm_full,       boot: false, << : *llvm_11}
-  - {<< : *mips,              << : *stable-6_6,       << : *mips_llvm,       boot: true,  << : *llvm_11}
+  # mips builds with GNU ld broken until 2.41: https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=6b958fe36b765f70878e8d3d002864967c4bc3a4
+  # - {<< : *mips,              << : *stable-6_6,       << : *mips_llvm,       boot: true,  << : *llvm_11}
   - {<< : *mipsel,            << : *stable-6_6,       << : *llvm,            boot: true,  << : *llvm_11}
   # ppc32 and ppc64: Build disabled (https://gitlab.com/Linaro/tuxmake/-/issues/108)
   # - {<< : *ppc32,             << : *stable-6_6,       << : *llvm,            boot: true,  << : *llvm_11}
@@ -92,7 +93,8 @@
   - {<< : *hexagon,           << : *stable-6_1,       << : *llvm_full,       boot: false, << : *llvm_11}
   - {<< : *i386,              << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *i386_suse,         << : *stable-6_1,       << : *llvm_full,       boot: false, << : *llvm_11}
-  - {<< : *mips,              << : *stable-6_1,       << : *mips_llvm,       boot: true,  << : *llvm_11}
+  # mips builds with GNU ld broken until 2.41: https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=6b958fe36b765f70878e8d3d002864967c4bc3a4
+  # - {<< : *mips,              << : *stable-6_1,       << : *mips_llvm,       boot: true,  << : *llvm_11}
   - {<< : *mipsel,            << : *stable-6_1,       << : *llvm,            boot: true,  << : *llvm_11}
   # ppc32 and ppc64: Build disabled (https://gitlab.com/Linaro/tuxmake/-/issues/108)
   # - {<< : *ppc32,             << : *stable-6_1,       << : *llvm,            boot: true,  << : *llvm_11}
@@ -150,7 +152,8 @@
   - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_11}
   - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}
   - {<< : *i386_suse,         << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_11}
-  - {<< : *mips,              << : *stable-5_15,      << : *mips_llvm,       boot: true,  << : *llvm_11}
+  # mips builds with GNU ld broken until 2.41: https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=6b958fe36b765f70878e8d3d002864967c4bc3a4
+  # - {<< : *mips,              << : *stable-5_15,      << : *mips_llvm,       boot: true,  << : *llvm_11}
   - {<< : *mipsel,            << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
   # ppc32 and ppc64: Build disabled (https://gitlab.com/Linaro/tuxmake/-/issues/108)
   # - {<< : *ppc32,             << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
@@ -191,7 +194,8 @@
   - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_11}
   - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_11}
   - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_11}
-  - {<< : *mips,              << : *stable-5_10,      << : *mips_llvm,       boot: true,  << : *llvm_11}
+  # mips builds with GNU ld broken until 2.41: https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=6b958fe36b765f70878e8d3d002864967c4bc3a4
+  # - {<< : *mips,              << : *stable-5_10,      << : *mips_llvm,       boot: true,  << : *llvm_11}
   - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_11}
   # ppc32 and ppc64: Build disabled (https://gitlab.com/Linaro/tuxmake/-/issues/108)
   # - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_11}

--- a/generator/yml/0009-llvm-12.yml
+++ b/generator/yml/0009-llvm-12.yml
@@ -33,7 +33,8 @@
   - {<< : *hexagon,           << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_12}
   - {<< : *i386,              << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *i386_suse,         << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_12}
-  - {<< : *mips,              << : *mainline,         << : *mips_llvm_full,  boot: true,  << : *llvm_12}
+  # mips builds with GNU ld broken until 2.41: https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=6b958fe36b765f70878e8d3d002864967c4bc3a4
+  # - {<< : *mips,              << : *mainline,         << : *mips_llvm_full,  boot: true,  << : *llvm_12}
   - {<< : *mipsel,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_12}
   # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)
   # - {<< : *ppc32,             << : *mainline,         << : *llvm,            boot: true,  << : *llvm_12}
@@ -92,7 +93,8 @@
   - {<< : *hexagon,           << : *stable,           << : *llvm_full,       boot: false, << : *llvm_12}
   - {<< : *i386,              << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *i386_suse,         << : *stable,           << : *llvm_full,       boot: false, << : *llvm_12}
-  - {<< : *mips,              << : *stable,           << : *mips_llvm_full,  boot: true,  << : *llvm_12}
+  # mips builds with GNU ld broken until 2.41: https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=6b958fe36b765f70878e8d3d002864967c4bc3a4
+  # - {<< : *mips,              << : *stable,           << : *mips_llvm_full,  boot: true,  << : *llvm_12}
   - {<< : *mipsel,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_12}
   # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)
   # - {<< : *ppc32,             << : *stable,           << : *llvm,            boot: true,  << : *llvm_12}
@@ -151,7 +153,8 @@
   - {<< : *hexagon,           << : *stable-6_6,       << : *llvm_full,       boot: false, << : *llvm_12}
   - {<< : *i386,              << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *i386_suse,         << : *stable-6_6,       << : *llvm_full,       boot: false, << : *llvm_12}
-  - {<< : *mips,              << : *stable-6_6,       << : *mips_llvm_full,  boot: true,  << : *llvm_12}
+  # mips builds with GNU ld broken until 2.41: https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=6b958fe36b765f70878e8d3d002864967c4bc3a4
+  # - {<< : *mips,              << : *stable-6_6,       << : *mips_llvm_full,  boot: true,  << : *llvm_12}
   - {<< : *mipsel,            << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_12}
   # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)
   # - {<< : *ppc32,             << : *stable-6_6,       << : *llvm,            boot: true,  << : *llvm_12}
@@ -210,7 +213,8 @@
   - {<< : *hexagon,           << : *stable-6_1,       << : *llvm_full,       boot: false, << : *llvm_12}
   - {<< : *i386,              << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *i386_suse,         << : *stable-6_1,       << : *llvm_full,       boot: false, << : *llvm_12}
-  - {<< : *mips,              << : *stable-6_1,       << : *mips_llvm_full,  boot: true,  << : *llvm_12}
+  # mips builds with GNU ld broken until 2.41: https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=6b958fe36b765f70878e8d3d002864967c4bc3a4
+  # - {<< : *mips,              << : *stable-6_1,       << : *mips_llvm_full,  boot: true,  << : *llvm_12}
   - {<< : *mipsel,            << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_12}
   # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)
   # - {<< : *ppc32,             << : *stable-6_1,       << : *llvm,            boot: true,  << : *llvm_12}
@@ -269,7 +273,8 @@
   - {<< : *hexagon,           << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_12}
   - {<< : *i386,              << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *i386_suse,         << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_12}
-  - {<< : *mips,              << : *stable-5_15,      << : *mips_llvm_full,  boot: true,  << : *llvm_12}
+  # mips builds with GNU ld broken until 2.41: https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=6b958fe36b765f70878e8d3d002864967c4bc3a4
+  # - {<< : *mips,              << : *stable-5_15,      << : *mips_llvm_full,  boot: true,  << : *llvm_12}
   - {<< : *mipsel,            << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *ppc32,             << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  << : *llvm_12}
@@ -309,7 +314,8 @@
   - {<< : *arm64_allno,       << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_12}
   - {<< : *arm64_allyes,      << : *stable-5_10,      << : *llvm_full,       boot: false, << : *llvm_12}
   - {<< : *i386,              << : *stable-5_10,      << : *llvm_full,       boot: true,  << : *llvm_12}
-  - {<< : *mips,              << : *stable-5_10,      << : *mips_llvm,       boot: true,  << : *llvm_12}
+  # mips builds with GNU ld broken until 2.41: https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=6b958fe36b765f70878e8d3d002864967c4bc3a4
+  # - {<< : *mips,              << : *stable-5_10,      << : *mips_llvm,       boot: true,  << : *llvm_12}
   - {<< : *mipsel,            << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *ppc32,             << : *stable-5_10,      << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *ppc64,             << : *stable-5_10,      << : *ppc64_llvm,      boot: true,  << : *llvm_12}

--- a/tuxsuite/5.10-clang-11.tux.yml
+++ b/tuxsuite/5.10-clang-11.tux.yml
@@ -70,19 +70,6 @@ jobs:
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    kernel_image: vmlinux
-    make_variables:
-      LD: mips-linux-gnu-ld
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: mips
-    toolchain: korg-clang-11
-    kconfig:
-    - malta_defconfig
-    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.10-clang-12.tux.yml
+++ b/tuxsuite/5.10-clang-12.tux.yml
@@ -70,19 +70,6 @@ jobs:
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    kernel_image: vmlinux
-    make_variables:
-      LD: mips-linux-gnu-ld
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: mips
-    toolchain: korg-clang-12
-    kconfig:
-    - malta_defconfig
-    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.15-clang-11.tux.yml
+++ b/tuxsuite/5.15-clang-11.tux.yml
@@ -163,19 +163,6 @@ jobs:
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    kernel_image: vmlinux
-    make_variables:
-      LD: mips-linux-gnu-ld
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: mips
-    toolchain: korg-clang-11
-    kconfig:
-    - malta_defconfig
-    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/5.15-clang-12.tux.yml
+++ b/tuxsuite/5.15-clang-12.tux.yml
@@ -174,19 +174,6 @@ jobs:
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    kernel_image: vmlinux
-    make_variables:
-      LD: mips-linux-gnu-ld
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: mips
-    toolchain: korg-clang-12
-    kconfig:
-    - malta_defconfig
-    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/6.1-clang-11.tux.yml
+++ b/tuxsuite/6.1-clang-11.tux.yml
@@ -163,19 +163,6 @@ jobs:
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    kernel_image: vmlinux
-    make_variables:
-      LD: mips-linux-gnu-ld
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: mips
-    toolchain: korg-clang-11
-    kconfig:
-    - malta_defconfig
-    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/6.1-clang-12.tux.yml
+++ b/tuxsuite/6.1-clang-12.tux.yml
@@ -163,19 +163,6 @@ jobs:
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    kernel_image: vmlinux
-    make_variables:
-      LD: mips-linux-gnu-ld
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: mips
-    toolchain: korg-clang-12
-    kconfig:
-    - malta_defconfig
-    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/6.6-clang-11.tux.yml
+++ b/tuxsuite/6.6-clang-11.tux.yml
@@ -163,19 +163,6 @@ jobs:
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    kernel_image: vmlinux
-    make_variables:
-      LD: mips-linux-gnu-ld
-      LLVM: 1
-      LLVM_IAS: 0
-  - target_arch: mips
-    toolchain: korg-clang-11
-    kconfig:
-    - malta_defconfig
-    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/6.6-clang-12.tux.yml
+++ b/tuxsuite/6.6-clang-12.tux.yml
@@ -163,19 +163,6 @@ jobs:
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    kernel_image: vmlinux
-    make_variables:
-      LD: mips-linux-gnu-ld
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: mips
-    toolchain: korg-clang-12
-    kconfig:
-    - malta_defconfig
-    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/mainline-clang-12.tux.yml
+++ b/tuxsuite/mainline-clang-12.tux.yml
@@ -163,19 +163,6 @@ jobs:
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    kernel_image: vmlinux
-    make_variables:
-      LD: mips-linux-gnu-ld
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: mips
-    toolchain: korg-clang-12
-    kconfig:
-    - malta_defconfig
-    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - kernel
     kernel_image: vmlinux

--- a/tuxsuite/stable-clang-12.tux.yml
+++ b/tuxsuite/stable-clang-12.tux.yml
@@ -163,19 +163,6 @@ jobs:
     kconfig:
     - malta_defconfig
     - CONFIG_BLK_DEV_INITRD=y
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    kernel_image: vmlinux
-    make_variables:
-      LD: mips-linux-gnu-ld
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: mips
-    toolchain: korg-clang-12
-    kconfig:
-    - malta_defconfig
-    - CONFIG_BLK_DEV_INITRD=y
     targets:
     - kernel
     kernel_image: vmlinux


### PR DESCRIPTION
After the upgrade from binutils 2.35.2 in Debian bullseye to binutils 2.40 in Debian bookworm, there is a build error:

```
llvm-objcopy: error: Link field value 24 in section .rel.dyn is not a symbol table
```

This is resolved in binutils 2.41 with commit [6b958fe36b7](https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=6b958fe36b765f70878e8d3d002864967c4bc3a4) ("Setting sh_link for SHT_REL/SHT_RELA"). Once Debian has binutils 2.41 or newer, these builds can be re-enabled.
