### PR TITLE
Drop RISC-V GKI builds

### DIFF
--- a/.github/workflows/android-mainline-clang-12.yml
+++ b/.github/workflows/android-mainline-clang-12.yml
@@ -134,34 +134,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _93eebbb3d39e4138918480a96661bfb5:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 gki_defconfig
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: riscv
-      LLVM_VERSION: 12
-      BOOT: 1
-      CONFIG: gki_defconfig
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _d24ad0cc4a0c9a09c6a8b5f717962455:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/android-mainline-clang-13.yml
+++ b/.github/workflows/android-mainline-clang-13.yml
@@ -134,34 +134,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _64d4082e3dfd4dbc4b23b68a5633e431:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: riscv
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: gki_defconfig
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _6597d87a555c679fa00784f2fd6c0f25:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/android-mainline-clang-14.yml
+++ b/.github/workflows/android-mainline-clang-14.yml
@@ -134,34 +134,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _bc4d9e79bec5d808043a57233a5d69be:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: riscv
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: gki_defconfig
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _7b80abae9889c18319bb557bedc34e57:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/android-mainline-clang-15.yml
+++ b/.github/workflows/android-mainline-clang-15.yml
@@ -162,34 +162,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _9d63787dd80567f37c0fba29cbdcbc48:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: riscv
-      LLVM_VERSION: 15
-      BOOT: 1
-      CONFIG: gki_defconfig
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   kick_tuxsuite_allconfigs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest

--- a/.github/workflows/android-mainline-clang-16.yml
+++ b/.github/workflows/android-mainline-clang-16.yml
@@ -134,34 +134,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _92b9a047dd08de5f3292d2704a843d08:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: riscv
-      LLVM_VERSION: 16
-      BOOT: 1
-      CONFIG: gki_defconfig
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _0313162a06bb046f4081c817855c8ac1:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/android-mainline-clang-17.yml
+++ b/.github/workflows/android-mainline-clang-17.yml
@@ -134,34 +134,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4953f3011f75ad44d5368294c9e65852:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: riscv
-      LLVM_VERSION: 17
-      BOOT: 1
-      CONFIG: gki_defconfig
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _c857a5b77f9ff7258c0b914b8ca906cd:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/android-mainline-clang-18.yml
+++ b/.github/workflows/android-mainline-clang-18.yml
@@ -134,34 +134,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _847819470d1d92795a672efbafff5951:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: riscv
-      LLVM_VERSION: 18
-      BOOT: 1
-      CONFIG: gki_defconfig
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _c89fe0a8c5057794c34bb22f1b69d33d:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/android-mainline-clang-19.yml
+++ b/.github/workflows/android-mainline-clang-19.yml
@@ -134,34 +134,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _08146471eb6125762b53c36ac9a3cde9:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: riscv
-      LLVM_VERSION: 19
-      BOOT: 1
-      CONFIG: gki_defconfig
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _69be54e07c0c29096e6473be61b248d6:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/android-mainline-clang-android.yml
+++ b/.github/workflows/android-mainline-clang-android.yml
@@ -134,34 +134,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b23e48c76a43ea3ebc8dad420a5b5d4b:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: riscv
-      LLVM_VERSION: android
-      BOOT: 1
-      CONFIG: gki_defconfig
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _54d3fa945b463031f59cd01c1779e62d:
     runs-on: ubuntu-latest
     needs:

--- a/generator/yml/0007-configs.yml
+++ b/generator/yml/0007-configs.yml
@@ -75,7 +75,6 @@ configs:
   - &riscv_no_efi      {config: [defconfig, CONFIG_EFI=n],                                                      kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
   - &riscv_alpine      {config: *riscv-alpine-config-url,                                                       kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
   - &riscv_suse        {config: *riscv-suse-config-url,                                                         kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
-  - &riscv_gki         {config: gki_defconfig,                                                                  kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
   - &s390              {config: defconfig,                                                                                                  ARCH: *s390-arch,       << : *kernel}
   - &s390_kasan        {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],             ARCH: *s390-arch,       << : *kernel}
   - &s390_fedora       {config: *s390-fedora-config-url,                                                                                    ARCH: *s390-arch,       << : *kernel}

--- a/generator/yml/0009-llvm-11.yml
+++ b/generator/yml/0009-llvm-11.yml
@@ -245,7 +245,6 @@
   - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, << : *llvm_android}
   - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
   - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
-  - {<< : *riscv_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_android}
   - {<< : *arm32_allmod,      << : *android15-6_6,    << : *llvm_full,       boot: false, << : *llvm_android}
   - {<< : *arm32_v7_t,        << : *android15-6_6,    << : *llvm_full,       boot: true,  << : *llvm_android}

--- a/generator/yml/0009-llvm-12.yml
+++ b/generator/yml/0009-llvm-12.yml
@@ -333,7 +333,6 @@
   - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm,            boot: false, << : *llvm_12}
   - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_12}
-  - {<< : *riscv_gki,         << : *android-mainline, << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *arm32_allmod,      << : *android15-6_6,    << : *llvm,            boot: false, << : *llvm_12}
   - {<< : *arm32_v7_t,        << : *android15-6_6,    << : *llvm,            boot: true,  << : *llvm_12}

--- a/generator/yml/0009-llvm-13.yml
+++ b/generator/yml/0009-llvm-13.yml
@@ -412,7 +412,6 @@
   - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *riscv_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm32_allmod,      << : *android15-6_6,    << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_v7_t,        << : *android15-6_6,    << : *llvm_full,       boot: true,  << : *llvm_13}

--- a/generator/yml/0009-llvm-14.yml
+++ b/generator/yml/0009-llvm-14.yml
@@ -418,7 +418,6 @@
   - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *riscv_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm32_allmod,      << : *android15-6_6,    << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *arm32_v7_t,        << : *android15-6_6,    << : *llvm_full,       boot: true,  << : *llvm_14}

--- a/generator/yml/0009-llvm-15.yml
+++ b/generator/yml/0009-llvm-15.yml
@@ -451,7 +451,6 @@
   - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_15}
-  - {<< : *riscv_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm32_allmod,      << : *android15-6_6,    << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *arm32_v7_t,        << : *android15-6_6,    << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64_gki,         << : *android15-6_6,    << : *llvm_full,       boot: true,  << : *llvm_15}

--- a/generator/yml/0009-llvm-16.yml
+++ b/generator/yml/0009-llvm-16.yml
@@ -474,7 +474,6 @@
   - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *riscv_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm32_allmod,      << : *android15-6_6,    << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *arm32_v7_t,        << : *android15-6_6,    << : *llvm_full,       boot: true,  << : *llvm_16}

--- a/generator/yml/0009-llvm-17.yml
+++ b/generator/yml/0009-llvm-17.yml
@@ -481,7 +481,6 @@
   - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, << : *llvm_17}
   - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *riscv_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm32_allmod,      << : *android15-6_6,    << : *llvm_full,       boot: false, << : *llvm_17}
   - {<< : *arm32_v7_t,        << : *android15-6_6,    << : *llvm_full,       boot: true,  << : *llvm_17}

--- a/generator/yml/0009-llvm-latest.yml
+++ b/generator/yml/0009-llvm-latest.yml
@@ -503,7 +503,6 @@
   - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *riscv_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm32_allmod,      << : *android15-6_6,    << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm32_v7_t,        << : *android15-6_6,    << : *llvm_full,       boot: true,  << : *llvm_latest}

--- a/generator/yml/0009-llvm-tot.yml
+++ b/generator/yml/0009-llvm-tot.yml
@@ -503,7 +503,6 @@
   - {<< : *arm32_allmod,      << : *android-mainline, << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm32_v7_t,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *riscv_gki,         << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_gki,        << : *android-mainline, << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm32_allmod,      << : *android15-6_6,    << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm32_v7_t,        << : *android15-6_6,    << : *llvm_full,       boot: true,  << : *llvm_tot}

--- a/tuxsuite/android-mainline-clang-12.tux.yml
+++ b/tuxsuite/android-mainline-clang-12.tux.yml
@@ -33,15 +33,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: riscv
-    toolchain: korg-clang-12
-    kconfig: gki_defconfig
-    targets:
-    - kernel
-    kernel_image: Image
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
   - target_arch: x86_64
     toolchain: korg-clang-12
     kconfig:

--- a/tuxsuite/android-mainline-clang-13.tux.yml
+++ b/tuxsuite/android-mainline-clang-13.tux.yml
@@ -33,15 +33,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: riscv
-    toolchain: korg-clang-13
-    kconfig: gki_defconfig
-    targets:
-    - kernel
-    kernel_image: Image
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-13
     kconfig:

--- a/tuxsuite/android-mainline-clang-14.tux.yml
+++ b/tuxsuite/android-mainline-clang-14.tux.yml
@@ -33,15 +33,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: riscv
-    toolchain: korg-clang-14
-    kconfig: gki_defconfig
-    targets:
-    - kernel
-    kernel_image: Image
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-14
     kconfig:

--- a/tuxsuite/android-mainline-clang-15.tux.yml
+++ b/tuxsuite/android-mainline-clang-15.tux.yml
@@ -43,15 +43,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: riscv
-    toolchain: korg-clang-15
-    kconfig: gki_defconfig
-    targets:
-    - kernel
-    kernel_image: Image
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
 - name: allconfigs
   builds:
   - target_arch: arm

--- a/tuxsuite/android-mainline-clang-16.tux.yml
+++ b/tuxsuite/android-mainline-clang-16.tux.yml
@@ -33,15 +33,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: riscv
-    toolchain: korg-clang-16
-    kconfig: gki_defconfig
-    targets:
-    - kernel
-    kernel_image: Image
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-16
     kconfig:

--- a/tuxsuite/android-mainline-clang-17.tux.yml
+++ b/tuxsuite/android-mainline-clang-17.tux.yml
@@ -33,15 +33,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: riscv
-    toolchain: korg-clang-17
-    kconfig: gki_defconfig
-    targets:
-    - kernel
-    kernel_image: Image
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-17
     kconfig:

--- a/tuxsuite/android-mainline-clang-18.tux.yml
+++ b/tuxsuite/android-mainline-clang-18.tux.yml
@@ -33,15 +33,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: riscv
-    toolchain: korg-clang-18
-    kconfig: gki_defconfig
-    targets:
-    - kernel
-    kernel_image: Image
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-18
     kconfig:

--- a/tuxsuite/android-mainline-clang-19.tux.yml
+++ b/tuxsuite/android-mainline-clang-19.tux.yml
@@ -33,15 +33,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: riscv
-    toolchain: clang-nightly
-    kconfig: gki_defconfig
-    targets:
-    - kernel
-    kernel_image: Image
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
     kconfig:

--- a/tuxsuite/android-mainline-clang-android.tux.yml
+++ b/tuxsuite/android-mainline-clang-android.tux.yml
@@ -33,15 +33,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: riscv
-    toolchain: clang-android
-    kconfig: gki_defconfig
-    targets:
-    - kernel
-    kernel_image: Image
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-android
     kconfig:


### PR DESCRIPTION
Support for RISC-V is being dropped in Android's common kernel:

https://android-review.googlesource.com/c/kernel/common/+/3061966
