### PR TITLE
Disable CONFIG_DRM_WERROR for certain Fedora configurations

### DIFF
--- a/.github/workflows/6.1-clang-11.yml
+++ b/.github/workflows/6.1-clang-11.yml
@@ -987,18 +987,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _07918b2671019496e596aabd08a61cf7:
+  _f66e59da9fe5f9626d127fac364a0944:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.1-clang-12.yml
+++ b/.github/workflows/6.1-clang-12.yml
@@ -1015,18 +1015,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _55896a4c2f1a6e21d369347ecf8a4e78:
+  _e22a8d62564f313df0ef6ce9bbb7f719:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.1-clang-13.yml
+++ b/.github/workflows/6.1-clang-13.yml
@@ -1043,18 +1043,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _fa6c358e91380b361e42af1bd52d0673:
+  _6325b5ec37ba4b2fa4865821ad485593:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.1-clang-14.yml
+++ b/.github/workflows/6.1-clang-14.yml
@@ -1043,18 +1043,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _45dacf10349373096ed44899cd870b2d:
+  _be66271c32f19b821970180f38a586a7:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.1-clang-15.yml
+++ b/.github/workflows/6.1-clang-15.yml
@@ -1127,18 +1127,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _487a3e8cc5183a63efdd929f11ece328:
+  _38f00460479d7ba5694195980692648d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1239,18 +1239,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _5e7d56eabe8c445a66a4d70bd40a7fab:
+  _65c3d3587bfd8c0e08fa010ff108ec27:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.1-clang-16.yml
+++ b/.github/workflows/6.1-clang-16.yml
@@ -1267,18 +1267,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3c66a950bb1f47f9ea519dd01ebc589f:
+  _a6c6a38b8502a0cf594e26da352c2b7c:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1379,18 +1379,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7dd066fedb317d23ffd5332c0fe34dac:
+  _f3a42d5711fc7960cf4a21beec3d71ad:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.1-clang-17.yml
+++ b/.github/workflows/6.1-clang-17.yml
@@ -1267,18 +1267,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _d75fb6d5c6e540bdc63f6cad858222ae:
+  _72663a4ee605c1657318795b61ca465e:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1379,18 +1379,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _19d11312dc6f057d41e531f682c1b285:
+  _0aca49d9e5133d324850af65e4d47a8a:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.1-clang-18.yml
+++ b/.github/workflows/6.1-clang-18.yml
@@ -1267,18 +1267,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _5e87558f48368d658d68c8e6a9c32b66:
+  _4fd3e331c7b4a6600a0e16b57e291baf:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1379,18 +1379,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _85c021aa7070a43cffc70e8eb749333d:
+  _35a5603080f6ec759d1e7e1cd4b68485:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.1-clang-19.yml
+++ b/.github/workflows/6.1-clang-19.yml
@@ -1267,18 +1267,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _c1017c26306edbf2fe4d4ef3bdd57c06:
+  _f809e329fba47a9a7ef5c5067de41439:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1379,18 +1379,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b2fe3d92de2f9c8f3356bd83602f25a7:
+  _15b03a9cd1672003f73c91600633c540:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.6-clang-11.yml
+++ b/.github/workflows/6.6-clang-11.yml
@@ -987,18 +987,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _07918b2671019496e596aabd08a61cf7:
+  _f66e59da9fe5f9626d127fac364a0944:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 11
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.6-clang-12.yml
+++ b/.github/workflows/6.6-clang-12.yml
@@ -1015,18 +1015,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _55896a4c2f1a6e21d369347ecf8a4e78:
+  _e22a8d62564f313df0ef6ce9bbb7f719:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 12
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.6-clang-13.yml
+++ b/.github/workflows/6.6-clang-13.yml
@@ -1043,18 +1043,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _fa6c358e91380b361e42af1bd52d0673:
+  _6325b5ec37ba4b2fa4865821ad485593:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.6-clang-14.yml
+++ b/.github/workflows/6.6-clang-14.yml
@@ -1043,18 +1043,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _45dacf10349373096ed44899cd870b2d:
+  _be66271c32f19b821970180f38a586a7:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.6-clang-15.yml
+++ b/.github/workflows/6.6-clang-15.yml
@@ -1127,18 +1127,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _487a3e8cc5183a63efdd929f11ece328:
+  _38f00460479d7ba5694195980692648d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1239,18 +1239,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _5e7d56eabe8c445a66a4d70bd40a7fab:
+  _65c3d3587bfd8c0e08fa010ff108ec27:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.6-clang-16.yml
+++ b/.github/workflows/6.6-clang-16.yml
@@ -1267,18 +1267,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3c66a950bb1f47f9ea519dd01ebc589f:
+  _a6c6a38b8502a0cf594e26da352c2b7c:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1379,18 +1379,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7dd066fedb317d23ffd5332c0fe34dac:
+  _f3a42d5711fc7960cf4a21beec3d71ad:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.6-clang-17.yml
+++ b/.github/workflows/6.6-clang-17.yml
@@ -1267,18 +1267,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _d75fb6d5c6e540bdc63f6cad858222ae:
+  _72663a4ee605c1657318795b61ca465e:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1379,18 +1379,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _19d11312dc6f057d41e531f682c1b285:
+  _0aca49d9e5133d324850af65e4d47a8a:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.6-clang-18.yml
+++ b/.github/workflows/6.6-clang-18.yml
@@ -1323,18 +1323,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _5e87558f48368d658d68c8e6a9c32b66:
+  _4fd3e331c7b4a6600a0e16b57e291baf:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1435,18 +1435,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _85c021aa7070a43cffc70e8eb749333d:
+  _35a5603080f6ec759d1e7e1cd4b68485:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.6-clang-19.yml
+++ b/.github/workflows/6.6-clang-19.yml
@@ -1323,18 +1323,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _c1017c26306edbf2fe4d4ef3bdd57c06:
+  _f809e329fba47a9a7ef5c5067de41439:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1435,18 +1435,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b2fe3d92de2f9c8f3356bd83602f25a7:
+  _15b03a9cd1672003f73c91600633c540:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-13.yml
+++ b/.github/workflows/mainline-clang-13.yml
@@ -1043,18 +1043,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _fa6c358e91380b361e42af1bd52d0673:
+  _6325b5ec37ba4b2fa4865821ad485593:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -1099,18 +1099,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _45dacf10349373096ed44899cd870b2d:
+  _be66271c32f19b821970180f38a586a7:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -1183,18 +1183,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _487a3e8cc5183a63efdd929f11ece328:
+  _38f00460479d7ba5694195980692648d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1295,18 +1295,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _5e7d56eabe8c445a66a4d70bd40a7fab:
+  _65c3d3587bfd8c0e08fa010ff108ec27:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -1323,18 +1323,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3c66a950bb1f47f9ea519dd01ebc589f:
+  _a6c6a38b8502a0cf594e26da352c2b7c:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1435,18 +1435,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7dd066fedb317d23ffd5332c0fe34dac:
+  _f3a42d5711fc7960cf4a21beec3d71ad:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-17.yml
+++ b/.github/workflows/mainline-clang-17.yml
@@ -1351,18 +1351,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _d75fb6d5c6e540bdc63f6cad858222ae:
+  _72663a4ee605c1657318795b61ca465e:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1463,18 +1463,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _19d11312dc6f057d41e531f682c1b285:
+  _0aca49d9e5133d324850af65e4d47a8a:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-18.yml
+++ b/.github/workflows/mainline-clang-18.yml
@@ -1463,18 +1463,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _5e87558f48368d658d68c8e6a9c32b66:
+  _4fd3e331c7b4a6600a0e16b57e291baf:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1575,18 +1575,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b09613e175e3f625085032870643e265:
+  _cc8b389e2953f213936d92179b2ae967:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-19.yml
+++ b/.github/workflows/mainline-clang-19.yml
@@ -1463,18 +1463,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _c1017c26306edbf2fe4d4ef3bdd57c06:
+  _f809e329fba47a9a7ef5c5067de41439:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1575,18 +1575,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _fa1e0cf8480f115830476f059cbe53bb:
+  _dcf635ff03c97826752041fc02a0b098:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-13.yml
+++ b/.github/workflows/next-clang-13.yml
@@ -1071,18 +1071,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _fa6c358e91380b361e42af1bd52d0673:
+  _6325b5ec37ba4b2fa4865821ad485593:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -1127,18 +1127,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _45dacf10349373096ed44899cd870b2d:
+  _be66271c32f19b821970180f38a586a7:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -1211,18 +1211,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _487a3e8cc5183a63efdd929f11ece328:
+  _38f00460479d7ba5694195980692648d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1323,18 +1323,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _5e7d56eabe8c445a66a4d70bd40a7fab:
+  _65c3d3587bfd8c0e08fa010ff108ec27:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -1379,18 +1379,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3c66a950bb1f47f9ea519dd01ebc589f:
+  _a6c6a38b8502a0cf594e26da352c2b7c:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1491,18 +1491,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7dd066fedb317d23ffd5332c0fe34dac:
+  _f3a42d5711fc7960cf4a21beec3d71ad:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-17.yml
+++ b/.github/workflows/next-clang-17.yml
@@ -1407,18 +1407,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _d75fb6d5c6e540bdc63f6cad858222ae:
+  _72663a4ee605c1657318795b61ca465e:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1519,18 +1519,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _19d11312dc6f057d41e531f682c1b285:
+  _0aca49d9e5133d324850af65e4d47a8a:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-18.yml
+++ b/.github/workflows/next-clang-18.yml
@@ -1519,18 +1519,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _5e87558f48368d658d68c8e6a9c32b66:
+  _4fd3e331c7b4a6600a0e16b57e291baf:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1631,18 +1631,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b09613e175e3f625085032870643e265:
+  _cc8b389e2953f213936d92179b2ae967:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-19.yml
+++ b/.github/workflows/next-clang-19.yml
@@ -1519,18 +1519,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _c1017c26306edbf2fe4d4ef3bdd57c06:
+  _f809e329fba47a9a7ef5c5067de41439:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1631,18 +1631,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _fa1e0cf8480f115830476f059cbe53bb:
+  _dcf635ff03c97826752041fc02a0b098:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -1043,18 +1043,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _fa6c358e91380b361e42af1bd52d0673:
+  _6325b5ec37ba4b2fa4865821ad485593:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 13
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -1099,18 +1099,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _45dacf10349373096ed44899cd870b2d:
+  _be66271c32f19b821970180f38a586a7:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 14
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -1183,18 +1183,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _487a3e8cc5183a63efdd929f11ece328:
+  _38f00460479d7ba5694195980692648d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1295,18 +1295,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _5e7d56eabe8c445a66a4d70bd40a7fab:
+  _65c3d3587bfd8c0e08fa010ff108ec27:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 15
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/stable-clang-16.yml
+++ b/.github/workflows/stable-clang-16.yml
@@ -1323,18 +1323,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3c66a950bb1f47f9ea519dd01ebc589f:
+  _a6c6a38b8502a0cf594e26da352c2b7c:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1435,18 +1435,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7dd066fedb317d23ffd5332c0fe34dac:
+  _f3a42d5711fc7960cf4a21beec3d71ad:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/stable-clang-17.yml
+++ b/.github/workflows/stable-clang-17.yml
@@ -1351,18 +1351,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _d75fb6d5c6e540bdc63f6cad858222ae:
+  _72663a4ee605c1657318795b61ca465e:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1463,18 +1463,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _19d11312dc6f057d41e531f682c1b285:
+  _0aca49d9e5133d324850af65e4d47a8a:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/stable-clang-18.yml
+++ b/.github/workflows/stable-clang-18.yml
@@ -1463,18 +1463,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _5e87558f48368d658d68c8e6a9c32b66:
+  _4fd3e331c7b4a6600a0e16b57e291baf:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1575,18 +1575,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _b09613e175e3f625085032870643e265:
+  _cc8b389e2953f213936d92179b2ae967:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/stable-clang-19.yml
+++ b/.github/workflows/stable-clang-19.yml
@@ -1463,18 +1463,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _c1017c26306edbf2fe4d4ef3bdd57c06:
+  _f809e329fba47a9a7ef5c5067de41439:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: powerpc
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1575,18 +1575,18 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _fa1e0cf8480f115830476f059cbe53bb:
+  _dcf635ff03c97826752041fc02a0b098:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
-    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: s390
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+      CONFIG: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/generator/yml/0007-configs.yml
+++ b/generator/yml/0007-configs.yml
@@ -62,7 +62,8 @@ configs:
   # Disable -Werror for ppc64_guest_defconfig for clang-13 and older: https://github.com/ClangBuiltLinux/linux/issues/1445
   - &ppc64_no_werror   {config: [ppc64_guest_defconfig, CONFIG_PPC_DISABLE_WERROR=y],                           kernel_image: vmlinux,      ARCH: *powerpc-arch,    << : *kernel}
   - &ppc64le           {config: powernv_defconfig,                                                              kernel_image: zImage.epapr, ARCH: *powerpc-arch,    << : *kernel}
-  - &ppc64le_fedora    {config: *ppc64le-fedora-config-url,                                                     kernel_image: zImage.epapr, ARCH: *powerpc-arch,    << : *kernel}
+  # CONFIG_DRM_WERROR=n due to https://github.com/ClangBuiltLinux/linux/issues/2036
+  - &ppc64le_fedora    {config: [*ppc64le-fedora-config-url, CONFIG_DRM_WERROR=n],                              kernel_image: zImage.epapr, ARCH: *powerpc-arch,    << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for pre-5.18 cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
   - &ppc64le_fedora_bpf {config: [*ppc64le-fedora-config-url, CONFIG_BPF_PRELOAD=n],                            kernel_image: zImage.epapr, ARCH: *powerpc-arch,    << : *kernel}
   - &ppc64le_suse      {config: *ppc64le-suse-config-url,                                                       kernel_image: zImage.epapr, ARCH: *powerpc-arch,    << : *kernel}

--- a/generator/yml/0007-configs.yml
+++ b/generator/yml/0007-configs.yml
@@ -79,7 +79,8 @@ configs:
   - &riscv_suse        {config: *riscv-suse-config-url,                                                         kernel_image: Image,        ARCH: *riscv-arch,      << : *kernel}
   - &s390              {config: defconfig,                                                                                                  ARCH: *s390-arch,       << : *kernel}
   - &s390_kasan        {config: [defconfig, CONFIG_KASAN=y, CONFIG_KASAN_KUNIT_TEST=y, CONFIG_KASAN_VMALLOC=y, CONFIG_KUNIT=y],             ARCH: *s390-arch,       << : *kernel}
-  - &s390_fedora       {config: *s390-fedora-config-url,                                                                                    ARCH: *s390-arch,       << : *kernel}
+  # CONFIG_DRM_WERROR=n due to https://github.com/ClangBuiltLinux/linux/issues/1285
+  - &s390_fedora       {config: [*s390-fedora-config-url, CONFIG_DRM_WERROR=n],                                                             ARCH: *s390-arch,       << : *kernel}
   # CONFIG_BPF_PRELOAD disabled for pre-5.18 cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
   - &s390_fedora_bpf   {config: [*s390-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                            ARCH: *s390-arch,       << : *kernel}
   - &s390_suse         {config: *s390-suse-config-url,                                                                                      ARCH: *s390-arch,       << : *kernel}

--- a/tuxsuite/6.1-clang-11.tux.yml
+++ b/tuxsuite/6.1-clang-11.tux.yml
@@ -312,7 +312,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-11
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/6.1-clang-12.tux.yml
+++ b/tuxsuite/6.1-clang-12.tux.yml
@@ -323,7 +323,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-12
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/6.1-clang-13.tux.yml
+++ b/tuxsuite/6.1-clang-13.tux.yml
@@ -335,7 +335,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-13
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/6.1-clang-14.tux.yml
+++ b/tuxsuite/6.1-clang-14.tux.yml
@@ -333,7 +333,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-14
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/6.1-clang-15.tux.yml
+++ b/tuxsuite/6.1-clang-15.tux.yml
@@ -362,7 +362,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-15
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -398,7 +400,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-15
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/6.1-clang-16.tux.yml
+++ b/tuxsuite/6.1-clang-16.tux.yml
@@ -413,7 +413,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-16
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -449,7 +451,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-16
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/6.1-clang-17.tux.yml
+++ b/tuxsuite/6.1-clang-17.tux.yml
@@ -413,7 +413,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-17
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -449,7 +451,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-17
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/6.1-clang-18.tux.yml
+++ b/tuxsuite/6.1-clang-18.tux.yml
@@ -413,7 +413,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-18
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -449,7 +451,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-18
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/6.1-clang-19.tux.yml
+++ b/tuxsuite/6.1-clang-19.tux.yml
@@ -413,7 +413,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -449,7 +451,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: clang-nightly
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/6.6-clang-11.tux.yml
+++ b/tuxsuite/6.6-clang-11.tux.yml
@@ -313,7 +313,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-11
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/6.6-clang-12.tux.yml
+++ b/tuxsuite/6.6-clang-12.tux.yml
@@ -323,7 +323,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-12
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/6.6-clang-13.tux.yml
+++ b/tuxsuite/6.6-clang-13.tux.yml
@@ -335,7 +335,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-13
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/6.6-clang-14.tux.yml
+++ b/tuxsuite/6.6-clang-14.tux.yml
@@ -333,7 +333,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-14
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/6.6-clang-15.tux.yml
+++ b/tuxsuite/6.6-clang-15.tux.yml
@@ -362,7 +362,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-15
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -398,7 +400,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-15
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/6.6-clang-16.tux.yml
+++ b/tuxsuite/6.6-clang-16.tux.yml
@@ -413,7 +413,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-16
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -449,7 +451,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-16
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/6.6-clang-17.tux.yml
+++ b/tuxsuite/6.6-clang-17.tux.yml
@@ -413,7 +413,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-17
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -449,7 +451,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-17
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/6.6-clang-18.tux.yml
+++ b/tuxsuite/6.6-clang-18.tux.yml
@@ -431,7 +431,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-18
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -467,7 +469,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-18
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/6.6-clang-19.tux.yml
+++ b/tuxsuite/6.6-clang-19.tux.yml
@@ -431,7 +431,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -467,7 +469,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: clang-nightly
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/mainline-clang-13.tux.yml
+++ b/tuxsuite/mainline-clang-13.tux.yml
@@ -335,7 +335,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-13
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/mainline-clang-14.tux.yml
+++ b/tuxsuite/mainline-clang-14.tux.yml
@@ -355,7 +355,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-14
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/mainline-clang-15.tux.yml
+++ b/tuxsuite/mainline-clang-15.tux.yml
@@ -384,7 +384,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-15
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -420,7 +422,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-15
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/mainline-clang-16.tux.yml
+++ b/tuxsuite/mainline-clang-16.tux.yml
@@ -435,7 +435,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-16
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -471,7 +473,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-16
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/mainline-clang-17.tux.yml
+++ b/tuxsuite/mainline-clang-17.tux.yml
@@ -445,7 +445,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-17
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -481,7 +483,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-17
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/mainline-clang-18.tux.yml
+++ b/tuxsuite/mainline-clang-18.tux.yml
@@ -485,7 +485,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-18
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -521,7 +523,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-18
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/mainline-clang-19.tux.yml
+++ b/tuxsuite/mainline-clang-19.tux.yml
@@ -485,7 +485,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -521,7 +523,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: clang-nightly
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/next-clang-13.tux.yml
+++ b/tuxsuite/next-clang-13.tux.yml
@@ -345,7 +345,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-13
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/next-clang-14.tux.yml
+++ b/tuxsuite/next-clang-14.tux.yml
@@ -365,7 +365,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-14
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/next-clang-15.tux.yml
+++ b/tuxsuite/next-clang-15.tux.yml
@@ -394,7 +394,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-15
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -430,7 +432,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-15
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/next-clang-16.tux.yml
+++ b/tuxsuite/next-clang-16.tux.yml
@@ -455,7 +455,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-16
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -491,7 +493,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-16
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/next-clang-17.tux.yml
+++ b/tuxsuite/next-clang-17.tux.yml
@@ -465,7 +465,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-17
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -501,7 +503,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-17
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/next-clang-18.tux.yml
+++ b/tuxsuite/next-clang-18.tux.yml
@@ -505,7 +505,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-18
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -541,7 +543,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-18
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/next-clang-19.tux.yml
+++ b/tuxsuite/next-clang-19.tux.yml
@@ -505,7 +505,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -541,7 +543,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: clang-nightly
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/stable-clang-13.tux.yml
+++ b/tuxsuite/stable-clang-13.tux.yml
@@ -335,7 +335,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-13
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/stable-clang-14.tux.yml
+++ b/tuxsuite/stable-clang-14.tux.yml
@@ -355,7 +355,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-14
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr

--- a/tuxsuite/stable-clang-15.tux.yml
+++ b/tuxsuite/stable-clang-15.tux.yml
@@ -384,7 +384,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-15
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -420,7 +422,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-15
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/stable-clang-16.tux.yml
+++ b/tuxsuite/stable-clang-16.tux.yml
@@ -435,7 +435,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-16
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -471,7 +473,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-16
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/stable-clang-17.tux.yml
+++ b/tuxsuite/stable-clang-17.tux.yml
@@ -445,7 +445,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-17
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -481,7 +483,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-17
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/stable-clang-18.tux.yml
+++ b/tuxsuite/stable-clang-18.tux.yml
@@ -485,7 +485,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: korg-clang-18
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -521,7 +523,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: korg-clang-18
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/stable-clang-19.tux.yml
+++ b/tuxsuite/stable-clang-19.tux.yml
@@ -485,7 +485,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: powerpc
     toolchain: clang-nightly
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     kernel_image: zImage.epapr
@@ -521,7 +523,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: s390
     toolchain: clang-nightly
-    kconfig: https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    kconfig:
+    - https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config
+    - CONFIG_DRM_WERROR=n
     targets:
     - kernel
     make_variables:


### PR DESCRIPTION
Fedora has turned on `CONFIG_DRM_WERROR` as of [this commit](https://src.fedoraproject.org/rpms/kernel/c/bef170ccecb11ccfd02b35b40868207706941e22?branch=rawhide). For some configurations, this is not a problem but it is for powerpc and s390. While those issues are sorted out and/or investigated, disable this configuration for these builds so that they are still end to end tested.
