### PR TITLE
Disable ARM configs with BPF enabled in -next with clang-13

### DIFF
--- a/.github/workflows/mainline-clang-13.yml
+++ b/.github/workflows/mainline-clang-13.yml
@@ -117,35 +117,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3dcc2dad9e1ef4e6a3f358ffef73f7fe:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 aspeed_g5_defconfig
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: aspeed_g5_defconfig
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _9532604fe2c353a710edd757453b4457:
     runs-on: ubuntu-latest
     needs:
@@ -914,64 +885,6 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
         if-no-files-found: error
-  _1dad89b577653ddc683e87e9409fc409:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_distribution_configs
-    - check_cache
-    - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
-  _1435de1ebd93ba0b4f841682571dd69b:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_distribution_configs
-    - check_cache
-    - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _41e97db7d8ed584321ef7865ba127060:
     runs-on: ubuntu-latest
     needs:
@@ -1363,35 +1276,6 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
         if-no-files-found: error
-  _2309c816a58459d87da53f6d2074f5d8:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_allconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm
-      LLVM_VERSION: 13
-      BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_allconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _e3671bdb6f10d3349593b86cc9b324f6:
     runs-on: ubuntu-latest
     needs:
@@ -1405,35 +1289,6 @@ jobs:
       LLVM_VERSION: 13
       BOOT: 0
       CONFIG: allnoconfig
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_allconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
-  _1d1b9fe50f6e08aeeaaaf80cf8333f67:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_allconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm
-      LLVM_VERSION: 13
-      BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-13.yml
+++ b/.github/workflows/next-clang-13.yml
@@ -117,35 +117,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3dcc2dad9e1ef4e6a3f358ffef73f7fe:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 aspeed_g5_defconfig
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: aspeed_g5_defconfig
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _9532604fe2c353a710edd757453b4457:
     runs-on: ubuntu-latest
     needs:
@@ -711,64 +682,6 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_distribution_configs
         if-no-files-found: error
-  _1dad89b577653ddc683e87e9409fc409:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_distribution_configs
-    - check_cache
-    - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
-  _1435de1ebd93ba0b4f841682571dd69b:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_distribution_configs
-    - check_cache
-    - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_distribution_configs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _41e97db7d8ed584321ef7865ba127060:
     runs-on: ubuntu-latest
     needs:
@@ -1015,35 +928,6 @@ jobs:
         path: boot-utils.json
         name: boot_utils_json_allconfigs
         if-no-files-found: error
-  _2309c816a58459d87da53f6d2074f5d8:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_allconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm
-      LLVM_VERSION: 13
-      BOOT: 0
-      CONFIG: allmodconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_allconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _e3671bdb6f10d3349593b86cc9b324f6:
     runs-on: ubuntu-latest
     needs:
@@ -1057,35 +941,6 @@ jobs:
       LLVM_VERSION: 13
       BOOT: 0
       CONFIG: allnoconfig
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_allconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
-  _1d1b9fe50f6e08aeeaaaf80cf8333f67:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_allconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm
-      LLVM_VERSION: 13
-      BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/generator/yml/0009-llvm-13.yml
+++ b/generator/yml/0009-llvm-13.yml
@@ -5,17 +5,23 @@
   #  Mainline  #
   ##############
   - {<< : *arm32_v5,          << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm32_v6,          << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  # BPF uses check_mul_overflow() with a 'long long' value, which is broken prior to clang-14:
+  # https://github.com/llvm/llvm-project/commit/5c91b98c5d45243352bf10262454bcac77cd3fed
+  # - {<< : *arm32_v6,          << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm32_v7,          << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm32_v7_t,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm32_imx,         << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_omap,        << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_lpae_fp,     << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm32_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  # BPF uses check_mul_overflow() with a 'long long' value, which is broken prior to clang-14:
+  # https://github.com/llvm/llvm-project/commit/5c91b98c5d45243352bf10262454bcac77cd3fed
+  # - {<< : *arm32_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_allno,       << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
-  - {<< : *arm32_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
-  - {<< : *arm32_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  # BPF uses check_mul_overflow() with a 'long long' value, which is broken prior to clang-14:
+  # https://github.com/llvm/llvm-project/commit/5c91b98c5d45243352bf10262454bcac77cd3fed
+  # - {<< : *arm32_allyes,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_13}
+  # - {<< : *arm32_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
+  # - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_13}
@@ -64,17 +70,23 @@
   #  Next  #
   ##########
   - {<< : *arm32_v5,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm32_v6,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  # BPF uses check_mul_overflow() with a 'long long' value, which is broken prior to clang-14:
+  # https://github.com/llvm/llvm-project/commit/5c91b98c5d45243352bf10262454bcac77cd3fed
+  # - {<< : *arm32_v6,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm32_v7,          << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm32_v7_t,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm32_imx,         << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_omap,        << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_lpae_fp,     << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm32_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  # BPF uses check_mul_overflow() with a 'long long' value, which is broken prior to clang-14:
+  # https://github.com/llvm/llvm-project/commit/5c91b98c5d45243352bf10262454bcac77cd3fed
+  # - {<< : *arm32_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
-  - {<< : *arm32_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
-  - {<< : *arm32_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  # BPF uses check_mul_overflow() with a 'long long' value, which is broken prior to clang-14:
+  # https://github.com/llvm/llvm-project/commit/5c91b98c5d45243352bf10262454bcac77cd3fed
+  # - {<< : *arm32_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_13}
+  # - {<< : *arm32_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
+  # - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_13}

--- a/tuxsuite/mainline-clang-13.tux.yml
+++ b/tuxsuite/mainline-clang-13.tux.yml
@@ -23,15 +23,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: korg-clang-13
-    kconfig: aspeed_g5_defconfig
-    targets:
-    - kernel
-    - dtbs
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: korg-clang-13
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -282,22 +273,6 @@ jobs:
       LLVM_IAS: 1
 - name: distribution_configs
   builds:
-  - target_arch: arm
-    toolchain: korg-clang-13
-    kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: korg-clang-13
-    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
@@ -404,29 +379,7 @@ jobs:
   builds:
   - target_arch: arm
     toolchain: korg-clang-13
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
-    - CONFIG_DRM_WERROR=n
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: korg-clang-13
     kconfig: allnoconfig
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: korg-clang-13
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
-    - CONFIG_DRM_WERROR=n
     targets:
     - default
     make_variables:

--- a/tuxsuite/next-clang-13.tux.yml
+++ b/tuxsuite/next-clang-13.tux.yml
@@ -23,15 +23,6 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm
     toolchain: korg-clang-13
-    kconfig: aspeed_g5_defconfig
-    targets:
-    - kernel
-    - dtbs
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: korg-clang-13
     kconfig: multi_v7_defconfig
     targets:
     - kernel
@@ -211,22 +202,6 @@ jobs:
       LLVM_IAS: 1
 - name: distribution_configs
   builds:
-  - target_arch: arm
-    toolchain: korg-clang-13
-    kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.armv7
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: korg-clang-13
-    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/armv7hl/default
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-13
     kconfig: https://git.alpinelinux.org/aports/plain/community/linux-edge/config-edge.aarch64
@@ -293,29 +268,7 @@ jobs:
   builds:
   - target_arch: arm
     toolchain: korg-clang-13
-    kconfig:
-    - allmodconfig
-    - CONFIG_WERROR=n
-    - CONFIG_DRM_WERROR=n
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: korg-clang-13
     kconfig: allnoconfig
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm
-    toolchain: korg-clang-13
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
-    - CONFIG_DRM_WERROR=n
     targets:
     - default
     make_variables:


### PR DESCRIPTION
After commit [9aa0ebde0014](https://git.kernel.org/bpf/bpf-next/c/9aa0ebde0014f01a8ca82adcbf43b92345da0d50) ("bpf, verifier: Improve precision of BPF_MUL"), there is an error in certain ARM configurations that enable `CONFIG_BPF_SYSCALL`:

```
ld.lld: error: undefined symbol: __mulodi4
>>> referenced by verifier.c:14221 (/builds/linux/kernel/bpf/verifier.c:14221)
>>>               kernel/bpf/verifier.o:(adjust_reg_min_max_vals) in archive vmlinux.a
>>> referenced by verifier.c:14222 (/builds/linux/kernel/bpf/verifier.c:14222)
>>>               kernel/bpf/verifier.o:(adjust_reg_min_max_vals) in archive vmlinux.a
>>> referenced by verifier.c:14223 (/builds/linux/kernel/bpf/verifier.c:14223)
>>>               kernel/bpf/verifier.o:(adjust_reg_min_max_vals) in archive vmlinux.a
>>> referenced 1 more times
```

This was [encountered previously](https://github.com/ClangBuiltLinux/linux/issues/1438), where it was fixed in clang-14 and avoided in the kernel with a source code workaround (that ended up being cleaner anyways).

This time around, inserting a source code workaround would not be as clean, as it may involve disabling a core part of the kernel on a limited condition (as it only impacts one supported LLVM version and architecture combination) or having a separate code path for this situation.

For now, just disable the builds that are impacted by this. If more people notice this problem, we can explore bumping the minimum supported version of LLVM for building `ARCH=arm` to 14.
