### PR TITLE
Add initial support for testing sparc64

### DIFF
--- a/.github/workflows/next-clang-20.yml
+++ b/.github/workflows/next-clang-20.yml
@@ -974,6 +974,34 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _c1f95a5d10da4358dc9fbc0075f7a8ca:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_defconfigs
+    - check_cache
+    name: ARCH=sparc CC=clang LLVM_IAS=0 LLVM_VERSION=20 sparc64_defconfig
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: sparc
+      LLVM_VERSION: 20
+      BOOT: 1
+      CONFIG: sparc64_defconfig
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_defconfigs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_defconfigs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _d549f06de3b0361d62337ef98fc167b9:
     runs-on: ubuntu-latest
     needs:

--- a/generator/yml/0005-architectures.yml
+++ b/generator/yml/0005-architectures.yml
@@ -8,4 +8,5 @@ architectures:
   - &powerpc-arch   powerpc
   - &riscv-arch     riscv
   - &s390-arch      s390
+  - &sparc-arch     sparc
   - &um-arch        um

--- a/generator/yml/0007-configs.yml
+++ b/generator/yml/0007-configs.yml
@@ -85,6 +85,7 @@ configs:
   # CONFIG_BPF_PRELOAD disabled for pre-5.18 cross compiled Fedora configs: https://github.com/ClangBuiltLinux/linux/issues/1433
   - &s390_fedora_bpf   {config: [*s390-fedora-config-url, CONFIG_BPF_PRELOAD=n],                                                            ARCH: *s390-arch,       << : *kernel}
   - &s390_suse         {config: *s390-suse-config-url,                                                                                      ARCH: *s390-arch,       << : *kernel}
+  - &sparc64           {config: sparc64_defconfig,                                                              kernel_image: image,        ARCH: *sparc-arch,      << : *kernel}
   - &um                {config: defconfig,                                                                                                  ARCH: *um-arch,         << : *kernel}
   - &x86_64            {config: defconfig,                                                                                                                          << : *kernel}
   - &x86_64_lto_full   {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                                               << : *kernel}

--- a/generator/yml/0009-llvm-tot.yml
+++ b/generator/yml/0009-llvm-tot.yml
@@ -147,6 +147,7 @@
   - {<< : *s390_kasan,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *s390_fedora,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *s390_suse,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *sparc64,           << : *next,             << : *clang,           boot: true,  << : *llvm_tot}
   - {<< : *um,                << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}

--- a/tuxsuite/next-clang-20.tux.yml
+++ b/tuxsuite/next-clang-20.tux.yml
@@ -328,6 +328,14 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: sparc
+    toolchain: clang-nightly
+    kconfig: sparc64_defconfig
+    targets:
+    - kernel
+    kernel_image: image
+    make_variables:
+      LLVM_IAS: 0
   - target_arch: um
     toolchain: clang-nightly
     kconfig: defconfig

--- a/utils.py
+++ b/utils.py
@@ -60,6 +60,7 @@ def get_image_name():
         "mips": "vmlinux",
         "riscv": "Image",
         "s390": "bzImage",
+        "sparc": "image",
         "um": "linux",
         "x86_64": "bzImage",
     }[arch]
@@ -126,6 +127,7 @@ def get_cbl_name():
         "ppc44x_defconfig": "ppc32",
         "ppc64_guest_defconfig": "ppc64",
         "powernv_defconfig": "ppc64le",
+        "sparc64_defconfig": "sparc64",
     }
     if "CONFIG_CPU_BIG_ENDIAN=y" in full_config:
         if arch == "arm64":


### PR DESCRIPTION
This is now supported in [tuxmake 1.28.4](https://gitlab.com/Linaro/tuxmake/-/merge_requests/456) and [boot-utils](https://github.com/ClangBuiltLinux/boot-utils/pull/122).

Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/786
