### PR TITLE
Disable RISC-V full LTO build on mainline with LLVM 14

### DIFF
--- a/.github/workflows/mainline-clang-14.yml
+++ b/.github/workflows/mainline-clang-14.yml
@@ -639,35 +639,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _40f8b547f75f3890da243a4d79d32380:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=riscv LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig+CONFIG_LTO_CLANG_FULL=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: riscv
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_LTO_CLANG_FULL=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _3b55af602ee9ae620028f2ed3f6ce5a4:
     runs-on: ubuntu-latest
     needs:

--- a/generator/yml/0009-llvm-14.yml
+++ b/generator/yml/0009-llvm-14.yml
@@ -42,7 +42,6 @@
   - {<< : *ppc64le_fedora,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *ppc64le_suse,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *riscv,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *riscv_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *riscv_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *riscv_allmod,      << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *riscv_allmod_lto,  << : *mainline,         << : *llvm_full,       boot: false, << : *llvm_14}

--- a/tuxsuite/mainline-clang-14.tux.yml
+++ b/tuxsuite/mainline-clang-14.tux.yml
@@ -203,17 +203,6 @@ jobs:
     toolchain: korg-clang-14
     kconfig:
     - defconfig
-    - CONFIG_LTO_CLANG_FULL=y
-    targets:
-    - kernel
-    kernel_image: Image
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: riscv
-    toolchain: korg-clang-14
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel


### PR DESCRIPTION
Same as commit b8e27bf0 ("generator: yml: Disable RISC-V full LTO build on -next with LLVM 14") but for mainline now that the breaking asm goto with outputs changes have been merged there.
