### PR TITLE
Enable sparc64 build on mainline

### DIFF
--- a/.github/workflows/mainline-clang-20.yml
+++ b/.github/workflows/mainline-clang-20.yml
@@ -974,6 +974,34 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
+  _c1f95a5d10da4358dc9fbc0075f7a8ca:
+    runs-on: ubuntu-latest
+    needs:
+    - kick_tuxsuite_defconfigs
+    - check_cache
+    name: ARCH=sparc CC=clang LLVM_IAS=0 LLVM_VERSION=20 sparc64_defconfig
+    if: ${{ needs.check_cache.outputs.status != 'pass' }}
+    env:
+      ARCH: sparc
+      LLVM_VERSION: 20
+      BOOT: 1
+      CONFIG: sparc64_defconfig
+      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
+    container:
+      image: ghcr.io/clangbuiltlinux/qemu
+      options: --ipc=host
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/download-artifact@v4
+      with:
+        name: output_artifact_defconfigs
+    - uses: actions/download-artifact@v4
+      with:
+        name: boot_utils_json_defconfigs
+    - name: Check Build and Boot Logs
+      run: scripts/check-logs.py
   _d549f06de3b0361d62337ef98fc167b9:
     runs-on: ubuntu-latest
     needs:

--- a/generator/yml/0009-llvm-tot.yml
+++ b/generator/yml/0009-llvm-tot.yml
@@ -65,6 +65,7 @@
   - {<< : *s390_kasan,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *s390_fedora,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *s390_suse,         << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *sparc64,           << : *mainline,         << : *clang,           boot: true,  << : *llvm_tot}
   - {<< : *um,                << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}

--- a/tuxsuite/mainline-clang-20.tux.yml
+++ b/tuxsuite/mainline-clang-20.tux.yml
@@ -329,6 +329,14 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
+  - target_arch: sparc
+    toolchain: clang-nightly
+    kconfig: sparc64_defconfig
+    targets:
+    - kernel
+    kernel_image: image
+    make_variables:
+      LLVM_IAS: 0
   - target_arch: um
     toolchain: clang-nightly
     kconfig: defconfig


### PR DESCRIPTION
The changes needed to build `ARCH=sparc` with `clang` have [landed in mainline](https://git.kernel.org/linus/fbb3c22f908accfd6fd34b1dbdd304fc2609c78a).
