### PR TITLE
patches: android14-5.15: Use 6.1 version of KVM patch

### DIFF
--- a/patches/android14-5.15/20250728_justinstitt_kvm_arm64_sys_regs_disable_wuninitialized_const_pointer_warning.patch
+++ b/patches/android14-5.15/20250728_justinstitt_kvm_arm64_sys_regs_disable_wuninitialized_const_pointer_warning.patch
@@ -2,8 +2,8 @@ From git@z Thu Jan  1 00:00:00 1970
 Subject: [PATCH] KVM: arm64: sys_regs: disable
  -Wuninitialized-const-pointer warning
 From: Justin Stitt <justinstitt@google.com>
-Date: Mon, 28 Jul 2025 14:04:24 -0700
-Message-Id: <20250728-b4-stable-disable-uninit-ptr-warn-5-15-v1-1-e373a895b9c5@google.com>
+Date: Mon, 28 Jul 2025 14:07:36 -0700
+Message-Id: <20250728-stable-disable-unit-ptr-warn-v1-1-958be9b66520@google.com>
 MIME-Version: 1.0
 Content-Type: text/plain; charset="utf-8"
 Content-Transfer-Encoding: 7bit
@@ -13,8 +13,8 @@ get_clidr_el1() is an uninitialized const pointer. get_clidr_el1()
 doesn't really care since it casts away the const-ness anyways -- it is
 a false positive.
 
-|  ../arch/arm64/kvm/sys_regs.c:2838:23: warning: variable 'clidr' is uninitialized when passed as a const pointer argument here [-Wuninitialized-const-pointer]
-|   2838 |         get_clidr_el1(NULL, &clidr); /* Ugly... */
+|  ../arch/arm64/kvm/sys_regs.c:2978:23: warning: variable 'clidr' is uninitialized when passed as a const pointer argument here [-Wuninitialized-const-pointer]
+|   2978 |         get_clidr_el1(NULL, &clidr); /* Ugly... */
 |        |                              ^~~~~
 
 Disable this warning for sys_regs.o with an iron fist as it doesn't make
@@ -29,28 +29,31 @@ Cc: stable@vger.kernel.org
 Fixes: 7c8c5e6a9101e ("arm64: KVM: system register handling")
 Link: https://github.com/llvm/llvm-project/commit/00dacf8c22f065cb52efb14cd091d441f19b319e [1]
 Signed-off-by: Justin Stitt <justinstitt@google.com>
-Link: https://lore.kernel.org/r/20250728-b4-stable-disable-uninit-ptr-warn-5-15-v1-1-e373a895b9c5@google.com
+Link: https://lore.kernel.org/r/20250728-stable-disable-unit-ptr-warn-v1-1-958be9b66520@google.com
 ---
-I'm sending a similar patch for 6.1.
+I've sent a similar patch for 5.15.
 ---
  arch/arm64/kvm/Makefile | 3 +++
  1 file changed, 3 insertions(+)
 
 diff --git a/arch/arm64/kvm/Makefile b/arch/arm64/kvm/Makefile
-index 989bb5dad2c8..109cca425d3e 100644
+index 5e33c2d4645a..5fdb5331bfad 100644
 --- a/arch/arm64/kvm/Makefile
 +++ b/arch/arm64/kvm/Makefile
-@@ -25,3 +25,6 @@ kvm-y := $(KVM)/kvm_main.o $(KVM)/coalesced_mmio.o $(KVM)/eventfd.o \
- 	 vgic/vgic-its.o vgic/vgic-debug.o
+@@ -24,6 +24,9 @@ kvm-y += arm.o mmu.o mmio.o psci.o hypercalls.o pvtime.o \
  
- kvm-$(CONFIG_HW_PERF_EVENTS)  += pmu-emul.o
-+
+ kvm-$(CONFIG_HW_PERF_EVENTS)  += pmu-emul.o pmu.o
+ 
 +# Work around a false positive Clang 22 -Wuninitialized-const-pointer warning
 +CFLAGS_sys_regs.o := $(call cc-disable-warning, uninitialized-const-pointer)
++
+ always-y := hyp_constants.h hyp-constants.s
+ 
+ define rule_gen_hyp_constants
 
 ---
-base-commit: 8bb7eca972ad531c9b149c0a51ab43a417385813
-change-id: 20250728-b4-stable-disable-uninit-ptr-warn-5-15-c0c9db3df206
+base-commit: 830b3c68c1fb1e9176028d02ef86f3cf76aa2476
+change-id: 20250728-stable-disable-unit-ptr-warn-281fee82539c
 
 Best regards,
 --


### PR DESCRIPTION
This branch has the hyp constants series backported.
