### PR TITLE
patches: 6.12: Apply 8b55f8818900c99dd4f55a59a103f5b29e41eb2c

### DIFF
--- a/patches/6.12/8b55f8818900c99dd4f55a59a103f5b29e41eb2c.patch
+++ b/patches/6.12/8b55f8818900c99dd4f55a59a103f5b29e41eb2c.patch
@@ -1,0 +1,45 @@
+From 8b55f8818900c99dd4f55a59a103f5b29e41eb2c Mon Sep 17 00:00:00 2001
+From: Arnd Bergmann <arnd@arndb.de>
+Date: Fri, 18 Oct 2024 15:14:42 +0000
+Subject: media: mediatek: vcodec: mark vdec_vp9_slice_map_counts_eob_coef
+ noinline
+
+With KASAN enabled, clang fails to optimize the inline version of
+vdec_vp9_slice_map_counts_eob_coef() properly, leading to kilobytes
+of temporary values spilled to the stack:
+
+drivers/media/platform/mediatek/vcodec/decoder/vdec/vdec_vp9_req_lat_if.c:1526:12: error: stack frame size (2160) exceeds limit (2048) in 'vdec_vp9_slice_update_prob' [-Werror,-Wframe-larger-than]
+
+This seems to affect all versions of clang including the latest (clang-20),
+but the degree of stack overhead is different per release.
+
+Marking the function as noinline_for_stack is harmless here and avoids
+the problem completely.
+
+Signed-off-by: Arnd Bergmann <arnd@arndb.de>
+Reviewed-by: Nathan Chancellor <nathan@kernel.org>
+Signed-off-by: Sebastian Fricke <sebastian.fricke@collabora.com>
+Signed-off-by: Mauro Carvalho Chehab <mchehab+huawei@kernel.org>
+---
+Link: https://git.linuxtv.org/media.git/commit/?id=8b55f8818900c99dd4f55a59a103f5b29e41eb2c
+---
+ .../media/platform/mediatek/vcodec/decoder/vdec/vdec_vp9_req_lat_if.c  | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/platform/mediatek/vcodec/decoder/vdec/vdec_vp9_req_lat_if.c b/drivers/media/platform/mediatek/vcodec/decoder/vdec/vdec_vp9_req_lat_if.c
+index eea709d93820..47c302745c1d 100644
+--- a/drivers/media/platform/mediatek/vcodec/decoder/vdec/vdec_vp9_req_lat_if.c
++++ b/drivers/media/platform/mediatek/vcodec/decoder/vdec/vdec_vp9_req_lat_if.c
+@@ -1188,7 +1188,8 @@ err:
+ 	return ret;
+ }
+ 
+-static
++/* clang stack usage explodes if this is inlined */
++static noinline_for_stack
+ void vdec_vp9_slice_map_counts_eob_coef(unsigned int i, unsigned int j, unsigned int k,
+ 					struct vdec_vp9_slice_frame_counts *counts,
+ 					struct v4l2_vp9_frame_symbol_counts *counts_helper)
+-- 
+cgit v1.2.3
+

--- a/patches/6.12/series
+++ b/patches/6.12/series
@@ -1,1 +1,2 @@
+8b55f8818900c99dd4f55a59a103f5b29e41eb2c.patch
 20250124_nathan_arm64_handle_arm_attributes_section_in_linker_scripts.patch


### PR DESCRIPTION
This should have been transferred to 6.12 properly during the 6.12 and 6.13 update/split but I missed it.
