### PR TITLE
Enable RISC-V allmodconfig ThinLTO builds on mainline

### DIFF
--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -1616,6 +1616,34 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _61186fd3eda520cd12c8508d59e5642f:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_allconfigs
+    - check_cache
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 14
+      BOOT: 0
+      CONFIG: allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_allconfigs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_allconfigs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _fe2c9057aa7118b7ceddc2c7bbdc8e2d:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/mainline-clang-17.yml
+++ b/.github/workflows/mainline-clang-17.yml
@@ -2008,6 +2008,34 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _8d42f068860c284b0cf1c3e69c6ba95c:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_allconfigs
+    - check_cache
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 17
+      BOOT: 0
+      CONFIG: allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_allconfigs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_allconfigs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _aefe45f6a7af5b92e2bee6cade8c823c:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/mainline-clang-18.yml
+++ b/.github/workflows/mainline-clang-18.yml
@@ -2176,6 +2176,34 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _773c4c0d80f04005802335236f84d00f:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_allconfigs
+    - check_cache
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 18
+      BOOT: 0
+      CONFIG: allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_allconfigs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_allconfigs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _023bdb66eac2efb5decd45b88317a7bd:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/mainline-clang-19.yml
+++ b/.github/workflows/mainline-clang-19.yml
@@ -2176,6 +2176,34 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _6e8de045238f3201ae3538f43bc29bdc:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_allconfigs
+    - check_cache
+    name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: riscv
+      LLVM_VERSION: 19
+      BOOT: 0
+      CONFIG: allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_allconfigs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_allconfigs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _6c8d9570f4fa572ebddb11289a3b1c8f:
     runs-on: ubuntu-latest
     needs:

--- a/generator/yml/0009-llvm-14.yml
+++ b/generator/yml/0009-llvm-14.yml
@@ -46,6 +46,7 @@
   - {<< : *riscv_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *riscv_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_14}
+  - {<< : *riscv_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *riscv_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *riscv_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *um,                << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}

--- a/generator/yml/0009-llvm-17.yml
+++ b/generator/yml/0009-llvm-17.yml
@@ -52,6 +52,7 @@
   - {<< : *riscv_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *riscv_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_17}
+  - {<< : *riscv_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_17}
   - {<< : *riscv_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *riscv_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *s390,              << : *mainline,         << : *clang_ias,       boot: true,  << : *llvm_17}

--- a/generator/yml/0009-llvm-latest.yml
+++ b/generator/yml/0009-llvm-latest.yml
@@ -57,6 +57,7 @@
   - {<< : *riscv_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *riscv_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
+  - {<< : *riscv_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *riscv_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *riscv_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *s390,              << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}

--- a/generator/yml/0009-llvm-tot.yml
+++ b/generator/yml/0009-llvm-tot.yml
@@ -57,6 +57,7 @@
   - {<< : *riscv_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *riscv_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
+  - {<< : *riscv_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *riscv_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *riscv_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *s390,              << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}

--- a/tuxsuite/mainline-clang-14.tux.yml
+++ b/tuxsuite/mainline-clang-14.tux.yml
@@ -512,6 +512,20 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: riscv
+    toolchain: korg-clang-14
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
+    - CONFIG_GCOV_KERNEL=n
+    - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_DRM_WERROR=n
+    targets:
+    - default
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-14
     kconfig: allmodconfig

--- a/tuxsuite/mainline-clang-17.tux.yml
+++ b/tuxsuite/mainline-clang-17.tux.yml
@@ -646,6 +646,20 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: riscv
+    toolchain: korg-clang-17
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
+    - CONFIG_GCOV_KERNEL=n
+    - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_DRM_WERROR=n
+    targets:
+    - default
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-17
     kconfig: allmodconfig

--- a/tuxsuite/mainline-clang-18.tux.yml
+++ b/tuxsuite/mainline-clang-18.tux.yml
@@ -708,6 +708,20 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: riscv
+    toolchain: korg-clang-18
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
+    - CONFIG_GCOV_KERNEL=n
+    - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_DRM_WERROR=n
+    targets:
+    - default
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-18
     kconfig: allmodconfig

--- a/tuxsuite/mainline-clang-19.tux.yml
+++ b/tuxsuite/mainline-clang-19.tux.yml
@@ -708,6 +708,20 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: riscv
+    toolchain: clang-nightly
+    kconfig:
+    - allmodconfig
+    - CONFIG_WERROR=n
+    - CONFIG_GCOV_KERNEL=n
+    - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_DRM_WERROR=n
+    targets:
+    - default
+    kernel_image: Image
+    make_variables:
+      LLVM: 1
+      LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
     kconfig: allmodconfig


### PR DESCRIPTION
This was missed when porting commit 9a01a2c ("Add support for RISC-V LTO on -next") from -next to mainline in commit 788146d ("generator: yml: Enable RISC-V LTO builds on mainline").
