### PR TITLE
scripts/check-patches-apply.py: Fix strip value for refs with a slash

### DIFF
--- a/scripts/check-patches-apply.py
+++ b/scripts/check-patches-apply.py
@@ -52,7 +52,7 @@ with TemporaryDirectory() as workdir:
         # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git ->
         # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/snapshot/linux-master.tar.gz
         tarball_url = f"{args.repo}/snapshot/{base_repo}-{args.ref}.tar.gz"
-        strip = 1
+        strip = len(args.ref.split('/'))
     elif 'googlesource.com' in args.repo:
         tarball_url = f"{args.repo}/+archive/refs/heads/{args.ref}.tar.gz"
         strip = 0


### PR DESCRIPTION
For refs with a slash in them, such as the arm64 refs `for-next/core` and `for-next/fixes`, the tarball will be formatted like:

```
for-next/core/Makefile
for-next/core/arch/...
```

which causes an incorrect layout with the current value of 1 and patches that would normally apply correctly fail to do so. The strip value for the above scenario needs to be 2 to allow the patches to apply correctly. Use the length of the list created by splitting on slashes as the strip value so that the layout is consistent for patch application.
