### PR TITLE
Add a step to check if patches apply before invoking TuxSuite

### DIFF
--- a/.github/workflows/4.19-clang-13.yml
+++ b/.github/workflows/4.19-clang-13.yml
@@ -16,10 +16,18 @@ name: 4.19 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/4.19 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-4.19.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-4.19.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/4.19-clang-14.yml
+++ b/.github/workflows/4.19-clang-14.yml
@@ -16,10 +16,18 @@ name: 4.19 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/4.19 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-4.19.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-4.19.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=14 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/4.19-clang-15.yml
+++ b/.github/workflows/4.19-clang-15.yml
@@ -16,10 +16,18 @@ name: 4.19 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/4.19 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-4.19.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-4.19.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=15 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/4.19-clang-16.yml
+++ b/.github/workflows/4.19-clang-16.yml
@@ -16,10 +16,18 @@ name: 4.19 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/4.19 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-4.19.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-4.19.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=16 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/4.19-clang-17.yml
+++ b/.github/workflows/4.19-clang-17.yml
@@ -16,10 +16,18 @@ name: 4.19 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/4.19 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-4.19.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-4.19.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=17 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/4.19-clang-18.yml
+++ b/.github/workflows/4.19-clang-18.yml
@@ -16,10 +16,18 @@ name: 4.19 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/4.19 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-4.19.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-4.19.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=18 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/4.19-clang-19.yml
+++ b/.github/workflows/4.19-clang-19.yml
@@ -16,10 +16,18 @@ name: 4.19 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/4.19 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-4.19.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-4.19.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=19 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/4.19-clang-20.yml
+++ b/.github/workflows/4.19-clang-20.yml
@@ -16,10 +16,18 @@ name: 4.19 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/4.19 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-4.19.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-4.19.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=20 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.10-clang-11.yml
+++ b/.github/workflows/5.10-clang-11.yml
@@ -16,10 +16,18 @@ name: 5.10 (clang-11)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.10 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.10.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-11
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.10.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_EFI=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -362,7 +382,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -404,6 +426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -432,6 +455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -460,6 +484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -488,6 +513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -516,6 +542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -544,6 +571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -572,6 +600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -600,6 +629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -628,6 +658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.10-clang-12.yml
+++ b/.github/workflows/5.10-clang-12.yml
@@ -16,10 +16,18 @@ name: 5.10 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.10 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.10.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-12
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.10.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=12 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_EFI=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -418,7 +440,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -460,6 +484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -488,6 +513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -516,6 +542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -544,6 +571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -572,6 +600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -600,6 +629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -628,6 +658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -656,6 +687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -684,6 +716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.10-clang-13.yml
+++ b/.github/workflows/5.10-clang-13.yml
@@ -16,10 +16,18 @@ name: 5.10 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.10 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.10.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.10.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=13 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -474,7 +498,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -516,6 +542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -544,6 +571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -572,6 +600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -600,6 +629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -628,6 +658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -656,6 +687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -684,6 +716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -712,6 +745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -740,6 +774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.10-clang-14.yml
+++ b/.github/workflows/5.10-clang-14.yml
@@ -16,10 +16,18 @@ name: 5.10 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.10 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.10.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.10.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=14 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -474,7 +498,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -516,6 +542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -544,6 +571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -572,6 +600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -600,6 +629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -628,6 +658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -656,6 +687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -684,6 +716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -712,6 +745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -740,6 +774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.10-clang-15.yml
+++ b/.github/workflows/5.10-clang-15.yml
@@ -16,10 +16,18 @@ name: 5.10 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.10 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.10.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.10.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=15 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -502,7 +527,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -544,6 +571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -572,6 +600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -600,6 +629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -628,6 +658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -656,6 +687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -684,6 +716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -712,6 +745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -740,6 +774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -768,6 +803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.10-clang-16.yml
+++ b/.github/workflows/5.10-clang-16.yml
@@ -16,10 +16,18 @@ name: 5.10 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.10 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.10.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.10.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=16 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -502,7 +527,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -544,6 +571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -572,6 +600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -600,6 +629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -628,6 +658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -656,6 +687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -684,6 +716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -712,6 +745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -740,6 +774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -768,6 +803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.10-clang-17.yml
+++ b/.github/workflows/5.10-clang-17.yml
@@ -16,10 +16,18 @@ name: 5.10 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.10 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.10.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.10.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=17 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -502,7 +527,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -544,6 +571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -572,6 +600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -600,6 +629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -628,6 +658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -656,6 +687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -684,6 +716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -712,6 +745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -740,6 +774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -768,6 +803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.10-clang-18.yml
+++ b/.github/workflows/5.10-clang-18.yml
@@ -16,10 +16,18 @@ name: 5.10 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.10 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.10.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.10.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=18 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -502,7 +527,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -544,6 +571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -572,6 +600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -600,6 +629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -628,6 +658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -656,6 +687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -684,6 +716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -712,6 +745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -740,6 +774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -768,6 +803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.10-clang-19.yml
+++ b/.github/workflows/5.10-clang-19.yml
@@ -16,10 +16,18 @@ name: 5.10 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.10 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.10.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.10.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=19 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -502,7 +527,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -544,6 +571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -572,6 +600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -600,6 +629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -628,6 +658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -656,6 +687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -684,6 +716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -712,6 +745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -740,6 +774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -768,6 +803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.10-clang-20.yml
+++ b/.github/workflows/5.10-clang-20.yml
@@ -16,10 +16,18 @@ name: 5.10 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.10 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.10.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.10.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=20 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LD=riscv64-linux-gnu-ld LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -502,7 +527,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -544,6 +571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -572,6 +600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -600,6 +629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -628,6 +658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -656,6 +687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -684,6 +716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -712,6 +745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -740,6 +774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -768,6 +803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -16,10 +16,18 @@ name: 5.15 (clang-11)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.15 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.15.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-11
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.15.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -754,7 +788,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -796,6 +832,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -824,6 +861,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -852,6 +890,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -880,6 +919,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -908,6 +948,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -936,6 +977,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1159,7 +1208,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1201,6 +1252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1229,6 +1281,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1257,6 +1310,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1285,6 +1339,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1313,6 +1368,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1341,6 +1397,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1369,6 +1426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1397,6 +1455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -16,10 +16,18 @@ name: 5.15 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.15 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.15.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-12
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.15.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=12 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -838,7 +875,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -880,6 +919,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -908,6 +948,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -936,6 +977,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1243,7 +1295,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1285,6 +1339,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1313,6 +1368,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1341,6 +1397,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1369,6 +1426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1397,6 +1455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.15-clang-13.yml
+++ b/.github/workflows/5.15-clang-13.yml
@@ -16,10 +16,18 @@ name: 5.15 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.15 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.15.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.15.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=13 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -922,7 +962,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1383,7 +1440,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.15-clang-14.yml
+++ b/.github/workflows/5.15-clang-14.yml
@@ -16,10 +16,18 @@ name: 5.15 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.15 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.15.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.15.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=14 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=14 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -922,7 +962,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1383,7 +1440,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.15-clang-15.yml
+++ b/.github/workflows/5.15-clang-15.yml
@@ -16,10 +16,18 @@ name: 5.15 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.15 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.15.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.15.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=15 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=15 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -950,7 +991,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1411,7 +1469,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.15-clang-16.yml
+++ b/.github/workflows/5.15-clang-16.yml
@@ -16,10 +16,18 @@ name: 5.15 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.15 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.15.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.15.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=16 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=16 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -950,7 +991,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1411,7 +1469,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.15-clang-17.yml
+++ b/.github/workflows/5.15-clang-17.yml
@@ -16,10 +16,18 @@ name: 5.15 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.15 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.15.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.15.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=17 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=17 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -950,7 +991,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1411,7 +1469,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.15-clang-18.yml
+++ b/.github/workflows/5.15-clang-18.yml
@@ -16,10 +16,18 @@ name: 5.15 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.15 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.15.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.15.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=18 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=18 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -950,7 +991,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1411,7 +1469,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.15-clang-19.yml
+++ b/.github/workflows/5.15-clang-19.yml
@@ -16,10 +16,18 @@ name: 5.15 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.15 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.15.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.15.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=19 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=19 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -950,7 +991,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1411,7 +1469,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.15-clang-20.yml
+++ b/.github/workflows/5.15-clang-20.yml
@@ -16,10 +16,18 @@ name: 5.15 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.15 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.15.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.15.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=20 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=20 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -950,7 +991,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_BPF_PRELOAD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=0 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1411,7 +1469,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.4-clang-13.yml
+++ b/.github/workflows/5.4-clang-13.yml
@@ -16,10 +16,18 @@ name: 5.4 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.4 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.4.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.4.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_COMPAT_VDSO=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=13 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -334,7 +353,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -376,6 +397,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.4-clang-14.yml
+++ b/.github/workflows/5.4-clang-14.yml
@@ -16,10 +16,18 @@ name: 5.4 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.4 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.4.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.4.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_COMPAT_VDSO=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=14 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -334,7 +353,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -376,6 +397,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.4-clang-15.yml
+++ b/.github/workflows/5.4-clang-15.yml
@@ -16,10 +16,18 @@ name: 5.4 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.4 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.4.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.4.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_COMPAT_VDSO=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=15 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -362,7 +382,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -404,6 +426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.4-clang-16.yml
+++ b/.github/workflows/5.4-clang-16.yml
@@ -16,10 +16,18 @@ name: 5.4 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.4 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.4.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.4.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_COMPAT_VDSO=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=16 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -362,7 +382,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -404,6 +426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.4-clang-17.yml
+++ b/.github/workflows/5.4-clang-17.yml
@@ -16,10 +16,18 @@ name: 5.4 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.4 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.4.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.4.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_COMPAT_VDSO=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=17 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -362,7 +382,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -404,6 +426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.4-clang-18.yml
+++ b/.github/workflows/5.4-clang-18.yml
@@ -16,10 +16,18 @@ name: 5.4 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.4 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.4.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.4.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_COMPAT_VDSO=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=18 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -362,7 +382,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -404,6 +426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.4-clang-19.yml
+++ b/.github/workflows/5.4-clang-19.yml
@@ -16,10 +16,18 @@ name: 5.4 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.4 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.4.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.4.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_COMPAT_VDSO=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=19 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -362,7 +382,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -404,6 +426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/5.4-clang-20.yml
+++ b/.github/workflows/5.4-clang-20.yml
@@ -16,10 +16,18 @@ name: 5.4 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/5.4 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-5.4.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-5.4.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_COMPAT_VDSO=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=20 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -362,7 +382,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -404,6 +426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.1-clang-11.yml
+++ b/.github/workflows/6.1-clang-11.yml
@@ -16,10 +16,18 @@ name: 6.1 (clang-11)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.1 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.1.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-11
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.1.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -782,7 +817,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -824,6 +861,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -852,6 +890,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -880,6 +919,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -908,6 +948,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -936,6 +977,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1215,7 +1266,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1257,6 +1310,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1285,6 +1339,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1313,6 +1368,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1341,6 +1397,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1369,6 +1426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1397,6 +1455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.1-clang-12.yml
+++ b/.github/workflows/6.1-clang-12.yml
@@ -16,10 +16,18 @@ name: 6.1 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.1 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.1.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-12
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.1.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=12 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -810,7 +846,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -852,6 +890,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -880,6 +919,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -908,6 +948,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -936,6 +977,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1243,7 +1295,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1285,6 +1339,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1313,6 +1368,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1341,6 +1397,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1369,6 +1426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1397,6 +1455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.1-clang-13.yml
+++ b/.github/workflows/6.1-clang-13.yml
@@ -16,10 +16,18 @@ name: 6.1 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.1 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.1.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.1.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=13 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -838,7 +875,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -880,6 +919,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -908,6 +948,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -936,6 +977,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1271,7 +1324,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1313,6 +1368,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1341,6 +1397,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1369,6 +1426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1397,6 +1455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.1-clang-14.yml
+++ b/.github/workflows/6.1-clang-14.yml
@@ -16,10 +16,18 @@ name: 6.1 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.1 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.1.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.1.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=14 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -838,7 +875,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -880,6 +919,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -908,6 +948,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -936,6 +977,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1271,7 +1324,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1313,6 +1368,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1341,6 +1397,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1369,6 +1426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1397,6 +1455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.1-clang-15.yml
+++ b/.github/workflows/6.1-clang-15.yml
@@ -16,10 +16,18 @@ name: 6.1 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.1 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.1.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.1.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=15 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -922,7 +962,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1411,7 +1469,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.1-clang-16.yml
+++ b/.github/workflows/6.1-clang-16.yml
@@ -16,10 +16,18 @@ name: 6.1 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.1 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.1.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.1.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=16 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1062,7 +1107,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1551,7 +1614,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.1-clang-17.yml
+++ b/.github/workflows/6.1-clang-17.yml
@@ -16,10 +16,18 @@ name: 6.1 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.1 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.1.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.1.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=17 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1062,7 +1107,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1551,7 +1614,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.1-clang-18.yml
+++ b/.github/workflows/6.1-clang-18.yml
@@ -16,10 +16,18 @@ name: 6.1 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.1 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.1.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.1.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=18 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1062,7 +1107,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1551,7 +1614,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.1-clang-19.yml
+++ b/.github/workflows/6.1-clang-19.yml
@@ -16,10 +16,18 @@ name: 6.1 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.1 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.1.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.1.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=19 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1062,7 +1107,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1551,7 +1614,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.1-clang-20.yml
+++ b/.github/workflows/6.1-clang-20.yml
@@ -16,10 +16,18 @@ name: 6.1 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.1 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.1.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.1.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=20 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1062,7 +1107,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1551,7 +1614,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.12-clang-13.yml
+++ b/.github/workflows/6.12-clang-13.yml
@@ -16,10 +16,18 @@ name: 6.12 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.12 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.12.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.12.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -838,7 +875,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -880,6 +919,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -908,6 +948,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -936,6 +977,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1271,7 +1324,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1313,6 +1368,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1341,6 +1397,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1369,6 +1426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1397,6 +1455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.12-clang-14.yml
+++ b/.github/workflows/6.12-clang-14.yml
@@ -16,10 +16,18 @@ name: 6.12 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.12 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.12.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.12.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -894,7 +933,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -936,6 +977,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1327,7 +1382,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1369,6 +1426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1397,6 +1455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.12-clang-15.yml
+++ b/.github/workflows/6.12-clang-15.yml
@@ -16,10 +16,18 @@ name: 6.12 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.12 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.12.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.12.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -978,7 +1020,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1467,7 +1527,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.12-clang-16.yml
+++ b/.github/workflows/6.12-clang-16.yml
@@ -16,10 +16,18 @@ name: 6.12 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.12 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.12.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.12.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1146,7 +1194,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1635,7 +1701,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.12-clang-17.yml
+++ b/.github/workflows/6.12-clang-17.yml
@@ -16,10 +16,18 @@ name: 6.12 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.12 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.12.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.12.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1146,7 +1194,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1636,6 +1702,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1664,6 +1731,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1691,7 +1759,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2125,6 +2209,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2153,6 +2238,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.12-clang-18.yml
+++ b/.github/workflows/6.12-clang-18.yml
@@ -16,10 +16,18 @@ name: 6.12 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.12 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.12.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.12.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1147,6 +1195,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1175,6 +1224,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1203,6 +1253,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1231,6 +1282,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1258,7 +1310,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1636,6 +1702,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1664,6 +1731,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1692,6 +1760,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1720,6 +1789,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1748,6 +1818,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1776,6 +1847,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1803,7 +1875,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2125,6 +2209,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2153,6 +2238,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2181,6 +2267,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2209,6 +2296,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2237,6 +2325,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2265,6 +2354,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2293,6 +2383,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2321,6 +2412,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.12-clang-19.yml
+++ b/.github/workflows/6.12-clang-19.yml
@@ -16,10 +16,18 @@ name: 6.12 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.12 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.12.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.12.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1147,6 +1195,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1175,6 +1224,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1203,6 +1253,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1231,6 +1282,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1258,7 +1310,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1636,6 +1702,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1664,6 +1731,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1692,6 +1760,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1720,6 +1789,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1748,6 +1818,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1776,6 +1847,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1803,7 +1875,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2125,6 +2209,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2153,6 +2238,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2181,6 +2267,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2209,6 +2296,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2237,6 +2325,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2265,6 +2354,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2293,6 +2383,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2321,6 +2412,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.12-clang-20.yml
+++ b/.github/workflows/6.12-clang-20.yml
@@ -16,10 +16,18 @@ name: 6.12 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.12 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.12.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.12.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1147,6 +1195,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1175,6 +1224,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1203,6 +1253,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1231,6 +1282,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1258,7 +1310,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1636,6 +1702,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1664,6 +1731,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1692,6 +1760,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1720,6 +1789,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1748,6 +1818,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1776,6 +1847,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1803,7 +1875,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2125,6 +2209,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2153,6 +2238,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2181,6 +2267,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2209,6 +2296,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2237,6 +2325,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2265,6 +2354,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2293,6 +2383,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2321,6 +2412,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.6-clang-11.yml
+++ b/.github/workflows/6.6-clang-11.yml
@@ -16,10 +16,18 @@ name: 6.6 (clang-11)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.6 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.6.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-11
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.6.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LD=powerpc64le-linux-gnu-ld LLVM_IAS=0 LLVM_VERSION=11 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -782,7 +817,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -824,6 +861,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -852,6 +890,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -880,6 +919,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -908,6 +948,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -936,6 +977,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1215,7 +1266,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1257,6 +1310,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1285,6 +1339,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1313,6 +1368,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1341,6 +1397,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1369,6 +1426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1397,6 +1455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=11 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.6-clang-12.yml
+++ b/.github/workflows/6.6-clang-12.yml
@@ -16,10 +16,18 @@ name: 6.6 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.6 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.6.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-12
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.6.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -810,7 +846,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -852,6 +890,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -880,6 +919,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -908,6 +948,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -936,6 +977,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1243,7 +1295,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1285,6 +1339,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1313,6 +1368,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1341,6 +1397,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1369,6 +1426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1397,6 +1455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.6-clang-13.yml
+++ b/.github/workflows/6.6-clang-13.yml
@@ -16,10 +16,18 @@ name: 6.6 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.6 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.6.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.6.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -838,7 +875,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -880,6 +919,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -908,6 +948,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -936,6 +977,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1271,7 +1324,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1313,6 +1368,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1341,6 +1397,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1369,6 +1426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1397,6 +1455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.6-clang-14.yml
+++ b/.github/workflows/6.6-clang-14.yml
@@ -16,10 +16,18 @@ name: 6.6 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.6 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.6.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.6.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -838,7 +875,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -880,6 +919,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -908,6 +948,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -936,6 +977,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1271,7 +1324,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1313,6 +1368,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1341,6 +1397,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1369,6 +1426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1397,6 +1455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.6-clang-15.yml
+++ b/.github/workflows/6.6-clang-15.yml
@@ -16,10 +16,18 @@ name: 6.6 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.6 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.6.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.6.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -922,7 +962,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1411,7 +1469,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.6-clang-16.yml
+++ b/.github/workflows/6.6-clang-16.yml
@@ -16,10 +16,18 @@ name: 6.6 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.6 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.6.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.6.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1062,7 +1107,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1551,7 +1614,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.6-clang-17.yml
+++ b/.github/workflows/6.6-clang-17.yml
@@ -16,10 +16,18 @@ name: 6.6 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.6 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.6.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.6.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1062,7 +1107,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1551,7 +1614,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.6-clang-18.yml
+++ b/.github/workflows/6.6-clang-18.yml
@@ -16,10 +16,18 @@ name: 6.6 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.6 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.6.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.6.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1118,7 +1165,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1607,7 +1672,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.6-clang-19.yml
+++ b/.github/workflows/6.6-clang-19.yml
@@ -16,10 +16,18 @@ name: 6.6 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.6 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.6.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.6.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1118,7 +1165,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1607,7 +1672,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/6.6-clang-20.yml
+++ b/.github/workflows/6.6-clang-20.yml
@@ -16,10 +16,18 @@ name: 6.6 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/6.6 --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.6.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.6.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1118,7 +1165,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1607,7 +1672,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-4.19-clang-12.yml
+++ b/.github/workflows/android-4.19-clang-12.yml
@@ -16,10 +16,18 @@ name: android-4.19 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-4.19 --repo https://android.googlesource.com/kernel/common.git --ref android-4.19-stable
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-12
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-4.19-clang-13.yml
+++ b/.github/workflows/android-4.19-clang-13.yml
@@ -16,10 +16,18 @@ name: android-4.19 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-4.19 --repo https://android.googlesource.com/kernel/common.git --ref android-4.19-stable
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-4.19-clang-14.yml
+++ b/.github/workflows/android-4.19-clang-14.yml
@@ -16,10 +16,18 @@ name: android-4.19 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-4.19 --repo https://android.googlesource.com/kernel/common.git --ref android-4.19-stable
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-4.19-clang-15.yml
+++ b/.github/workflows/android-4.19-clang-15.yml
@@ -16,10 +16,18 @@ name: android-4.19 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-4.19 --repo https://android.googlesource.com/kernel/common.git --ref android-4.19-stable
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-4.19-clang-16.yml
+++ b/.github/workflows/android-4.19-clang-16.yml
@@ -16,10 +16,18 @@ name: android-4.19 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-4.19 --repo https://android.googlesource.com/kernel/common.git --ref android-4.19-stable
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-4.19-clang-17.yml
+++ b/.github/workflows/android-4.19-clang-17.yml
@@ -16,10 +16,18 @@ name: android-4.19 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-4.19 --repo https://android.googlesource.com/kernel/common.git --ref android-4.19-stable
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-4.19-clang-18.yml
+++ b/.github/workflows/android-4.19-clang-18.yml
@@ -16,10 +16,18 @@ name: android-4.19 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-4.19 --repo https://android.googlesource.com/kernel/common.git --ref android-4.19-stable
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-4.19-clang-19.yml
+++ b/.github/workflows/android-4.19-clang-19.yml
@@ -16,10 +16,18 @@ name: android-4.19 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-4.19 --repo https://android.googlesource.com/kernel/common.git --ref android-4.19-stable
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-4.19-clang-20.yml
+++ b/.github/workflows/android-4.19-clang-20.yml
@@ -16,10 +16,18 @@ name: android-4.19 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-4.19 --repo https://android.googlesource.com/kernel/common.git --ref android-4.19-stable
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-4.19-clang-android.yml
+++ b/.github/workflows/android-4.19-clang-android.yml
@@ -16,10 +16,18 @@ name: android-4.19 (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-4.19 --repo https://android.googlesource.com/kernel/common.git --ref android-4.19-stable
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-android
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-4.19-stable
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-mainline-clang-13.yml
+++ b/.github/workflows/android-mainline-clang-13.yml
@@ -16,10 +16,18 @@ name: android-mainline (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-mainline --repo https://android.googlesource.com/kernel/common.git --ref android-mainline
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-mainline
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-mainline-clang-14.yml
+++ b/.github/workflows/android-mainline-clang-14.yml
@@ -16,10 +16,18 @@ name: android-mainline (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-mainline --repo https://android.googlesource.com/kernel/common.git --ref android-mainline
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-mainline
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-mainline-clang-15.yml
+++ b/.github/workflows/android-mainline-clang-15.yml
@@ -16,10 +16,18 @@ name: android-mainline (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-mainline --repo https://android.googlesource.com/kernel/common.git --ref android-mainline
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-mainline
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-mainline-clang-16.yml
+++ b/.github/workflows/android-mainline-clang-16.yml
@@ -16,10 +16,18 @@ name: android-mainline (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-mainline --repo https://android.googlesource.com/kernel/common.git --ref android-mainline
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-mainline
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-mainline-clang-17.yml
+++ b/.github/workflows/android-mainline-clang-17.yml
@@ -16,10 +16,18 @@ name: android-mainline (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-mainline --repo https://android.googlesource.com/kernel/common.git --ref android-mainline
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-mainline
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-mainline-clang-18.yml
+++ b/.github/workflows/android-mainline-clang-18.yml
@@ -16,10 +16,18 @@ name: android-mainline (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-mainline --repo https://android.googlesource.com/kernel/common.git --ref android-mainline
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-mainline
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-mainline-clang-19.yml
+++ b/.github/workflows/android-mainline-clang-19.yml
@@ -16,10 +16,18 @@ name: android-mainline (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-mainline --repo https://android.googlesource.com/kernel/common.git --ref android-mainline
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-mainline
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-mainline-clang-20.yml
+++ b/.github/workflows/android-mainline-clang-20.yml
@@ -16,10 +16,18 @@ name: android-mainline (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-mainline --repo https://android.googlesource.com/kernel/common.git --ref android-mainline
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-mainline
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android-mainline-clang-android.yml
+++ b/.github/workflows/android-mainline-clang-android.yml
@@ -16,10 +16,18 @@ name: android-mainline (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android-mainline --repo https://android.googlesource.com/kernel/common.git --ref android-mainline
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-android
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android-mainline
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=android multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.10-clang-12.yml
+++ b/.github/workflows/android12-5.10-clang-12.yml
@@ -16,10 +16,18 @@ name: android12-5.10 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-12
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.10-clang-13.yml
+++ b/.github/workflows/android12-5.10-clang-13.yml
@@ -16,10 +16,18 @@ name: android12-5.10 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.10-clang-14.yml
+++ b/.github/workflows/android12-5.10-clang-14.yml
@@ -16,10 +16,18 @@ name: android12-5.10 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.10-clang-15.yml
+++ b/.github/workflows/android12-5.10-clang-15.yml
@@ -16,10 +16,18 @@ name: android12-5.10 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.10-clang-16.yml
+++ b/.github/workflows/android12-5.10-clang-16.yml
@@ -16,10 +16,18 @@ name: android12-5.10 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.10-clang-17.yml
+++ b/.github/workflows/android12-5.10-clang-17.yml
@@ -16,10 +16,18 @@ name: android12-5.10 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.10-clang-18.yml
+++ b/.github/workflows/android12-5.10-clang-18.yml
@@ -16,10 +16,18 @@ name: android12-5.10 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.10-clang-19.yml
+++ b/.github/workflows/android12-5.10-clang-19.yml
@@ -16,10 +16,18 @@ name: android12-5.10 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.10-clang-20.yml
+++ b/.github/workflows/android12-5.10-clang-20.yml
@@ -16,10 +16,18 @@ name: android12-5.10 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.10-clang-android.yml
+++ b/.github/workflows/android12-5.10-clang-android.yml
@@ -16,10 +16,18 @@ name: android12-5.10 (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-android
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=android multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.4-clang-12.yml
+++ b/.github/workflows/android12-5.4-clang-12.yml
@@ -16,10 +16,18 @@ name: android12-5.4 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.4 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.4
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-12
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.4-clang-13.yml
+++ b/.github/workflows/android12-5.4-clang-13.yml
@@ -16,10 +16,18 @@ name: android12-5.4 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.4 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.4
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.4-clang-14.yml
+++ b/.github/workflows/android12-5.4-clang-14.yml
@@ -16,10 +16,18 @@ name: android12-5.4 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.4 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.4
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.4-clang-15.yml
+++ b/.github/workflows/android12-5.4-clang-15.yml
@@ -16,10 +16,18 @@ name: android12-5.4 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.4 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.4
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.4-clang-16.yml
+++ b/.github/workflows/android12-5.4-clang-16.yml
@@ -16,10 +16,18 @@ name: android12-5.4 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.4 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.4
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.4-clang-17.yml
+++ b/.github/workflows/android12-5.4-clang-17.yml
@@ -16,10 +16,18 @@ name: android12-5.4 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.4 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.4
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.4-clang-18.yml
+++ b/.github/workflows/android12-5.4-clang-18.yml
@@ -16,10 +16,18 @@ name: android12-5.4 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.4 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.4
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.4-clang-19.yml
+++ b/.github/workflows/android12-5.4-clang-19.yml
@@ -16,10 +16,18 @@ name: android12-5.4 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.4 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.4
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.4-clang-20.yml
+++ b/.github/workflows/android12-5.4-clang-20.yml
@@ -16,10 +16,18 @@ name: android12-5.4 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.4 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.4
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android12-5.4-clang-android.yml
+++ b/.github/workflows/android12-5.4-clang-android.yml
@@ -16,10 +16,18 @@ name: android12-5.4 (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android12-5.4 --repo https://android.googlesource.com/kernel/common.git --ref android12-5.4
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-android
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android12-5.4
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=android multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.10-clang-12.yml
+++ b/.github/workflows/android13-5.10-clang-12.yml
@@ -16,10 +16,18 @@ name: android13-5.10 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-12
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.10-clang-13.yml
+++ b/.github/workflows/android13-5.10-clang-13.yml
@@ -16,10 +16,18 @@ name: android13-5.10 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.10-clang-14.yml
+++ b/.github/workflows/android13-5.10-clang-14.yml
@@ -16,10 +16,18 @@ name: android13-5.10 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.10-clang-15.yml
+++ b/.github/workflows/android13-5.10-clang-15.yml
@@ -16,10 +16,18 @@ name: android13-5.10 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.10-clang-16.yml
+++ b/.github/workflows/android13-5.10-clang-16.yml
@@ -16,10 +16,18 @@ name: android13-5.10 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.10-clang-17.yml
+++ b/.github/workflows/android13-5.10-clang-17.yml
@@ -16,10 +16,18 @@ name: android13-5.10 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.10-clang-18.yml
+++ b/.github/workflows/android13-5.10-clang-18.yml
@@ -16,10 +16,18 @@ name: android13-5.10 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.10-clang-19.yml
+++ b/.github/workflows/android13-5.10-clang-19.yml
@@ -16,10 +16,18 @@ name: android13-5.10 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.10-clang-20.yml
+++ b/.github/workflows/android13-5.10-clang-20.yml
@@ -16,10 +16,18 @@ name: android13-5.10 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.10-clang-android.yml
+++ b/.github/workflows/android13-5.10-clang-android.yml
@@ -16,10 +16,18 @@ name: android13-5.10 (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.10 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-android
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=android multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.15-clang-12.yml
+++ b/.github/workflows/android13-5.15-clang-12.yml
@@ -16,10 +16,18 @@ name: android13-5.15 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-12
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.15-clang-13.yml
+++ b/.github/workflows/android13-5.15-clang-13.yml
@@ -16,10 +16,18 @@ name: android13-5.15 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.15-clang-14.yml
+++ b/.github/workflows/android13-5.15-clang-14.yml
@@ -16,10 +16,18 @@ name: android13-5.15 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.15-clang-15.yml
+++ b/.github/workflows/android13-5.15-clang-15.yml
@@ -16,10 +16,18 @@ name: android13-5.15 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.15-clang-16.yml
+++ b/.github/workflows/android13-5.15-clang-16.yml
@@ -16,10 +16,18 @@ name: android13-5.15 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.15-clang-17.yml
+++ b/.github/workflows/android13-5.15-clang-17.yml
@@ -16,10 +16,18 @@ name: android13-5.15 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.15-clang-18.yml
+++ b/.github/workflows/android13-5.15-clang-18.yml
@@ -16,10 +16,18 @@ name: android13-5.15 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.15-clang-19.yml
+++ b/.github/workflows/android13-5.15-clang-19.yml
@@ -16,10 +16,18 @@ name: android13-5.15 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.15-clang-20.yml
+++ b/.github/workflows/android13-5.15-clang-20.yml
@@ -16,10 +16,18 @@ name: android13-5.15 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android13-5.15-clang-android.yml
+++ b/.github/workflows/android13-5.15-clang-android.yml
@@ -16,10 +16,18 @@ name: android13-5.15 (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android13-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android13-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-android
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android13-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=android multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-5.15-clang-12.yml
+++ b/.github/workflows/android14-5.15-clang-12.yml
@@ -16,10 +16,18 @@ name: android14-5.15 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android14-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-12
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-5.15-clang-13.yml
+++ b/.github/workflows/android14-5.15-clang-13.yml
@@ -16,10 +16,18 @@ name: android14-5.15 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android14-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-5.15-clang-14.yml
+++ b/.github/workflows/android14-5.15-clang-14.yml
@@ -16,10 +16,18 @@ name: android14-5.15 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android14-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-5.15-clang-15.yml
+++ b/.github/workflows/android14-5.15-clang-15.yml
@@ -16,10 +16,18 @@ name: android14-5.15 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android14-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-5.15-clang-16.yml
+++ b/.github/workflows/android14-5.15-clang-16.yml
@@ -16,10 +16,18 @@ name: android14-5.15 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android14-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-5.15-clang-17.yml
+++ b/.github/workflows/android14-5.15-clang-17.yml
@@ -16,10 +16,18 @@ name: android14-5.15 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android14-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-5.15-clang-18.yml
+++ b/.github/workflows/android14-5.15-clang-18.yml
@@ -16,10 +16,18 @@ name: android14-5.15 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android14-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-5.15-clang-19.yml
+++ b/.github/workflows/android14-5.15-clang-19.yml
@@ -16,10 +16,18 @@ name: android14-5.15 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android14-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-5.15-clang-20.yml
+++ b/.github/workflows/android14-5.15-clang-20.yml
@@ -16,10 +16,18 @@ name: android14-5.15 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android14-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-5.15-clang-android.yml
+++ b/.github/workflows/android14-5.15-clang-android.yml
@@ -16,10 +16,18 @@ name: android14-5.15 (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-5.15 --repo https://android.googlesource.com/kernel/common.git --ref android14-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-android
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=android multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-6.1-clang-12.yml
+++ b/.github/workflows/android14-6.1-clang-12.yml
@@ -16,10 +16,18 @@ name: android14-6.1 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-6.1 --repo https://android.googlesource.com/kernel/common.git --ref android14-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-12
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-6.1-clang-13.yml
+++ b/.github/workflows/android14-6.1-clang-13.yml
@@ -16,10 +16,18 @@ name: android14-6.1 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-6.1 --repo https://android.googlesource.com/kernel/common.git --ref android14-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-6.1-clang-14.yml
+++ b/.github/workflows/android14-6.1-clang-14.yml
@@ -16,10 +16,18 @@ name: android14-6.1 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-6.1 --repo https://android.googlesource.com/kernel/common.git --ref android14-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-6.1-clang-15.yml
+++ b/.github/workflows/android14-6.1-clang-15.yml
@@ -16,10 +16,18 @@ name: android14-6.1 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-6.1 --repo https://android.googlesource.com/kernel/common.git --ref android14-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-6.1-clang-16.yml
+++ b/.github/workflows/android14-6.1-clang-16.yml
@@ -16,10 +16,18 @@ name: android14-6.1 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-6.1 --repo https://android.googlesource.com/kernel/common.git --ref android14-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-6.1-clang-17.yml
+++ b/.github/workflows/android14-6.1-clang-17.yml
@@ -16,10 +16,18 @@ name: android14-6.1 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-6.1 --repo https://android.googlesource.com/kernel/common.git --ref android14-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-6.1-clang-18.yml
+++ b/.github/workflows/android14-6.1-clang-18.yml
@@ -16,10 +16,18 @@ name: android14-6.1 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-6.1 --repo https://android.googlesource.com/kernel/common.git --ref android14-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-6.1-clang-19.yml
+++ b/.github/workflows/android14-6.1-clang-19.yml
@@ -16,10 +16,18 @@ name: android14-6.1 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-6.1 --repo https://android.googlesource.com/kernel/common.git --ref android14-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-6.1-clang-20.yml
+++ b/.github/workflows/android14-6.1-clang-20.yml
@@ -16,10 +16,18 @@ name: android14-6.1 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-6.1 --repo https://android.googlesource.com/kernel/common.git --ref android14-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android14-6.1-clang-android.yml
+++ b/.github/workflows/android14-6.1-clang-android.yml
@@ -16,10 +16,18 @@ name: android14-6.1 (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android14-6.1 --repo https://android.googlesource.com/kernel/common.git --ref android14-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-android
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android14-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=android multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android15-6.6-clang-12.yml
+++ b/.github/workflows/android15-6.6-clang-12.yml
@@ -16,10 +16,18 @@ name: android15-6.6 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android15-6.6 --repo https://android.googlesource.com/kernel/common.git --ref android15-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-12
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android15-6.6-clang-13.yml
+++ b/.github/workflows/android15-6.6-clang-13.yml
@@ -16,10 +16,18 @@ name: android15-6.6 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android15-6.6 --repo https://android.googlesource.com/kernel/common.git --ref android15-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android15-6.6-clang-14.yml
+++ b/.github/workflows/android15-6.6-clang-14.yml
@@ -16,10 +16,18 @@ name: android15-6.6 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android15-6.6 --repo https://android.googlesource.com/kernel/common.git --ref android15-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android15-6.6-clang-15.yml
+++ b/.github/workflows/android15-6.6-clang-15.yml
@@ -16,10 +16,18 @@ name: android15-6.6 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android15-6.6 --repo https://android.googlesource.com/kernel/common.git --ref android15-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android15-6.6-clang-16.yml
+++ b/.github/workflows/android15-6.6-clang-16.yml
@@ -16,10 +16,18 @@ name: android15-6.6 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android15-6.6 --repo https://android.googlesource.com/kernel/common.git --ref android15-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android15-6.6-clang-17.yml
+++ b/.github/workflows/android15-6.6-clang-17.yml
@@ -16,10 +16,18 @@ name: android15-6.6 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android15-6.6 --repo https://android.googlesource.com/kernel/common.git --ref android15-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android15-6.6-clang-18.yml
+++ b/.github/workflows/android15-6.6-clang-18.yml
@@ -16,10 +16,18 @@ name: android15-6.6 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android15-6.6 --repo https://android.googlesource.com/kernel/common.git --ref android15-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android15-6.6-clang-19.yml
+++ b/.github/workflows/android15-6.6-clang-19.yml
@@ -16,10 +16,18 @@ name: android15-6.6 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android15-6.6 --repo https://android.googlesource.com/kernel/common.git --ref android15-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android15-6.6-clang-20.yml
+++ b/.github/workflows/android15-6.6-clang-20.yml
@@ -16,10 +16,18 @@ name: android15-6.6 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android15-6.6 --repo https://android.googlesource.com/kernel/common.git --ref android15-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/android15-6.6-clang-android.yml
+++ b/.github/workflows/android15-6.6-clang-android.yml
@@ -16,10 +16,18 @@ name: android15-6.6 (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/android15-6.6 --repo https://android.googlesource.com/kernel/common.git --ref android15-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-android
+    needs: check_patches
     env:
       GIT_REPO: https://android.googlesource.com/kernel/common.git
       GIT_REF: android15-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=android multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -166,7 +179,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/arm64-clang-13.yml
+++ b/.github/workflows/arm64-clang-13.yml
@@ -16,10 +16,18 @@ name: arm64 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/arm64 --repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --ref for-next/core
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/core
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -110,7 +121,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -152,6 +165,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/arm64-clang-14.yml
+++ b/.github/workflows/arm64-clang-14.yml
@@ -16,10 +16,18 @@ name: arm64 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/arm64 --repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --ref for-next/core
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/core
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -110,7 +121,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -152,6 +165,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/arm64-clang-15.yml
+++ b/.github/workflows/arm64-clang-15.yml
@@ -16,10 +16,18 @@ name: arm64 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/arm64 --repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --ref for-next/core
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/core
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/arm64-clang-16.yml
+++ b/.github/workflows/arm64-clang-16.yml
@@ -16,10 +16,18 @@ name: arm64 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/arm64 --repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --ref for-next/core
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/core
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/arm64-clang-17.yml
+++ b/.github/workflows/arm64-clang-17.yml
@@ -16,10 +16,18 @@ name: arm64 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/arm64 --repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --ref for-next/core
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/core
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/arm64-clang-18.yml
+++ b/.github/workflows/arm64-clang-18.yml
@@ -16,10 +16,18 @@ name: arm64 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/arm64 --repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --ref for-next/core
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/core
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/arm64-clang-19.yml
+++ b/.github/workflows/arm64-clang-19.yml
@@ -16,10 +16,18 @@ name: arm64 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/arm64 --repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --ref for-next/core
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/core
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/arm64-clang-20.yml
+++ b/.github/workflows/arm64-clang-20.yml
@@ -16,10 +16,18 @@ name: arm64 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/arm64 --repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --ref for-next/core
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/core
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/arm64-fixes-clang-13.yml
+++ b/.github/workflows/arm64-fixes-clang-13.yml
@@ -16,10 +16,18 @@ name: arm64-fixes (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/arm64-fixes --repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --ref for-next/fixes
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/fixes
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -110,7 +121,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -152,6 +165,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/arm64-fixes-clang-14.yml
+++ b/.github/workflows/arm64-fixes-clang-14.yml
@@ -16,10 +16,18 @@ name: arm64-fixes (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/arm64-fixes --repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --ref for-next/fixes
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/fixes
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -110,7 +121,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -152,6 +165,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/arm64-fixes-clang-15.yml
+++ b/.github/workflows/arm64-fixes-clang-15.yml
@@ -16,10 +16,18 @@ name: arm64-fixes (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/arm64-fixes --repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --ref for-next/fixes
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/fixes
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/arm64-fixes-clang-16.yml
+++ b/.github/workflows/arm64-fixes-clang-16.yml
@@ -16,10 +16,18 @@ name: arm64-fixes (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/arm64-fixes --repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --ref for-next/fixes
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/fixes
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/arm64-fixes-clang-17.yml
+++ b/.github/workflows/arm64-fixes-clang-17.yml
@@ -16,10 +16,18 @@ name: arm64-fixes (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/arm64-fixes --repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --ref for-next/fixes
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/fixes
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/arm64-fixes-clang-18.yml
+++ b/.github/workflows/arm64-fixes-clang-18.yml
@@ -16,10 +16,18 @@ name: arm64-fixes (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/arm64-fixes --repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --ref for-next/fixes
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/fixes
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/arm64-fixes-clang-19.yml
+++ b/.github/workflows/arm64-fixes-clang-19.yml
@@ -16,10 +16,18 @@ name: arm64-fixes (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/arm64-fixes --repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --ref for-next/fixes
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/fixes
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/arm64-fixes-clang-20.yml
+++ b/.github/workflows/arm64-fixes-clang-20.yml
@@ -16,10 +16,18 @@ name: arm64-fixes (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/arm64-fixes --repo https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git --ref for-next/fixes
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/arm64/linux.git
       GIT_REF: for-next/fixes
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-5.10-clang-12.yml
+++ b/.github/workflows/chromeos-5.10-clang-12.yml
@@ -16,10 +16,18 @@ name: chromeos-5.10 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-5.10 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-12
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-5.10-clang-13.yml
+++ b/.github/workflows/chromeos-5.10-clang-13.yml
@@ -16,10 +16,18 @@ name: chromeos-5.10 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-5.10 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-5.10-clang-14.yml
+++ b/.github/workflows/chromeos-5.10-clang-14.yml
@@ -16,10 +16,18 @@ name: chromeos-5.10 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-5.10 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-5.10-clang-15.yml
+++ b/.github/workflows/chromeos-5.10-clang-15.yml
@@ -16,10 +16,18 @@ name: chromeos-5.10 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-5.10 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-5.10-clang-16.yml
+++ b/.github/workflows/chromeos-5.10-clang-16.yml
@@ -16,10 +16,18 @@ name: chromeos-5.10 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-5.10 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-5.10-clang-17.yml
+++ b/.github/workflows/chromeos-5.10-clang-17.yml
@@ -16,10 +16,18 @@ name: chromeos-5.10 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-5.10 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-5.10-clang-18.yml
+++ b/.github/workflows/chromeos-5.10-clang-18.yml
@@ -16,10 +16,18 @@ name: chromeos-5.10 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-5.10 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-5.10-clang-19.yml
+++ b/.github/workflows/chromeos-5.10-clang-19.yml
@@ -16,10 +16,18 @@ name: chromeos-5.10 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-5.10 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-5.10-clang-20.yml
+++ b/.github/workflows/chromeos-5.10-clang-20.yml
@@ -16,10 +16,18 @@ name: chromeos-5.10 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-5.10 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-5.10
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.10
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-5.15-clang-12.yml
+++ b/.github/workflows/chromeos-5.15-clang-12.yml
@@ -16,10 +16,18 @@ name: chromeos-5.15 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-5.15 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-12
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-5.15-clang-13.yml
+++ b/.github/workflows/chromeos-5.15-clang-13.yml
@@ -16,10 +16,18 @@ name: chromeos-5.15 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-5.15 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-5.15-clang-14.yml
+++ b/.github/workflows/chromeos-5.15-clang-14.yml
@@ -16,10 +16,18 @@ name: chromeos-5.15 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-5.15 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-5.15-clang-15.yml
+++ b/.github/workflows/chromeos-5.15-clang-15.yml
@@ -16,10 +16,18 @@ name: chromeos-5.15 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-5.15 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-5.15-clang-16.yml
+++ b/.github/workflows/chromeos-5.15-clang-16.yml
@@ -16,10 +16,18 @@ name: chromeos-5.15 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-5.15 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-5.15-clang-17.yml
+++ b/.github/workflows/chromeos-5.15-clang-17.yml
@@ -16,10 +16,18 @@ name: chromeos-5.15 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-5.15 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-5.15-clang-18.yml
+++ b/.github/workflows/chromeos-5.15-clang-18.yml
@@ -16,10 +16,18 @@ name: chromeos-5.15 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-5.15 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-5.15-clang-19.yml
+++ b/.github/workflows/chromeos-5.15-clang-19.yml
@@ -16,10 +16,18 @@ name: chromeos-5.15 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-5.15 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-5.15-clang-20.yml
+++ b/.github/workflows/chromeos-5.15-clang-20.yml
@@ -16,10 +16,18 @@ name: chromeos-5.15 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-5.15 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-5.15
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-5.15
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-6.1-clang-12.yml
+++ b/.github/workflows/chromeos-6.1-clang-12.yml
@@ -16,10 +16,18 @@ name: chromeos-6.1 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-6.1 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-12
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-6.1-clang-13.yml
+++ b/.github/workflows/chromeos-6.1-clang-13.yml
@@ -16,10 +16,18 @@ name: chromeos-6.1 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-6.1 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-6.1-clang-14.yml
+++ b/.github/workflows/chromeos-6.1-clang-14.yml
@@ -16,10 +16,18 @@ name: chromeos-6.1 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-6.1 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-6.1-clang-15.yml
+++ b/.github/workflows/chromeos-6.1-clang-15.yml
@@ -16,10 +16,18 @@ name: chromeos-6.1 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-6.1 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-6.1-clang-16.yml
+++ b/.github/workflows/chromeos-6.1-clang-16.yml
@@ -16,10 +16,18 @@ name: chromeos-6.1 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-6.1 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-6.1-clang-17.yml
+++ b/.github/workflows/chromeos-6.1-clang-17.yml
@@ -16,10 +16,18 @@ name: chromeos-6.1 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-6.1 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-6.1-clang-18.yml
+++ b/.github/workflows/chromeos-6.1-clang-18.yml
@@ -16,10 +16,18 @@ name: chromeos-6.1 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-6.1 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-6.1-clang-19.yml
+++ b/.github/workflows/chromeos-6.1-clang-19.yml
@@ -16,10 +16,18 @@ name: chromeos-6.1 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-6.1 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-6.1-clang-20.yml
+++ b/.github/workflows/chromeos-6.1-clang-20.yml
@@ -16,10 +16,18 @@ name: chromeos-6.1 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-6.1 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-6.1
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.1
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-6.6-clang-12.yml
+++ b/.github/workflows/chromeos-6.6-clang-12.yml
@@ -16,10 +16,18 @@ name: chromeos-6.6 (clang-12)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-6.6 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-12
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=12 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-6.6-clang-13.yml
+++ b/.github/workflows/chromeos-6.6-clang-13.yml
@@ -16,10 +16,18 @@ name: chromeos-6.6 (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-6.6 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-6.6-clang-14.yml
+++ b/.github/workflows/chromeos-6.6-clang-14.yml
@@ -16,10 +16,18 @@ name: chromeos-6.6 (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-6.6 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-6.6-clang-15.yml
+++ b/.github/workflows/chromeos-6.6-clang-15.yml
@@ -16,10 +16,18 @@ name: chromeos-6.6 (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-6.6 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-6.6-clang-16.yml
+++ b/.github/workflows/chromeos-6.6-clang-16.yml
@@ -16,10 +16,18 @@ name: chromeos-6.6 (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-6.6 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-6.6-clang-17.yml
+++ b/.github/workflows/chromeos-6.6-clang-17.yml
@@ -16,10 +16,18 @@ name: chromeos-6.6 (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-6.6 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-6.6-clang-18.yml
+++ b/.github/workflows/chromeos-6.6-clang-18.yml
@@ -16,10 +16,18 @@ name: chromeos-6.6 (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-6.6 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-6.6-clang-19.yml
+++ b/.github/workflows/chromeos-6.6-clang-19.yml
@@ -16,10 +16,18 @@ name: chromeos-6.6 (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-6.6 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/chromeos-6.6-clang-20.yml
+++ b/.github/workflows/chromeos-6.6-clang-20.yml
@@ -16,10 +16,18 @@ name: chromeos-6.6 (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/chromeos-6.6 --repo https://chromium.googlesource.com/chromiumos/third_party/kernel.git --ref chromeos-6.6
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://chromium.googlesource.com/chromiumos/third_party/kernel.git
       GIT_REF: chromeos-6.6
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 chromeos/config/chromeos/base.config+chromeos/config/chromeos/arm64/common.config+chromeos/config/chromeos/arm64/chromiumos-arm64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 chromeos/config/chromeos/base.config+chromeos/config/chromeos/x86_64/common.config+chromeos/config/chromeos/x86_64/chromiumos-x86_64-generic.flavour.config+CONFIG_SECURITY_CHROMIUMOS=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/mainline-clang-13.yml
+++ b/.github/workflows/mainline-clang-13.yml
@@ -16,10 +16,18 @@ name: mainline (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/mainline --repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -838,7 +875,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -880,6 +919,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -908,6 +948,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -936,6 +977,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1271,7 +1324,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1313,6 +1368,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1341,6 +1397,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1369,6 +1426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1397,6 +1455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -16,10 +16,18 @@ name: mainline (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/mainline --repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -894,7 +933,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -936,6 +977,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1327,7 +1382,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1369,6 +1426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1397,6 +1455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -16,10 +16,18 @@ name: mainline (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/mainline --repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -978,7 +1020,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1467,7 +1527,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -16,10 +16,18 @@ name: mainline (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/mainline --repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1146,7 +1194,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1635,7 +1701,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/mainline-clang-17.yml
+++ b/.github/workflows/mainline-clang-17.yml
@@ -16,10 +16,18 @@ name: mainline (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/mainline --repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1146,7 +1194,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1636,6 +1702,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1664,6 +1731,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1691,7 +1759,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2125,6 +2209,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2153,6 +2238,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/mainline-clang-18.yml
+++ b/.github/workflows/mainline-clang-18.yml
@@ -16,10 +16,18 @@ name: mainline (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/mainline --repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1147,6 +1195,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1175,6 +1224,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1203,6 +1253,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1231,6 +1282,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1258,7 +1310,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1636,6 +1702,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1664,6 +1731,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1692,6 +1760,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1720,6 +1789,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1748,6 +1818,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1776,6 +1847,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1803,7 +1875,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2125,6 +2209,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2153,6 +2238,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2181,6 +2267,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2209,6 +2296,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2237,6 +2325,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2265,6 +2354,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2293,6 +2383,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2321,6 +2412,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/mainline-clang-19.yml
+++ b/.github/workflows/mainline-clang-19.yml
@@ -16,10 +16,18 @@ name: mainline (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/mainline --repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1147,6 +1195,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1175,6 +1224,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1203,6 +1253,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1231,6 +1282,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1258,7 +1310,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1636,6 +1702,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1664,6 +1731,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1692,6 +1760,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1720,6 +1789,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1748,6 +1818,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1776,6 +1847,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1803,7 +1875,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2125,6 +2209,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2153,6 +2238,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2181,6 +2267,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2209,6 +2296,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2237,6 +2325,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2265,6 +2354,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2293,6 +2383,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2321,6 +2412,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/mainline-clang-20.yml
+++ b/.github/workflows/mainline-clang-20.yml
@@ -16,10 +16,18 @@ name: mainline (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/mainline --repo https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=sparc CC=clang LLVM_IAS=0 LLVM_VERSION=20 sparc64_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1147,6 +1195,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1175,6 +1224,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1203,6 +1253,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1231,6 +1282,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1259,6 +1311,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1286,7 +1339,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1636,6 +1702,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1664,6 +1731,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1692,6 +1760,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1720,6 +1789,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1748,6 +1818,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1776,6 +1847,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1804,6 +1876,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1831,7 +1904,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2125,6 +2209,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2153,6 +2238,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2181,6 +2267,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2209,6 +2296,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2237,6 +2325,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2265,6 +2354,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2293,6 +2383,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2321,6 +2412,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2349,6 +2441,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/next-clang-13.yml
+++ b/.github/workflows/next-clang-13.yml
@@ -16,10 +16,18 @@ name: next (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/next --repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_GCOV_KERNEL=y+CONFIG_GCOV_PROFILE_ALL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -866,7 +904,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -908,6 +948,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -936,6 +977,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1299,7 +1353,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1341,6 +1397,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1369,6 +1426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1397,6 +1455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/next-clang-14.yml
+++ b/.github/workflows/next-clang-14.yml
@@ -16,10 +16,18 @@ name: next (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/next --repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_GCOV_KERNEL=y+CONFIG_GCOV_PROFILE_ALL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -922,7 +962,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1355,7 +1411,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1397,6 +1455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -16,10 +16,18 @@ name: next (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/next --repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_GCOV_KERNEL=y+CONFIG_GCOV_PROFILE_ALL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1006,7 +1049,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1495,7 +1556,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -16,10 +16,18 @@ name: next (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/next --repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1147,6 +1195,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_GCOV_KERNEL=y+CONFIG_GCOV_PROFILE_ALL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1174,7 +1223,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1636,6 +1702,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1663,7 +1730,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/next-clang-17.yml
+++ b/.github/workflows/next-clang-17.yml
@@ -16,10 +16,18 @@ name: next (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/next --repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1147,6 +1195,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_GCOV_KERNEL=y+CONFIG_GCOV_PROFILE_ALL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1174,7 +1223,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1636,6 +1702,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1664,6 +1731,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1692,6 +1760,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1719,7 +1788,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2125,6 +2209,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2153,6 +2238,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2181,6 +2267,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/next-clang-18.yml
+++ b/.github/workflows/next-clang-18.yml
@@ -16,10 +16,18 @@ name: next (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/next --repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1147,6 +1195,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1175,6 +1224,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1203,6 +1253,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1231,6 +1282,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1259,6 +1311,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_GCOV_KERNEL=y+CONFIG_GCOV_PROFILE_ALL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1286,7 +1339,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1636,6 +1702,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1664,6 +1731,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1692,6 +1760,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1720,6 +1789,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1748,6 +1818,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1776,6 +1847,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1804,6 +1876,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1831,7 +1904,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2125,6 +2209,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2153,6 +2238,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2181,6 +2267,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2209,6 +2296,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2237,6 +2325,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2265,6 +2354,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2293,6 +2383,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2321,6 +2412,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2349,6 +2441,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/next-clang-19.yml
+++ b/.github/workflows/next-clang-19.yml
@@ -16,10 +16,18 @@ name: next (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/next --repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1147,6 +1195,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1175,6 +1224,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1203,6 +1253,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1231,6 +1282,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1259,6 +1311,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_GCOV_KERNEL=y+CONFIG_GCOV_PROFILE_ALL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1286,7 +1339,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1636,6 +1702,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1664,6 +1731,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1692,6 +1760,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1720,6 +1789,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1748,6 +1818,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1776,6 +1847,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1804,6 +1876,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1831,7 +1904,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2125,6 +2209,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2153,6 +2238,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2181,6 +2267,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2209,6 +2296,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2237,6 +2325,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2265,6 +2354,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2293,6 +2383,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2321,6 +2412,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2349,6 +2441,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/next-clang-20.yml
+++ b/.github/workflows/next-clang-20.yml
@@ -16,10 +16,18 @@ name: next (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/next --repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=sparc CC=clang LLVM_IAS=0 LLVM_VERSION=20 sparc64_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1147,6 +1195,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1175,6 +1224,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1203,6 +1253,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1231,6 +1282,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1259,6 +1311,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1287,6 +1340,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_GCOV_KERNEL=y+CONFIG_GCOV_PROFILE_ALL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1314,7 +1368,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1636,6 +1702,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1664,6 +1731,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1692,6 +1760,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1720,6 +1789,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1748,6 +1818,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1776,6 +1847,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1804,6 +1876,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1832,6 +1905,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1859,7 +1933,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2125,6 +2209,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2153,6 +2238,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2181,6 +2267,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2209,6 +2296,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2237,6 +2325,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2265,6 +2354,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2293,6 +2383,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2321,6 +2412,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2349,6 +2441,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2377,6 +2470,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/next-clang-android.yml
+++ b/.github/workflows/next-clang-android.yml
@@ -16,10 +16,18 @@ name: next (clang-android)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/next --repo https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-android
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=android multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=0 LLVM_VERSION=android aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=android multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=android multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android defconfig+CONFIG_GCOV_KERNEL=y+CONFIG_GCOV_PROFILE_ALL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -446,7 +469,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -488,6 +513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=android allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -516,6 +542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -544,6 +571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -572,6 +600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -600,6 +629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -628,6 +658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -656,6 +687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -684,6 +716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -712,6 +745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -740,6 +774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/stable-clang-13.yml
+++ b/.github/workflows/stable-clang-13.yml
@@ -16,10 +16,18 @@ name: stable (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/stable --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.13.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.13.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 ppc64_guest_defconfig+CONFIG_PPC_DISABLE_WERROR=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=0 LLVM_VERSION=13 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -838,7 +875,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -880,6 +919,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -908,6 +948,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -936,6 +977,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc CC=clang LLVM_IAS=0 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1271,7 +1324,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1313,6 +1368,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1341,6 +1397,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1369,6 +1426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1397,6 +1455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/stable-clang-14.yml
+++ b/.github/workflows/stable-clang-14.yml
@@ -16,10 +16,18 @@ name: stable (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/stable --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.13.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.13.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -894,7 +933,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -936,6 +977,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -964,6 +1006,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -992,6 +1035,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1327,7 +1382,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1369,6 +1426,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1397,6 +1455,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1425,6 +1484,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1453,6 +1513,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1481,6 +1542,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/stable-clang-15.yml
+++ b/.github/workflows/stable-clang-15.yml
@@ -16,10 +16,18 @@ name: stable (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/stable --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.13.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.13.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -978,7 +1020,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1020,6 +1064,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1048,6 +1093,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1076,6 +1122,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1104,6 +1151,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1132,6 +1180,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1160,6 +1209,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1467,7 +1527,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1509,6 +1571,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1537,6 +1600,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1565,6 +1629,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1593,6 +1658,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1621,6 +1687,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1649,6 +1716,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/stable-clang-16.yml
+++ b/.github/workflows/stable-clang-16.yml
@@ -16,10 +16,18 @@ name: stable (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/stable --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.13.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.13.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=16 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1146,7 +1194,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1635,7 +1701,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1677,6 +1745,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1705,6 +1774,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/stable-clang-17.yml
+++ b/.github/workflows/stable-clang-17.yml
@@ -16,10 +16,18 @@ name: stable (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/stable --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.13.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.13.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=17 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1146,7 +1194,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1188,6 +1238,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1216,6 +1267,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1244,6 +1296,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1272,6 +1325,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 CC=clang LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1636,6 +1702,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1664,6 +1731,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1691,7 +1759,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1733,6 +1803,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1761,6 +1832,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1789,6 +1861,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1817,6 +1890,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2125,6 +2209,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2153,6 +2238,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/stable-clang-18.yml
+++ b/.github/workflows/stable-clang-18.yml
@@ -16,10 +16,18 @@ name: stable (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/stable --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.13.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.13.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=18 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1147,6 +1195,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1175,6 +1224,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1203,6 +1253,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1231,6 +1282,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1258,7 +1310,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1636,6 +1702,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1664,6 +1731,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1692,6 +1760,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1720,6 +1789,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1748,6 +1818,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1776,6 +1847,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1803,7 +1875,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2125,6 +2209,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2153,6 +2238,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2181,6 +2267,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2209,6 +2296,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2237,6 +2325,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2265,6 +2354,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2293,6 +2383,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2321,6 +2412,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/stable-clang-19.yml
+++ b/.github/workflows/stable-clang-19.yml
@@ -16,10 +16,18 @@ name: stable (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/stable --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.13.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.13.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=19 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1147,6 +1195,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1175,6 +1224,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1203,6 +1253,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1231,6 +1282,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1258,7 +1310,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1300,6 +1354,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1636,6 +1702,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1664,6 +1731,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1692,6 +1760,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1720,6 +1789,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1748,6 +1818,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1776,6 +1847,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1803,7 +1875,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1845,6 +1919,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2125,6 +2209,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2153,6 +2238,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2181,6 +2267,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2209,6 +2296,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2237,6 +2325,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2265,6 +2354,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2293,6 +2383,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2321,6 +2412,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/stable-clang-20.yml
+++ b/.github/workflows/stable-clang-20.yml
@@ -16,10 +16,18 @@ name: stable (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/stable --repo https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git --ref linux-6.13.y
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
       GIT_REF: linux-6.13.y
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 aspeed_g5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -139,6 +151,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -167,6 +180,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_THUMB2_KERNEL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -195,6 +209,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -223,6 +238,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 imx_v4_v5_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -251,6 +267,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 omap2plus_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -279,6 +296,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_ARM_LPAE=y+CONFIG_UNWINDER_FRAME_POINTER=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -307,6 +325,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -335,6 +354,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -363,6 +383,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -391,6 +412,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -419,6 +441,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -447,6 +470,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -475,6 +499,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -503,6 +528,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_FTRACE=y+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_SW_TAGS=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -531,6 +557,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -559,6 +586,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -587,6 +615,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -615,6 +644,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -643,6 +673,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -671,6 +702,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -699,6 +731,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 malta_defconfig+CONFIG_BLK_DEV_INITRD=y+CONFIG_CPU_BIG_ENDIAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -727,6 +760,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=mips LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 malta_defconfig+CONFIG_BLK_DEV_INITRD=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -755,6 +789,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=20 ppc44x_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -783,6 +818,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 ppc64_guest_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -811,6 +847,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 powernv_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -839,6 +876,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -867,6 +905,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -895,6 +934,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -923,6 +963,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -951,6 +992,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -979,6 +1021,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=sparc CC=clang LLVM_IAS=0 LLVM_VERSION=20 sparc64_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1007,6 +1050,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=um LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1035,6 +1079,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1063,6 +1108,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_FULL=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1091,6 +1137,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1119,6 +1166,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1147,6 +1195,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1175,6 +1224,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KASAN=y+CONFIG_KASAN_KUNIT_TEST=y+CONFIG_KASAN_VMALLOC=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1203,6 +1253,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_KCSAN=y+CONFIG_KCSAN_KUNIT_TEST=y+CONFIG_KUNIT=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1231,6 +1282,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_UBSAN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1259,6 +1311,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+hardening.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1286,7 +1339,9 @@ jobs:
     name: TuxSuite (distribution_configs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1328,6 +1383,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1356,6 +1412,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1384,6 +1441,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1412,6 +1470,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1440,6 +1499,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-aarch64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1468,6 +1528,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1496,6 +1557,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1524,6 +1586,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-ppc64le-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1552,6 +1615,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=powerpc LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/ppc64le/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1580,6 +1644,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.riscv64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1608,6 +1673,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/riscv64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1636,6 +1702,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-s390x-fedora.config+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1664,6 +1731,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=s390 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/s390x/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1692,6 +1760,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.x86_64
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1720,6 +1789,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/raw/main/config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1748,6 +1818,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1776,6 +1847,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://src.fedoraproject.org/rpms/kernel/raw/rawhide/f/kernel-x86_64-fedora.config+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1804,6 +1876,7 @@ jobs:
     needs:
     - kick_tuxsuite_distribution_configs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 https://github.com/openSUSE/kernel-source/raw/master/config/x86_64/default
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1831,7 +1904,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -1873,6 +1948,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1901,6 +1977,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1929,6 +2006,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1957,6 +2035,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -1985,6 +2064,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2013,6 +2093,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2041,6 +2122,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2069,6 +2151,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 virtconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2097,6 +2180,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=hexagon BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2125,6 +2209,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2153,6 +2238,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=loongarch BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_FTRACE=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_OMAP=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2181,6 +2267,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=powerpc BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_PPC64_BIG_ENDIAN_ELF_ABI_V2=y+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2209,6 +2296,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2237,6 +2325,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=riscv BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_WERROR=n+CONFIG_GCOV_KERNEL=n+CONFIG_LTO_CLANG_THIN=y+CONFIG_DRM_WERROR=n
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2265,6 +2354,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2293,6 +2383,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig+CONFIG_GCOV_KERNEL=n+CONFIG_KASAN=n+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2321,6 +2412,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -2349,6 +2441,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/tip-clang-13.yml
+++ b/.github/workflows/tip-clang-13.yml
@@ -16,10 +16,18 @@ name: tip (clang-13)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/tip --repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-13
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/tip-clang-14.yml
+++ b/.github/workflows/tip-clang-14.yml
@@ -16,10 +16,18 @@ name: tip (clang-14)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/tip --repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-14
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/tip-clang-15.yml
+++ b/.github/workflows/tip-clang-15.yml
@@ -16,10 +16,18 @@ name: tip (clang-15)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/tip --repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-15
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/tip-clang-16.yml
+++ b/.github/workflows/tip-clang-16.yml
@@ -16,10 +16,18 @@ name: tip (clang-16)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/tip --repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-16
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/tip-clang-17.yml
+++ b/.github/workflows/tip-clang-17.yml
@@ -16,10 +16,18 @@ name: tip (clang-17)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/tip --repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-17
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/tip-clang-18.yml
+++ b/.github/workflows/tip-clang-18.yml
@@ -16,10 +16,18 @@ name: tip (clang-18)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/tip --repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-18
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/tip-clang-19.yml
+++ b/.github/workflows/tip-clang-19.yml
@@ -16,10 +16,18 @@ name: tip (clang-19)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/tip --repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_korg-clang-19
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/.github/workflows/tip-clang-20.yml
+++ b/.github/workflows/tip-clang-20.yml
@@ -16,10 +16,18 @@ name: tip (clang-20)
   workflow_dispatch: null
 permissions: read-all
 jobs:
+  check_patches:
+    name: Check that patches are applicable
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: check-patches-apply.py
+      run: python3 scripts/check-patches-apply.py --patches-dir patches/tip --repo https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git --ref master
   check_cache:
     name: Check Cache
     runs-on: ubuntu-latest
     container: tuxmake/x86_64_clang-nightly
+    needs: check_patches
     env:
       GIT_REPO: https://git.kernel.org/pub/scm/linux/kernel/git/tip/tip.git
       GIT_REF: master
@@ -41,7 +49,9 @@ jobs:
     name: TuxSuite (defconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -83,6 +93,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -111,6 +122,7 @@ jobs:
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -138,7 +150,9 @@ jobs:
     name: TuxSuite (allconfigs)
     runs-on: ubuntu-latest
     container: tuxsuite/tuxsuite
-    needs: check_cache
+    needs:
+    - check_cache
+    - check_patches
     env:
       TUXSUITE_TOKEN: ${{ secrets.TUXSUITE_TOKEN }}
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
@@ -180,6 +194,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allmodconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -208,6 +223,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allnoconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
@@ -236,6 +252,7 @@ jobs:
     needs:
     - kick_tuxsuite_allconfigs
     - check_cache
+    - check_patches
     name: ARCH=x86_64 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 allyesconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:

--- a/scripts/check-patch-apply.py
+++ b/scripts/check-patch-apply.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# pylint: disable=invalid-name
+
+from argparse import ArgumentParser
+from pathlib import Path
+import os
+import subprocess
+import sys
+from tempfile import TemporaryDirectory
+
+parser = ArgumentParser(
+    description='Check that patches apply to their tree before running CI')
+parser.add_argument(
+    '-p',
+    '--patches-dir',
+    help='Path to patches directory (can be relative or absolute)',
+    required=True,
+    type=Path)
+parser.add_argument('-r',
+                    '--repo',
+                    help='URL to git repository',
+                    required=True)
+parser.add_argument('-R',
+                    '--ref',
+                    help='Git reference to apply patches upon',
+                    required=True)
+args = parser.parse_args()
+
+# If patches directory does not exist, there is nothing to check
+if not (patches_dir := args.patches_dir.resolve()).exists():
+    print(f"{patches_dir} does not exist, exiting 0...")
+    sys.exit(0)
+
+# There should be patches in there due to check-patches.py but we should double
+# check and fail if not
+if not list(patches_dir.glob('*.patch')):
+    print(f"{patches_dir} does not contain any patches?")
+    sys.exit(1)
+
+# Rather that invoke 'git clone', which can be expensive for servers depending
+# on the frequency and duration of requests, we fetch a tarball and 'git init'
+# that.
+with TemporaryDirectory() as workdir:
+    # Fetch the tarball from the repository. This is different for each type of
+    # tree that we support.
+    if args.repo.startswith(
+            'https://git.kernel.org/pub/scm/linux/kernel/git/'):
+        # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git -> 'linux'
+        if (base_repo := args.repo.rsplit('/', 1)[1]).endswith('.git'):
+            base_repo = base_repo[:-len('.git')]
+
+        # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git ->
+        # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/snapshot/linux-master.tar.gz
+        tarball_url = f"{args.repo}/snapshot/{base_repo}-{args.ref}.tar.gz"
+        strip = 1
+    elif 'googlesource.com' in args.repo:
+        tarball_url = f"{args.repo}/+archive/refs/heads/{args.ref}.tar.gz"
+        strip = 0
+    else:
+        raise RuntimeError(f"Do not know how to download {args.repo}?")
+
+    try:
+        print(f"Downloading {tarball_url}...")
+        tarball = subprocess.run(['curl', '-LSs', tarball_url],
+                                 capture_output=True,
+                                 check=True).stdout
+
+        print(f"Extracting {tarball_url}...")
+        subprocess.run(
+            ['tar', '-C', workdir, f"--strip-components={strip}", '-xzf-'],
+            check=True,
+            input=tarball)
+    except subprocess.CalledProcessError:
+        print(
+            'Downloading or extracting tarball failed! As this may be flakiness on the server end, exiting 0 to have TuxSuite fail later...'
+        )
+        sys.exit(0)
+
+    # Ensure that we can always commit regardless of whether user.name or
+    # user.email are set in whatever environment we are running in, as this is
+    # a temporary tree.
+    git_name = 'check-patch-apply.py'
+    git_email = f"{git_name}@{os.uname().nodename}.local"
+    git_commit_env_vars = {
+        **os.environ,   # clone the environment, as subprocess may need it
+        'GIT_AUTHOR_NAME': git_name,
+        'GIT_AUTHOR_EMAIL': git_email,
+        'GIT_COMMITTER_NAME': git_name,
+        'GIT_COMMITTER_EMAIL': git_email,
+    }  # yapf: disable
+
+    print(f"Creating initial git repository in {workdir}...")
+    subprocess.run(['git', 'init', '-q'], check=True, cwd=workdir)
+
+    print(f"Adding files in {workdir}...")
+    subprocess.run(['git', 'add', '.'], check=True, cwd=workdir)
+
+    print(
+        f"Creating initial commit '{args.repo} @ {args.ref}' in {workdir}...")
+    subprocess.run(['git', 'commit', '-m', f"{args.repo} @ {args.ref}", '-q'],
+                   check=True,
+                   cwd=workdir,
+                   env=git_commit_env_vars)
+
+    print(f"Applying patches in {workdir}...")
+    subprocess.run(['git', 'quiltimport', '--patches', patches_dir],
+                   check=True,
+                   cwd=workdir,
+                   env=git_commit_env_vars)


### PR DESCRIPTION
There is no point in spinning up TuxSuite for a build if any patches that we need to apply are going to fail to do so. At the beginning of a build, check if the patches apply to the current repository and reference. This is done by downloading a tarball of the source, running `git init` and committing the files, then finally running `git quiltimport` to make sure that that patches still apply. It would be simpler to use `git clone --depth=1` but cloning can be expensive on the server side and these jobs may run at the same time.

Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/796

NOTE: I have not bumped the generated files to make this easier to review and reason through. I will do it before merging.
