### PR TITLE
scripts/build-local.py: Add else with assertion to clear up new pylint warning

### DIFF
--- a/scripts/build-local.py
+++ b/scripts/build-local.py
@@ -164,6 +164,8 @@ for name, builds in jobs.items():
                 distro = 'fedora'
             elif 'openSUSE' in url:
                 distro = 'opensuse'
+            else:
+                raise RuntimeError(f"URL ('{url}') was not handled?")
             cfg_str = cfg_str.replace(url, distro)
         specific_output_dir = Path(output_dir, toolchain, target_arch, cfg_str)
         specific_output_dir.mkdir(exist_ok=True, parents=True)


### PR DESCRIPTION
```
scripts/build-local.py:167:43: E0606: Possibly using variable 'distro' before assignment (possibly-used-before-assignment)
```
