### PR TITLE
Disable CONFIG_DRM_OMAP with LoongArch configurations

### DIFF
--- a/.github/workflows/6.6-clang-18.yml
+++ b/.github/workflows/6.6-clang-18.yml
@@ -1896,18 +1896,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _03fb3a458a2932225d42f868649d6285:
+  _70edc4828baa096aebb148ac9449c627:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_DRM_OMAP=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1924,18 +1924,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _c1cdf2678eeae9d3f6207b9c46a72d59:
+  _9c3aa0ba596ee2d56a7fba8c89d9791c:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.6-clang-20.yml
+++ b/.github/workflows/6.6-clang-20.yml
@@ -1896,18 +1896,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _2b4144e9f058b8fe9bcf9f8c73ccb0a6:
+  _d04ab9cb20a908b426976920fdbd04e3:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 20
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_DRM_OMAP=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1924,18 +1924,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _99e8c2e8226482536e0d6e550cec4700:
+  _48e1899f415421c18c6f52941e0cbfd2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 20
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-18.yml
+++ b/.github/workflows/mainline-clang-18.yml
@@ -2064,18 +2064,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _03fb3a458a2932225d42f868649d6285:
+  _70edc4828baa096aebb148ac9449c627:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_DRM_OMAP=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -2092,18 +2092,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _c1cdf2678eeae9d3f6207b9c46a72d59:
+  _9c3aa0ba596ee2d56a7fba8c89d9791c:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-20.yml
+++ b/.github/workflows/mainline-clang-20.yml
@@ -2064,18 +2064,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _2b4144e9f058b8fe9bcf9f8c73ccb0a6:
+  _d04ab9cb20a908b426976920fdbd04e3:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 20
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_DRM_OMAP=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -2092,18 +2092,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _99e8c2e8226482536e0d6e550cec4700:
+  _48e1899f415421c18c6f52941e0cbfd2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 20
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-18.yml
+++ b/.github/workflows/next-clang-18.yml
@@ -2120,18 +2120,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _03fb3a458a2932225d42f868649d6285:
+  _70edc4828baa096aebb148ac9449c627:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_DRM_OMAP=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -2148,18 +2148,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _c1cdf2678eeae9d3f6207b9c46a72d59:
+  _9c3aa0ba596ee2d56a7fba8c89d9791c:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-20.yml
+++ b/.github/workflows/next-clang-20.yml
@@ -2120,18 +2120,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _2b4144e9f058b8fe9bcf9f8c73ccb0a6:
+  _d04ab9cb20a908b426976920fdbd04e3:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 20
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_DRM_OMAP=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -2148,18 +2148,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _99e8c2e8226482536e0d6e550cec4700:
+  _48e1899f415421c18c6f52941e0cbfd2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 20
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/stable-clang-18.yml
+++ b/.github/workflows/stable-clang-18.yml
@@ -2064,18 +2064,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _03fb3a458a2932225d42f868649d6285:
+  _70edc4828baa096aebb148ac9449c627:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_DRM_OMAP=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -2092,18 +2092,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _c1cdf2678eeae9d3f6207b9c46a72d59:
+  _9c3aa0ba596ee2d56a7fba8c89d9791c:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 18
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/stable-clang-20.yml
+++ b/.github/workflows/stable-clang-20.yml
@@ -2064,18 +2064,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _2b4144e9f058b8fe9bcf9f8c73ccb0a6:
+  _d04ab9cb20a908b426976920fdbd04e3:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 20
       BOOT: 0
-      CONFIG: allmodconfig
+      CONFIG: allmodconfig+CONFIG_DRM_OMAP=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -2092,18 +2092,18 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _99e8c2e8226482536e0d6e550cec4700:
+  _48e1899f415421c18c6f52941e0cbfd2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
-    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: loongarch
       LLVM_VERSION: 20
       BOOT: 0
-      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/generator/yml/0007-configs.yml
+++ b/generator/yml/0007-configs.yml
@@ -53,8 +53,9 @@ configs:
   - &i386_suse         {config: *i386-suse-config-url,                                                                                      ARCH: *i386-arch,       << : *default}
   - &loong             {config: defconfig,                                                                                                  ARCH: *loongarch-arch,  << : *kernel}
   - &loong_lto_thin    {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                       ARCH: *loongarch-arch,  << : *kernel}
-  - &loong_allmod      {config: allmodconfig,                                                                                               ARCH: *loongarch-arch,  << : *default}
-  - &loong_allmod_lto  {config: [allmodconfig, CONFIG_FTRACE=n, CONFIG_GCOV_KERNEL=n, CONFIG_LTO_CLANG_THIN=y],                             ARCH: *loongarch-arch,  << : *default}
+  # CONFIG_DRM_OMAP=n due to https://github.com/ClangBuiltLinux/linux/issues/2038
+  - &loong_allmod      {config: [allmodconfig, CONFIG_DRM_OMAP=n],                                                                          ARCH: *loongarch-arch,  << : *default}
+  - &loong_allmod_lto  {config: [allmodconfig, CONFIG_FTRACE=n, CONFIG_GCOV_KERNEL=n, CONFIG_LTO_CLANG_THIN=y, CONFIG_DRM_OMAP=n],          ARCH: *loongarch-arch,  << : *default}
   - &mips              {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y, CONFIG_CPU_BIG_ENDIAN=y],            kernel_image: vmlinux,      ARCH: *mips-arch,       << : *kernel}
   - &mipsel            {config: [malta_defconfig, CONFIG_BLK_DEV_INITRD=y],                                     kernel_image: vmlinux,      ARCH: *mips-arch,       << : *kernel}
   - &ppc32             {config: ppc44x_defconfig,                                                               kernel_image: uImage,       ARCH: *powerpc-arch,    << : *kernel}

--- a/tuxsuite/6.6-clang-18.tux.yml
+++ b/tuxsuite/6.6-clang-18.tux.yml
@@ -604,7 +604,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: loongarch
     toolchain: korg-clang-18
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_DRM_OMAP=n
     targets:
     - default
     make_variables:
@@ -617,6 +619,7 @@ jobs:
     - CONFIG_FTRACE=n
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_DRM_OMAP=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/6.6-clang-20.tux.yml
+++ b/tuxsuite/6.6-clang-20.tux.yml
@@ -604,7 +604,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: loongarch
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_DRM_OMAP=n
     targets:
     - default
     make_variables:
@@ -617,6 +619,7 @@ jobs:
     - CONFIG_FTRACE=n
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_DRM_OMAP=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/mainline-clang-18.tux.yml
+++ b/tuxsuite/mainline-clang-18.tux.yml
@@ -669,7 +669,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: loongarch
     toolchain: korg-clang-18
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_DRM_OMAP=n
     targets:
     - default
     make_variables:
@@ -682,6 +684,7 @@ jobs:
     - CONFIG_FTRACE=n
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_DRM_OMAP=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/mainline-clang-20.tux.yml
+++ b/tuxsuite/mainline-clang-20.tux.yml
@@ -669,7 +669,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: loongarch
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_DRM_OMAP=n
     targets:
     - default
     make_variables:
@@ -682,6 +684,7 @@ jobs:
     - CONFIG_FTRACE=n
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_DRM_OMAP=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/next-clang-18.tux.yml
+++ b/tuxsuite/next-clang-18.tux.yml
@@ -690,7 +690,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: loongarch
     toolchain: korg-clang-18
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_DRM_OMAP=n
     targets:
     - default
     make_variables:
@@ -703,6 +705,7 @@ jobs:
     - CONFIG_FTRACE=n
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_DRM_OMAP=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/next-clang-20.tux.yml
+++ b/tuxsuite/next-clang-20.tux.yml
@@ -690,7 +690,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: loongarch
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_DRM_OMAP=n
     targets:
     - default
     make_variables:
@@ -703,6 +705,7 @@ jobs:
     - CONFIG_FTRACE=n
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_DRM_OMAP=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/stable-clang-18.tux.yml
+++ b/tuxsuite/stable-clang-18.tux.yml
@@ -670,7 +670,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: loongarch
     toolchain: korg-clang-18
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_DRM_OMAP=n
     targets:
     - default
     make_variables:
@@ -683,6 +685,7 @@ jobs:
     - CONFIG_FTRACE=n
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_DRM_OMAP=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/stable-clang-20.tux.yml
+++ b/tuxsuite/stable-clang-20.tux.yml
@@ -670,7 +670,9 @@ jobs:
       LLVM_IAS: 1
   - target_arch: loongarch
     toolchain: clang-nightly
-    kconfig: allmodconfig
+    kconfig:
+    - allmodconfig
+    - CONFIG_DRM_OMAP=n
     targets:
     - default
     make_variables:
@@ -683,6 +685,7 @@ jobs:
     - CONFIG_FTRACE=n
     - CONFIG_GCOV_KERNEL=n
     - CONFIG_LTO_CLANG_THIN=y
+    - CONFIG_DRM_OMAP=n
     targets:
     - default
     make_variables:


### PR DESCRIPTION
A recent change in linux-next allows this driver to be built with `CONFIG_COMPILE_TEST=y`, which causes a couple instances of `-Wframe-larger-than` to show up with `ARCH=loongarch`. This appears to be an issue in LLVM, for which I filed an issue. As this code won't actually run on LoongArch machines, just disable it to avoid having to turn off `CONFIG_WERROR` altogether with this configuration.

Link: https://github.com/ClangBuiltLinux/linux/issues/2038
