### PR TITLE
github: Fix internal problem matcher for color ASCII escape codes

### DIFF
--- a/.github/problem-matchers/internal.json
+++ b/.github/problem-matchers/internal.json
@@ -6,7 +6,7 @@
             "pattern": [
                 {
                     "__comment_regexp1": "ERROR: Build is not finished on TuxSuite's side!",
-                    "regexp": "^(WARNING|ERROR):\\s+(.*)$",
+                    "regexp": "^\\x1b\\[[0-9]+m(WARNING|ERROR):\\s+(.*)\\x1b\\[0m$",
                     "severity": 1,
                     "message": 2
                 }


### PR DESCRIPTION
The internal warnings/errors problem matcher regex still does not highlight the messages properly, even though I tested the regex. Unfortunately, the reason is only obvious when looking at the raw GitHublogs, which shows the raw color ASCII escape codes that `print_red()` and `print_yellow()` use.

Add the escape codes to the regex to fix the matching, which ends up making the matcher more robust because it will only highlight the color messages that the script generates.
