### PR TITLE
Drop OpenSUSE's PowerPC configuration from 5.15

### DIFF
--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -987,34 +987,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _25f87da1043f926ba53aee8e9493b399:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_distribution_configs
-    - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: powerpc
-      LLVM_VERSION: 11
-      BOOT: 1
-      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _56346298d74420f54e010a2d76dc70d1:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -1071,34 +1071,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _a1c5ea612cdbf834b80c6187336f6949:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_distribution_configs
-    - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: powerpc
-      LLVM_VERSION: 12
-      BOOT: 1
-      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _6a01647ada93ad6be921a6c12aff0c60:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -1155,34 +1155,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _409b28e38bc385e6d3d3068f3489ea8c:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_distribution_configs
-    - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: powerpc
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _fb6058c4a5aade8dd9afe91a3e96a21a:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -1155,34 +1155,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e8fe479b70c34d11aad415d50bf69af1:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_distribution_configs
-    - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: powerpc
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _5ebb54d2427e2fa01846a377746ae95c:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -1183,34 +1183,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _cf214bc1ac3d0d1e5d672c288d3a49e6:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_distribution_configs
-    - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: powerpc
-      LLVM_VERSION: 15
-      BOOT: 1
-      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _532945e0d765170a7ede23bee03bc324:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/5.15-clang-16.yml
+++ b/.github/workflows/5.15-clang-16.yml
@@ -1183,34 +1183,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e51c25ab2c25ecb7f9a88c6fd1887202:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_distribution_configs
-    - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: powerpc
-      LLVM_VERSION: 16
-      BOOT: 1
-      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _6b0b88c9d2487641ed8bd1d04878d9be:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/5.15-clang-17.yml
+++ b/.github/workflows/5.15-clang-17.yml
@@ -1183,34 +1183,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _8877458831e5cd486f5c65a01e2f98b8:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_distribution_configs
-    - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: powerpc
-      LLVM_VERSION: 17
-      BOOT: 1
-      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _8aabfc8320e1c02358f81a35f05ed329:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/5.15-clang-18.yml
+++ b/.github/workflows/5.15-clang-18.yml
@@ -1183,34 +1183,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e217b6b06b4cccc3e1f6678f8bdb66df:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_distribution_configs
-    - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: powerpc
-      LLVM_VERSION: 18
-      BOOT: 1
-      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _d9406a3c6f448622f5fa76e53bb6606d:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/5.15-clang-19.yml
+++ b/.github/workflows/5.15-clang-19.yml
@@ -1183,34 +1183,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3dd97e4f726478e3c9a8bea258edf262:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_distribution_configs
-    - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: powerpc
-      LLVM_VERSION: 19
-      BOOT: 1
-      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _028623f9d1f214d514a13b05774b5679:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/5.15-clang-20.yml
+++ b/.github/workflows/5.15-clang-20.yml
@@ -1183,34 +1183,6 @@ jobs:
         name: boot_utils_json_distribution_configs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _f0c7c87617a071094bcd3713479db3eb:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_distribution_configs
-    - check_cache
-    name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: powerpc
-      LLVM_VERSION: 20
-      BOOT: 1
-      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _58ff2bae5b5b7b7b6d62f8f6142cadb3:
     runs-on: ubuntu-latest
     needs:

--- a/generator/yml/0009-llvm-11.yml
+++ b/generator/yml/0009-llvm-11.yml
@@ -160,7 +160,6 @@
   # - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  << : *llvm_11}
   - {<< : *ppc64le,           << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  << : *llvm_11}
   - {<< : *ppc64le_fedora_bpf, << : *stable-5_15,     << : *clang,           boot: true,  << : *llvm_11}
-  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_11}
   - {<< : *riscv,             << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_11}
   - {<< : *riscv_alpine,      << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}

--- a/generator/yml/0009-llvm-12.yml
+++ b/generator/yml/0009-llvm-12.yml
@@ -160,7 +160,6 @@
   - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  << : *llvm_12}
   - {<< : *ppc64le,           << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *ppc64le_fedora_bpf, << : *stable-5_15,     << : *clang,           boot: true,  << : *llvm_12}
-  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_12}
   - {<< : *riscv,             << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_12}
   - {<< : *riscv_alpine,      << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}

--- a/generator/yml/0009-llvm-13.yml
+++ b/generator/yml/0009-llvm-13.yml
@@ -336,7 +336,6 @@
   - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  << : *llvm_13}
   - {<< : *ppc64le,           << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_13}
   - {<< : *ppc64le_fedora_bpf, << : *stable-5_15,     << : *clang,           boot: true,  << : *llvm_13}
-  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_13}
   - {<< : *riscv,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *riscv_alpine,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}

--- a/generator/yml/0009-llvm-14.yml
+++ b/generator/yml/0009-llvm-14.yml
@@ -346,7 +346,6 @@
   - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  << : *llvm_14}
   - {<< : *ppc64le,           << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_14}
   - {<< : *ppc64le_fedora_bpf, << : *stable-5_15,     << : *clang,           boot: true,  << : *llvm_14}
-  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_14}
   - {<< : *riscv,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *riscv_alpine,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}

--- a/generator/yml/0009-llvm-15.yml
+++ b/generator/yml/0009-llvm-15.yml
@@ -373,7 +373,6 @@
   - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  << : *llvm_15}
   - {<< : *ppc64le,           << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_15}
   - {<< : *ppc64le_fedora_bpf, << : *stable-5_15,     << : *clang,           boot: true,  << : *llvm_15}
-  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_15}
   - {<< : *riscv,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *riscv_alpine,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_15}

--- a/generator/yml/0009-llvm-16.yml
+++ b/generator/yml/0009-llvm-16.yml
@@ -400,7 +400,6 @@
   - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  << : *llvm_16}
   - {<< : *ppc64le,           << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_16}
   - {<< : *ppc64le_fedora_bpf, << : *stable-5_15,     << : *clang,           boot: true,  << : *llvm_16}
-  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_16}
   - {<< : *riscv,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *riscv_alpine,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_16}

--- a/generator/yml/0009-llvm-17.yml
+++ b/generator/yml/0009-llvm-17.yml
@@ -409,7 +409,6 @@
   - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  << : *llvm_17}
   - {<< : *ppc64le,           << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_17}
   - {<< : *ppc64le_fedora_bpf, << : *stable-5_15,     << : *clang,           boot: true,  << : *llvm_17}
-  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_17}
   - {<< : *riscv,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_17}
   - {<< : *riscv_alpine,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_17}

--- a/generator/yml/0009-llvm-18.yml
+++ b/generator/yml/0009-llvm-18.yml
@@ -431,7 +431,6 @@
   - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  << : *llvm_18}
   - {<< : *ppc64le,           << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_18}
   - {<< : *ppc64le_fedora_bpf, << : *stable-5_15,     << : *clang,           boot: true,  << : *llvm_18}
-  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_18}
   - {<< : *riscv,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_18}
   - {<< : *riscv_alpine,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_18}

--- a/generator/yml/0009-llvm-latest.yml
+++ b/generator/yml/0009-llvm-latest.yml
@@ -431,7 +431,6 @@
   - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  << : *llvm_latest}
   - {<< : *ppc64le,           << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_latest}
   - {<< : *ppc64le_fedora_bpf, << : *stable-5_15,     << : *clang,           boot: true,  << : *llvm_latest}
-  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_latest}
   - {<< : *riscv,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *riscv_alpine,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}

--- a/generator/yml/0009-llvm-tot.yml
+++ b/generator/yml/0009-llvm-tot.yml
@@ -431,7 +431,6 @@
   - {<< : *ppc64,             << : *stable-5_15,      << : *ppc64_llvm,      boot: true,  << : *llvm_tot}
   - {<< : *ppc64le,           << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_tot}
   - {<< : *ppc64le_fedora_bpf, << : *stable-5_15,     << : *clang,           boot: true,  << : *llvm_tot}
-  - {<< : *ppc64le_suse,      << : *stable-5_15,      << : *clang,           boot: true,  << : *llvm_tot}
   - {<< : *riscv,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *riscv_allmod,      << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *riscv_alpine,      << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}

--- a/tuxsuite/5.15-clang-11.tux.yml
+++ b/tuxsuite/5.15-clang-11.tux.yml
@@ -314,14 +314,6 @@ jobs:
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
-  - target_arch: powerpc
-    toolchain: korg-clang-11
-    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    targets:
-    - kernel
-    kernel_image: zImage.epapr
-    make_variables:
-      LLVM_IAS: 0
   - target_arch: riscv
     toolchain: korg-clang-11
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64

--- a/tuxsuite/5.15-clang-12.tux.yml
+++ b/tuxsuite/5.15-clang-12.tux.yml
@@ -343,14 +343,6 @@ jobs:
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
-  - target_arch: powerpc
-    toolchain: korg-clang-12
-    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    targets:
-    - kernel
-    kernel_image: zImage.epapr
-    make_variables:
-      LLVM_IAS: 0
   - target_arch: riscv
     toolchain: korg-clang-12
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64

--- a/tuxsuite/5.15-clang-13.tux.yml
+++ b/tuxsuite/5.15-clang-13.tux.yml
@@ -374,14 +374,6 @@ jobs:
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
-  - target_arch: powerpc
-    toolchain: korg-clang-13
-    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    targets:
-    - kernel
-    kernel_image: zImage.epapr
-    make_variables:
-      LLVM_IAS: 0
   - target_arch: riscv
     toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64

--- a/tuxsuite/5.15-clang-14.tux.yml
+++ b/tuxsuite/5.15-clang-14.tux.yml
@@ -374,14 +374,6 @@ jobs:
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
-  - target_arch: powerpc
-    toolchain: korg-clang-14
-    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    targets:
-    - kernel
-    kernel_image: zImage.epapr
-    make_variables:
-      LLVM_IAS: 0
   - target_arch: riscv
     toolchain: korg-clang-14
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64

--- a/tuxsuite/5.15-clang-15.tux.yml
+++ b/tuxsuite/5.15-clang-15.tux.yml
@@ -384,14 +384,6 @@ jobs:
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
-  - target_arch: powerpc
-    toolchain: korg-clang-15
-    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    targets:
-    - kernel
-    kernel_image: zImage.epapr
-    make_variables:
-      LLVM_IAS: 0
   - target_arch: riscv
     toolchain: korg-clang-15
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64

--- a/tuxsuite/5.15-clang-16.tux.yml
+++ b/tuxsuite/5.15-clang-16.tux.yml
@@ -384,14 +384,6 @@ jobs:
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
-  - target_arch: powerpc
-    toolchain: korg-clang-16
-    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    targets:
-    - kernel
-    kernel_image: zImage.epapr
-    make_variables:
-      LLVM_IAS: 0
   - target_arch: riscv
     toolchain: korg-clang-16
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64

--- a/tuxsuite/5.15-clang-17.tux.yml
+++ b/tuxsuite/5.15-clang-17.tux.yml
@@ -384,14 +384,6 @@ jobs:
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
-  - target_arch: powerpc
-    toolchain: korg-clang-17
-    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    targets:
-    - kernel
-    kernel_image: zImage.epapr
-    make_variables:
-      LLVM_IAS: 0
   - target_arch: riscv
     toolchain: korg-clang-17
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64

--- a/tuxsuite/5.15-clang-18.tux.yml
+++ b/tuxsuite/5.15-clang-18.tux.yml
@@ -384,14 +384,6 @@ jobs:
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
-  - target_arch: powerpc
-    toolchain: korg-clang-18
-    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    targets:
-    - kernel
-    kernel_image: zImage.epapr
-    make_variables:
-      LLVM_IAS: 0
   - target_arch: riscv
     toolchain: korg-clang-18
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64

--- a/tuxsuite/5.15-clang-19.tux.yml
+++ b/tuxsuite/5.15-clang-19.tux.yml
@@ -384,14 +384,6 @@ jobs:
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
-  - target_arch: powerpc
-    toolchain: korg-clang-19
-    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    targets:
-    - kernel
-    kernel_image: zImage.epapr
-    make_variables:
-      LLVM_IAS: 0
   - target_arch: riscv
     toolchain: korg-clang-19
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64

--- a/tuxsuite/5.15-clang-20.tux.yml
+++ b/tuxsuite/5.15-clang-20.tux.yml
@@ -384,14 +384,6 @@ jobs:
     kernel_image: zImage.epapr
     make_variables:
       LLVM_IAS: 0
-  - target_arch: powerpc
-    toolchain: clang-nightly
-    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
-    targets:
-    - kernel
-    kernel_image: zImage.epapr
-    make_variables:
-      LLVM_IAS: 0
   - target_arch: riscv
     toolchain: clang-nightly
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64


### PR DESCRIPTION
OpenSUSE recently [increased `CONFIG_NR_CPUS` to `8192` for the powerpc64leconfiguration](https://github.com/openSUSE/kernel-source/commit/20a31e9f1f5630dec71c579f76e63a593ebe3258) to match other architectures. Unfortunately, this breaks the build on 5.15 with:

```
arch/powerpc/kvm/book3s_64_entry.S:231: Error: operand out of range (0x109ba is not between 0xffffffffffff8000 and 0x7fff)
arch/powerpc/kvm/book3s_64_entry.S:384: Error: operand out of range (0x10178 is not between 0xffffffffffff8000 and 0x7fff)
arch/powerpc/kvm/book3s_64_entry.S:389: Error: operand out of range (0x10180 is not between 0xffffffffffff8000 and 0x7ffc)
arch/powerpc/kvm/book3s_hv_rmhandlers.S:551: Error: operand out of range (0x10148 is not between 0xffffffffffff8000 and 0x7fff)
arch/powerpc/kvm/book3s_hv_rmhandlers.S:552: Error: operand out of range (0x10188 is not between 0xffffffffffff8000 and 0x7ffc)
arch/powerpc/kvm/book3s_hv_rmhandlers.S:1432: Error: operand out of range (0x10178 is not between 0xffffffffffff8000 and 0x7fff)
arch/powerpc/kvm/book3s_hv_rmhandlers.S:1433: Error: operand out of range (0x10190 is not between 0xffffffffffff8000 and 0x7ffc)
arch/powerpc/kvm/book3s_hv_rmhandlers.S:1496: Error: operand out of range (0x10180 is not between 0xffffffffffff8000 and 0x7ffc)
arch/powerpc/kvm/book3s_hv_rmhandlers.S:1658: Error: operand out of range (0x101a0 is not between 0xffffffffffff8000 and 0x7ffc)
arch/powerpc/kvm/book3s_hv_rmhandlers.S:1723: Error: operand out of range (0x101a0 is not between 0xffffffffffff8000 and 0x7ffc)
arch/powerpc/kvm/book3s_hv_rmhandlers.S:1748: Error: operand out of range (0x10a20 is not between 0xffffffffffff8000 and 0x7ffc)
arch/powerpc/kvm/book3s_hv_interrupts.S:66: Error: operand out of range (0x10180 is not between 0xffffffffffff8000 and 0x7ffc)
```

This is not clang specific, as it happens with GCC as well.

Doing a reverse bisect between 5.15 and 6.1 points to commit [c5b077549136](https://git.kernel.org/linus/c5b077549136584618a66258f09d8d4b41e7409c) ("KVM: Convert the kvm->vcpus array to a xarray") in 5.17 fixing this issue but that change is part of a larger series that does not really appear to be stable material.

To avoid configuration fragmentation and/or changing the value for all trees, just stop building this configuration in 5.15. If others eventually notice this and it gets fixed in stable, it can bere-enabled.
