### PR TITLE
patches: Add workaround for https://github.com/ClangBuiltLinux/linux/issues/2014

### DIFF
--- a/patches/mainline/series
+++ b/patches/mainline/series
@@ -1,2 +1,3 @@
 7d80e7ebf9e333dc5463a48a914f55caef15f62f.patch
 v2_20240305_nathan_media_mxl5xx_move_xpt_structures_off_stack.patch
+workaround-cbl-2014.patch

--- a/patches/mainline/workaround-cbl-2014.patch
+++ b/patches/mainline/workaround-cbl-2014.patch
@@ -1,0 +1,27 @@
+From 7fff6119df84de4336e983d58f5e894206bc8d4d Mon Sep 17 00:00:00 2001
+From: Nathan Chancellor <nathan@kernel.org>
+Date: Wed, 10 Apr 2024 09:11:15 -0700
+Subject: [PATCH] Temporary hack for
+ https://github.com/ClangBuiltLinux/linux/issues/2014
+
+---
+ drivers/media/platform/mediatek/vcodec/decoder/Makefile | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/drivers/media/platform/mediatek/vcodec/decoder/Makefile b/drivers/media/platform/mediatek/vcodec/decoder/Makefile
+index 904cd22def84..e732e526d06c 100644
+--- a/drivers/media/platform/mediatek/vcodec/decoder/Makefile
++++ b/drivers/media/platform/mediatek/vcodec/decoder/Makefile
+@@ -22,4 +22,9 @@ mtk-vcodec-dec-y := vdec/vdec_h264_if.o \
+ 		mtk_vcodec_dec_stateless.o \
+ 		mtk_vcodec_dec_pm.o \
+ 
++# https://github.com/ClangBuiltLinux/linux/issues/2014
++ifeq ($(CONFIG_LOONGARCH)$(CONFIG_ARCH_STRICT_ALIGN)$(CONFIG_UBSAN_ARRAY_BOUNDS)$(call clang-min-version, 190000),yyyy)
++UBSAN_SANITIZE_vdec/vdec_vp9_req_lat_if.o := n
++endif
++
+ mtk-vcodec-dec-hw-y := mtk_vcodec_dec_hw.o
+-- 
+2.44.0
+

--- a/patches/next/series
+++ b/patches/next/series
@@ -1,1 +1,2 @@
 v2_20240305_nathan_media_mxl5xx_move_xpt_structures_off_stack.patch
+workaround-cbl-2014.patch

--- a/patches/next/workaround-cbl-2014.patch
+++ b/patches/next/workaround-cbl-2014.patch
@@ -1,0 +1,27 @@
+From 7fff6119df84de4336e983d58f5e894206bc8d4d Mon Sep 17 00:00:00 2001
+From: Nathan Chancellor <nathan@kernel.org>
+Date: Wed, 10 Apr 2024 09:11:15 -0700
+Subject: [PATCH] Temporary hack for
+ https://github.com/ClangBuiltLinux/linux/issues/2014
+
+---
+ drivers/media/platform/mediatek/vcodec/decoder/Makefile | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/drivers/media/platform/mediatek/vcodec/decoder/Makefile b/drivers/media/platform/mediatek/vcodec/decoder/Makefile
+index 904cd22def84..e732e526d06c 100644
+--- a/drivers/media/platform/mediatek/vcodec/decoder/Makefile
++++ b/drivers/media/platform/mediatek/vcodec/decoder/Makefile
+@@ -22,4 +22,9 @@ mtk-vcodec-dec-y := vdec/vdec_h264_if.o \
+ 		mtk_vcodec_dec_stateless.o \
+ 		mtk_vcodec_dec_pm.o \
+ 
++# https://github.com/ClangBuiltLinux/linux/issues/2014
++ifeq ($(CONFIG_LOONGARCH)$(CONFIG_ARCH_STRICT_ALIGN)$(CONFIG_UBSAN_ARRAY_BOUNDS)$(call clang-min-version, 190000),yyyy)
++UBSAN_SANITIZE_vdec/vdec_vp9_req_lat_if.o := n
++endif
++
+ mtk-vcodec-dec-hw-y := mtk_vcodec_dec_hw.o
+-- 
+2.44.0
+


### PR DESCRIPTION
This warning should likely be fixed with a change on the LLVM side. While that is worked on, hide this instances with a localized `UBSAN_SANITIZE := n` for the affected file.
