### PR TITLE
Add and enable Fedora LTO build

### DIFF
--- a/.github/workflows/mainline-clang-17.yml
+++ b/.github/workflows/mainline-clang-17.yml
@@ -1267,6 +1267,34 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _7507e66b38d2d417241e209a2df64ee9:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_distribution_configs
+    - check_cache
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: arm64
+      LLVM_VERSION: 17
+      BOOT: 1
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_distribution_configs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_distribution_configs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _5a26addb96716dec505a81e4c270cbc8:
     runs-on: ubuntu-latest
     needs:
@@ -1559,6 +1587,34 @@ jobs:
       LLVM_VERSION: 17
       BOOT: 1
       CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_distribution_configs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_distribution_configs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
+  _251c61c4c862e0440f8a7406ebecb34b:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_distribution_configs
+    - check_cache
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 17
+      BOOT: 1
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-18.yml
+++ b/.github/workflows/mainline-clang-18.yml
@@ -1379,6 +1379,34 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _c719053759da12c30a2bcd4ba44a0136:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_distribution_configs
+    - check_cache
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: arm64
+      LLVM_VERSION: 18
+      BOOT: 1
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_distribution_configs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_distribution_configs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _b32701be7ea8e1a2cb43d20b9cc22821:
     runs-on: ubuntu-latest
     needs:
@@ -1671,6 +1699,34 @@ jobs:
       LLVM_VERSION: 18
       BOOT: 1
       CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_distribution_configs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_distribution_configs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
+  _39b154df6935a41b2952e5cd43b908be:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_distribution_configs
+    - check_cache
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 18
+      BOOT: 1
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-19.yml
+++ b/.github/workflows/mainline-clang-19.yml
@@ -1379,6 +1379,34 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _5fd7ba41b2d9304c0016d0427f2e88ac:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_distribution_configs
+    - check_cache
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: arm64
+      LLVM_VERSION: 19
+      BOOT: 1
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_distribution_configs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_distribution_configs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _ff0df706f24e25e0685590346bdd44e8:
     runs-on: ubuntu-latest
     needs:
@@ -1671,6 +1699,34 @@ jobs:
       LLVM_VERSION: 19
       BOOT: 1
       CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_distribution_configs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_distribution_configs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
+  _299e543a68730cc10e9d179f680f63e0:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_distribution_configs
+    - check_cache
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 19
+      BOOT: 1
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-17.yml
+++ b/.github/workflows/next-clang-17.yml
@@ -1295,6 +1295,34 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _7507e66b38d2d417241e209a2df64ee9:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_distribution_configs
+    - check_cache
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: arm64
+      LLVM_VERSION: 17
+      BOOT: 1
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_distribution_configs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_distribution_configs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _5a26addb96716dec505a81e4c270cbc8:
     runs-on: ubuntu-latest
     needs:
@@ -1587,6 +1615,34 @@ jobs:
       LLVM_VERSION: 17
       BOOT: 1
       CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_distribution_configs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_distribution_configs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
+  _251c61c4c862e0440f8a7406ebecb34b:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_distribution_configs
+    - check_cache
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 17
+      BOOT: 1
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-18.yml
+++ b/.github/workflows/next-clang-18.yml
@@ -1407,6 +1407,34 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _c719053759da12c30a2bcd4ba44a0136:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_distribution_configs
+    - check_cache
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: arm64
+      LLVM_VERSION: 18
+      BOOT: 1
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_distribution_configs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_distribution_configs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _b32701be7ea8e1a2cb43d20b9cc22821:
     runs-on: ubuntu-latest
     needs:
@@ -1699,6 +1727,34 @@ jobs:
       LLVM_VERSION: 18
       BOOT: 1
       CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_distribution_configs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_distribution_configs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
+  _39b154df6935a41b2952e5cd43b908be:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_distribution_configs
+    - check_cache
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 18
+      BOOT: 1
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-19.yml
+++ b/.github/workflows/next-clang-19.yml
@@ -1407,6 +1407,34 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _5fd7ba41b2d9304c0016d0427f2e88ac:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_distribution_configs
+    - check_cache
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: arm64
+      LLVM_VERSION: 19
+      BOOT: 1
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_distribution_configs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_distribution_configs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _ff0df706f24e25e0685590346bdd44e8:
     runs-on: ubuntu-latest
     needs:
@@ -1699,6 +1727,34 @@ jobs:
       LLVM_VERSION: 19
       BOOT: 1
       CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_distribution_configs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_distribution_configs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
+  _299e543a68730cc10e9d179f680f63e0:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_distribution_configs
+    - check_cache
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 19
+      BOOT: 1
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/stable-clang-17.yml
+++ b/.github/workflows/stable-clang-17.yml
@@ -1211,6 +1211,34 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _7507e66b38d2d417241e209a2df64ee9:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_distribution_configs
+    - check_cache
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: arm64
+      LLVM_VERSION: 17
+      BOOT: 1
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_distribution_configs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_distribution_configs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _5a26addb96716dec505a81e4c270cbc8:
     runs-on: ubuntu-latest
     needs:
@@ -1503,6 +1531,34 @@ jobs:
       LLVM_VERSION: 17
       BOOT: 1
       CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_distribution_configs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_distribution_configs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
+  _251c61c4c862e0440f8a7406ebecb34b:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_distribution_configs
+    - check_cache
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 17
+      BOOT: 1
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/stable-clang-18.yml
+++ b/.github/workflows/stable-clang-18.yml
@@ -1323,6 +1323,34 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _c719053759da12c30a2bcd4ba44a0136:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_distribution_configs
+    - check_cache
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: arm64
+      LLVM_VERSION: 18
+      BOOT: 1
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_distribution_configs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_distribution_configs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _b32701be7ea8e1a2cb43d20b9cc22821:
     runs-on: ubuntu-latest
     needs:
@@ -1615,6 +1643,34 @@ jobs:
       LLVM_VERSION: 18
       BOOT: 1
       CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_distribution_configs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_distribution_configs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
+  _39b154df6935a41b2952e5cd43b908be:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_distribution_configs
+    - check_cache
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 18
+      BOOT: 1
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/stable-clang-19.yml
+++ b/.github/workflows/stable-clang-19.yml
@@ -1323,6 +1323,34 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _5fd7ba41b2d9304c0016d0427f2e88ac:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_distribution_configs
+    - check_cache
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: arm64
+      LLVM_VERSION: 19
+      BOOT: 1
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_distribution_configs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_distribution_configs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _ff0df706f24e25e0685590346bdd44e8:
     runs-on: ubuntu-latest
     needs:
@@ -1615,6 +1643,34 @@ jobs:
       LLVM_VERSION: 19
       BOOT: 1
       CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_distribution_configs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_distribution_configs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
+  _299e543a68730cc10e9d179f680f63e0:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_distribution_configs
+    - check_cache
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: x86_64
+      LLVM_VERSION: 19
+      BOOT: 1
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/generator/yml/0007-configs.yml
+++ b/generator/yml/0007-configs.yml
@@ -39,6 +39,7 @@ configs:
   - &arm64_allyes      {config: allyesconfig,                                                                                               ARCH: *arm64-arch,      << : *default}
   - &arm64_alpine      {config: *arm64-alpine-config-url,                                                                                   ARCH: *arm64-arch,      << : *kernel}
   - &arm64_fedora      {config: *arm64-fedora-config-url,                                                                                   ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_fedora_lto  {config: [*arm64-fedora-config-url, CONFIG_LTO_CLANG_THIN=y],                                                        ARCH: *arm64-arch,      << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for pre-5.18 cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
   - &arm64_fedora_bpf  {config: [*arm64-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                           ARCH: *arm64-arch,      << : *kernel}
   # CONFIG_DEBUG_INFO_BTF disabled for certain SUSE configs due to pahole issue: https://lore.kernel.org/r/20210506205622.3663956-1-kafai@fb.com/
@@ -103,4 +104,5 @@ configs:
   - &x86_64_alpine     {config: *x86_64-alpine-config-url,                                                                                                          << : *kernel}
   - &x86_64_arch       {config: *x86_64-arch-config-url,                                                                                                            << : *kernel}
   - &x86_64_fedora     {config: *x86_64-fedora-config-url,                                                                                                          << : *kernel}
+  - &x86_64_fedora_lto {config: [*x86_64-fedora-config-url, CONFIG_LTO_CLANG_THIN=y],                                                                               << : *kernel}
   - &x86_64_suse       {config: *x86_64-suse-config-url,                                                                                                            << : *kernel}

--- a/generator/yml/0009-llvm-17.yml
+++ b/generator/yml/0009-llvm-17.yml
@@ -32,6 +32,7 @@
   - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_17}
   - {<< : *arm64_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *arm64_fedora_lto,  << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_virt,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *hexagon,           << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_17}
@@ -73,6 +74,7 @@
   - {<< : *x86_64_alpine,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_arch,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_fedora,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *x86_64_fedora_lto, << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_suse,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
   ##########
   #  Next  #
@@ -104,6 +106,7 @@
   - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_17}
   - {<< : *arm64_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_fedora,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *arm64_fedora_lto,  << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_virt,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *hexagon,           << : *next,             << : *llvm_full,       boot: false, << : *llvm_17}
@@ -147,6 +150,7 @@
   - {<< : *x86_64_alpine,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_arch,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_fedora,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *x86_64_fedora_lto, << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_suse,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
   ###########################
   #  Latest stable release  #
@@ -178,6 +182,7 @@
   - {<< : *arm64_allyes,      << : *stable,           << : *llvm_full,       boot: false, << : *llvm_17}
   - {<< : *arm64_alpine,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_fedora,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *arm64_fedora_lto,  << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_suse,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_virt,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *hexagon,           << : *stable,           << : *llvm_full,       boot: false, << : *llvm_17}
@@ -217,6 +222,7 @@
   - {<< : *x86_64_alpine,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_arch,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_fedora,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *x86_64_fedora_lto, << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_suse,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   ###########
   #  6.6.y  #

--- a/generator/yml/0009-llvm-latest.yml
+++ b/generator/yml/0009-llvm-latest.yml
@@ -32,6 +32,7 @@
   - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm64_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_fedora_lto,  << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_virt,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_hardening,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -79,6 +80,7 @@
   - {<< : *x86_64_alpine,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_arch,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_fedora,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_fedora_lto, << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_suse,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   ##########
   #  Next  #
@@ -110,6 +112,7 @@
   - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm64_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_fedora,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_fedora_lto,  << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_virt,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_hardening,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -159,6 +162,7 @@
   - {<< : *x86_64_alpine,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_arch,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_fedora,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_fedora_lto, << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_suse,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   ###########################
   #  Latest stable release  #
@@ -190,6 +194,7 @@
   - {<< : *arm64_allyes,      << : *stable,           << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm64_alpine,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_fedora,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_fedora_lto,  << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_suse,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_virt,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_hardening,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -234,6 +239,7 @@
   - {<< : *x86_64_alpine,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_arch,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_fedora,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_fedora_lto, << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_suse,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_hardening,  << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   ###########

--- a/generator/yml/0009-llvm-tot.yml
+++ b/generator/yml/0009-llvm-tot.yml
@@ -32,6 +32,7 @@
   - {<< : *arm64_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm64_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_fedora,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_fedora_lto,  << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_virt,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_hardening,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -79,6 +80,7 @@
   - {<< : *x86_64_alpine,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_arch,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_fedora,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_fedora_lto, << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_suse,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   ##########
   #  Next  #
@@ -110,6 +112,7 @@
   - {<< : *arm64_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm64_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_fedora,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_fedora_lto,  << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_virt,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_hardening,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -159,6 +162,7 @@
   - {<< : *x86_64_alpine,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_arch,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_fedora,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_fedora_lto, << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_suse,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   ###########################
   #  Latest stable release  #
@@ -190,6 +194,7 @@
   - {<< : *arm64_allyes,      << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm64_alpine,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_fedora,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_fedora_lto,  << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_suse,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_virt,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_hardening,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -234,6 +239,7 @@
   - {<< : *x86_64_alpine,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_arch,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_fedora,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_fedora_lto, << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_suse,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_hardening,  << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   ###########

--- a/tuxsuite/mainline-clang-17.tux.yml
+++ b/tuxsuite/mainline-clang-17.tux.yml
@@ -418,6 +418,16 @@ jobs:
   - target_arch: arm64
     toolchain: korg-clang-17
     kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
+    - CONFIG_LTO_CLANG_THIN=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: arm64
+    toolchain: korg-clang-17
+    kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
@@ -502,6 +512,16 @@ jobs:
   - target_arch: x86_64
     toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: korg-clang-17
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+    - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/mainline-clang-18.tux.yml
+++ b/tuxsuite/mainline-clang-18.tux.yml
@@ -458,6 +458,16 @@ jobs:
   - target_arch: arm64
     toolchain: korg-clang-18
     kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
+    - CONFIG_LTO_CLANG_THIN=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: arm64
+    toolchain: korg-clang-18
+    kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
@@ -544,6 +554,16 @@ jobs:
   - target_arch: x86_64
     toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: korg-clang-18
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+    - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/mainline-clang-19.tux.yml
+++ b/tuxsuite/mainline-clang-19.tux.yml
@@ -458,6 +458,16 @@ jobs:
   - target_arch: arm64
     toolchain: clang-nightly
     kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
+    - CONFIG_LTO_CLANG_THIN=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: arm64
+    toolchain: clang-nightly
+    kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
@@ -544,6 +554,16 @@ jobs:
   - target_arch: x86_64
     toolchain: clang-nightly
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-nightly
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+    - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/next-clang-17.tux.yml
+++ b/tuxsuite/next-clang-17.tux.yml
@@ -429,6 +429,16 @@ jobs:
   - target_arch: arm64
     toolchain: korg-clang-17
     kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
+    - CONFIG_LTO_CLANG_THIN=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: arm64
+    toolchain: korg-clang-17
+    kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
@@ -513,6 +523,16 @@ jobs:
   - target_arch: x86_64
     toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: korg-clang-17
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+    - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/next-clang-18.tux.yml
+++ b/tuxsuite/next-clang-18.tux.yml
@@ -469,6 +469,16 @@ jobs:
   - target_arch: arm64
     toolchain: korg-clang-18
     kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
+    - CONFIG_LTO_CLANG_THIN=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: arm64
+    toolchain: korg-clang-18
+    kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
@@ -555,6 +565,16 @@ jobs:
   - target_arch: x86_64
     toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: korg-clang-18
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+    - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/next-clang-19.tux.yml
+++ b/tuxsuite/next-clang-19.tux.yml
@@ -469,6 +469,16 @@ jobs:
   - target_arch: arm64
     toolchain: clang-nightly
     kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
+    - CONFIG_LTO_CLANG_THIN=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: arm64
+    toolchain: clang-nightly
+    kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
@@ -555,6 +565,16 @@ jobs:
   - target_arch: x86_64
     toolchain: clang-nightly
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-nightly
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+    - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/stable-clang-17.tux.yml
+++ b/tuxsuite/stable-clang-17.tux.yml
@@ -396,6 +396,16 @@ jobs:
   - target_arch: arm64
     toolchain: korg-clang-17
     kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
+    - CONFIG_LTO_CLANG_THIN=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: arm64
+    toolchain: korg-clang-17
+    kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
@@ -480,6 +490,16 @@ jobs:
   - target_arch: x86_64
     toolchain: korg-clang-17
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: korg-clang-17
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+    - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/stable-clang-18.tux.yml
+++ b/tuxsuite/stable-clang-18.tux.yml
@@ -434,6 +434,16 @@ jobs:
   - target_arch: arm64
     toolchain: korg-clang-18
     kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
+    - CONFIG_LTO_CLANG_THIN=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: arm64
+    toolchain: korg-clang-18
+    kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
@@ -518,6 +528,16 @@ jobs:
   - target_arch: x86_64
     toolchain: korg-clang-18
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: korg-clang-18
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+    - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/stable-clang-19.tux.yml
+++ b/tuxsuite/stable-clang-19.tux.yml
@@ -434,6 +434,16 @@ jobs:
   - target_arch: arm64
     toolchain: clang-nightly
     kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
+    - CONFIG_LTO_CLANG_THIN=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: arm64
+    toolchain: clang-nightly
+    kconfig:
     - https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
@@ -518,6 +528,16 @@ jobs:
   - target_arch: x86_64
     toolchain: clang-nightly
     kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: x86_64
+    toolchain: clang-nightly
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
+    - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
     make_variables:


### PR DESCRIPTION
Fedora builds with LTO when building with clang upstream, which is an important difference from how we currently build their configuration. Having side by side builds of LTO and no LTO is valuable for quickly narrowing down issues caused or exposed by LTO. Add a Fedora + ThinLTO build to match the official configuration and catch any regressions with this configuration from LLVM.

This is enabled for stable (6.8) and newer with LLVM 17 and newer to avoid adding too many builds to the matrix, which matches the versions of LLVM and the kernel that are in Fedora 40 and newer. This adds 90 builds per week.

Closes: https://github.com/ClangBuiltLinux/linux/issues/2009
