### PR TITLE
patches: tip: Add iio bmi323 patch from mainline folder

### DIFF
--- a/patches/tip/series
+++ b/patches/tip/series
@@ -1,1 +1,2 @@
 0001-lib-Kconfig.debug-Force-disable-BUILTIN_MODULE_RANGE.patch
+v2_20240916_dan_carpenter_iio_bmi323_fix_copy_and_paste_bugs_in_suspend_resume.patch

--- a/patches/tip/v2_20240916_dan_carpenter_iio_bmi323_fix_copy_and_paste_bugs_in_suspend_resume.patch
+++ b/patches/tip/v2_20240916_dan_carpenter_iio_bmi323_fix_copy_and_paste_bugs_in_suspend_resume.patch
@@ -1,0 +1,65 @@
+From git@z Thu Jan  1 00:00:00 1970
+Subject: [PATCH v2 1/2] iio: bmi323: fix copy and paste bugs in suspend
+ resume
+From: Dan Carpenter <dan.carpenter@linaro.org>
+Date: Mon, 16 Sep 2024 17:09:10 +0300
+Message-Id: <7175b8ec-85cf-4fbf-a4e1-c4c43c3b665c@stanley.mountain>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+This code is using bmi323_reg_savestate[] and ->reg_settings[] instead
+of bmi323_ext_reg_savestate[] and ->ext_reg_settings[].  This was
+discovered by Smatch:
+
+    drivers/iio/imu/bmi323/bmi323_core.c:2202 bmi323_core_runtime_suspend()
+    error: buffer overflow 'bmi323_reg_savestate' 9 <= 11
+
+Fixes: 16531118ba63 ("iio: bmi323: peripheral in lowest power state on suspend")
+Signed-off-by: Dan Carpenter <dan.carpenter@linaro.org>
+Link: https://lore.kernel.org/r/7175b8ec-85cf-4fbf-a4e1-c4c43c3b665c@stanley.mountain
+---
+v2: no change
+
+ drivers/iio/imu/bmi323/bmi323_core.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/iio/imu/bmi323/bmi323_core.c b/drivers/iio/imu/bmi323/bmi323_core.c
+index 89eab40bcfdf..f6ff07ba98cd 100644
+--- a/drivers/iio/imu/bmi323/bmi323_core.c
++++ b/drivers/iio/imu/bmi323/bmi323_core.c
+@@ -2193,12 +2193,12 @@ static int bmi323_core_runtime_suspend(struct device *dev)
+ 	}
+ 
+ 	for (unsigned int i = 0; i < ARRAY_SIZE(bmi323_ext_reg_savestate); i++) {
+-		ret = bmi323_read_ext_reg(data, bmi323_reg_savestate[i],
+-					  &savestate->reg_settings[i]);
++		ret = bmi323_read_ext_reg(data, bmi323_ext_reg_savestate[i],
++					  &savestate->ext_reg_settings[i]);
+ 		if (ret) {
+ 			dev_err(data->dev,
+ 				"Error reading bmi323 external reg 0x%x: %d\n",
+-				bmi323_reg_savestate[i], ret);
++				bmi323_ext_reg_savestate[i], ret);
+ 			return ret;
+ 		}
+ 	}
+@@ -2237,12 +2237,12 @@ static int bmi323_core_runtime_resume(struct device *dev)
+ 	}
+ 
+ 	for (unsigned int i = 0; i < ARRAY_SIZE(bmi323_ext_reg_savestate); i++) {
+-		ret = bmi323_write_ext_reg(data, bmi323_reg_savestate[i],
+-					   savestate->reg_settings[i]);
++		ret = bmi323_write_ext_reg(data, bmi323_ext_reg_savestate[i],
++					   savestate->ext_reg_settings[i]);
+ 		if (ret) {
+ 			dev_err(data->dev,
+ 				"Error writing bmi323 external reg 0x%x: %d\n",
+-				bmi323_reg_savestate[i], ret);
++				bmi323_ext_reg_savestate[i], ret);
+ 			return ret;
+ 		}
+ 	}
+-- 
+2.45.2
+


### PR DESCRIPTION
-tip is now synced with 6.12-rc1, which includes the warning addressed by the patch added in #777. Apply it to -tip for the same reason.
