### PR TITLE
Add a CONFIG_CFI_CLANG build for ARCH=arm on -next with LLVM >= 16

### DIFF
--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -190,6 +190,34 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _6caf4470519e51764e10589f05d70d73:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_defconfigs
+    - check_cache
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_CFI_CLANG=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: arm
+      LLVM_VERSION: 16
+      BOOT: 1
+      CONFIG: multi_v7_defconfig+CONFIG_CFI_CLANG=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_defconfigs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_defconfigs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _99f832d1047e3cd59873b7d37a5f9dd7:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/next-clang-17.yml
+++ b/.github/workflows/next-clang-17.yml
@@ -190,6 +190,34 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _dbcc7c8c97a20736fe248501b8b18733:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_defconfigs
+    - check_cache
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_CFI_CLANG=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: arm
+      LLVM_VERSION: 17
+      BOOT: 1
+      CONFIG: multi_v7_defconfig+CONFIG_CFI_CLANG=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_defconfigs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_defconfigs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _6c5f5d7bdbae9a86515c356aafd40713:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/next-clang-18.yml
+++ b/.github/workflows/next-clang-18.yml
@@ -190,6 +190,34 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _67e1fcae7d2eeb4ad0f5528446acd86d:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_defconfigs
+    - check_cache
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_CFI_CLANG=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: arm
+      LLVM_VERSION: 18
+      BOOT: 1
+      CONFIG: multi_v7_defconfig+CONFIG_CFI_CLANG=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_defconfigs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_defconfigs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _d7ad2c4a096dccb5b24d52248c8608ca:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/next-clang-19.yml
+++ b/.github/workflows/next-clang-19.yml
@@ -190,6 +190,34 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _bca6d618b51d85b3925a9169685f6e71:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_defconfigs
+    - check_cache
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_CFI_CLANG=y
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: arm
+      LLVM_VERSION: 19
+      BOOT: 1
+      CONFIG: multi_v7_defconfig+CONFIG_CFI_CLANG=y
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_defconfigs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_defconfigs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _8264e293bd3e23724234f37778bc3a15:
     runs-on: ubuntu-latest
     needs:

--- a/generator/yml/0007-configs.yml
+++ b/generator/yml/0007-configs.yml
@@ -10,6 +10,7 @@ configs:
   - &arm32_v6          {config: aspeed_g5_defconfig,                                                                                        ARCH: *arm-arch,        << : *kernel_dtbs}
   - &arm32_v7          {config: multi_v7_defconfig,                                                                                         ARCH: *arm-arch,        << : *kernel}
   - &arm32_v7_t        {config: [multi_v7_defconfig, CONFIG_THUMB2_KERNEL=y],                                                               ARCH: *arm-arch,        << : *kernel}
+  - &arm32_cfi         {config: [multi_v7_defconfig, CONFIG_CFI_CLANG=y],                                                                   ARCH: *arm-arch,        << : *kernel}
   - &arm32_imx         {config: imx_v4_v5_defconfig,                                                                                        ARCH: *arm-arch,        << : *default}
   - &arm32_omap        {config: omap2plus_defconfig,                                                                                        ARCH: *arm-arch,        << : *default}
   - &arm32_lpae_fp     {config: [multi_v7_defconfig, CONFIG_ARM_LPAE=y, CONFIG_UNWINDER_FRAME_POINTER=y],                                   ARCH: *arm-arch,        << : *kernel}

--- a/generator/yml/0009-llvm-16.yml
+++ b/generator/yml/0009-llvm-16.yml
@@ -81,6 +81,7 @@
   - {<< : *arm32_v6,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm32_v7,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm32_v7_t,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *arm32_cfi,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm32_imx,         << : *next,             << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *arm32_omap,        << : *next,             << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *arm32_lpae_fp,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}

--- a/generator/yml/0009-llvm-17.yml
+++ b/generator/yml/0009-llvm-17.yml
@@ -83,6 +83,7 @@
   - {<< : *arm32_v6,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm32_v7,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm32_v7_t,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *arm32_cfi,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm32_imx,         << : *next,             << : *llvm_full,       boot: false, << : *llvm_17}
   - {<< : *arm32_omap,        << : *next,             << : *llvm_full,       boot: false, << : *llvm_17}
   - {<< : *arm32_lpae_fp,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}

--- a/generator/yml/0009-llvm-latest.yml
+++ b/generator/yml/0009-llvm-latest.yml
@@ -89,6 +89,7 @@
   - {<< : *arm32_v6,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm32_v7,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm32_v7_t,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_cfi,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm32_imx,         << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm32_omap,        << : *next,             << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm32_lpae_fp,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}

--- a/generator/yml/0009-llvm-tot.yml
+++ b/generator/yml/0009-llvm-tot.yml
@@ -89,6 +89,7 @@
   - {<< : *arm32_v6,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm32_v7,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm32_v7_t,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_cfi,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm32_imx,         << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm32_omap,        << : *next,             << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm32_lpae_fp,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}

--- a/tuxsuite/next-clang-16.tux.yml
+++ b/tuxsuite/next-clang-16.tux.yml
@@ -51,6 +51,16 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: korg-clang-16
+    kconfig:
+    - multi_v7_defconfig
+    - CONFIG_CFI_CLANG=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: arm
+    toolchain: korg-clang-16
     kconfig: imx_v4_v5_defconfig
     targets:
     - default

--- a/tuxsuite/next-clang-17.tux.yml
+++ b/tuxsuite/next-clang-17.tux.yml
@@ -51,6 +51,16 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: korg-clang-17
+    kconfig:
+    - multi_v7_defconfig
+    - CONFIG_CFI_CLANG=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: arm
+    toolchain: korg-clang-17
     kconfig: imx_v4_v5_defconfig
     targets:
     - default

--- a/tuxsuite/next-clang-18.tux.yml
+++ b/tuxsuite/next-clang-18.tux.yml
@@ -51,6 +51,16 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: korg-clang-18
+    kconfig:
+    - multi_v7_defconfig
+    - CONFIG_CFI_CLANG=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: arm
+    toolchain: korg-clang-18
     kconfig: imx_v4_v5_defconfig
     targets:
     - default

--- a/tuxsuite/next-clang-19.tux.yml
+++ b/tuxsuite/next-clang-19.tux.yml
@@ -51,6 +51,16 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: clang-nightly
+    kconfig:
+    - multi_v7_defconfig
+    - CONFIG_CFI_CLANG=y
+    targets:
+    - kernel
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
+  - target_arch: arm
+    toolchain: clang-nightly
     kconfig: imx_v4_v5_defconfig
     targets:
     - default


### PR DESCRIPTION
`CONFIG_CFI_CLANG` is [now supported for `ARCH=arm` on -next](https://git.kernel.org/next/linux-next/c/1a4fec49efe5273eb2fcf575175a117745f76f97). kCFI was first added in LLVM 16, so add an `ARCH=arm defconfig` + `CONFIG_CFI_CLANG=y` build when using LLVM 16 or newer.
