### PR TITLE
utils.py: Fix get_cbl_name() for Alpine config change for real

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -81,7 +81,7 @@ def get_cbl_name():
                 "x86_64": "x86_64"
             }
             # The URL is https://.../stable.<arch>.config
-            alpine_arch = base_config.split(".")[1]
+            alpine_arch = base_config.split(".")[-2]
             return alpine_to_cbl[alpine_arch]
         if "fedora" in base_config:
             fedora_to_cbl = {


### PR DESCRIPTION
The previous fix in commit b04e3869 ("utils.py: Update get_cbl_name() for new Alpine configuration scheme") traded one error for another because I did not account for the period in the domain name. Index from the right to resolve the error more consistently. This has actually been tested locally now :^)
