### PR TITLE
scripts/check-logs.py: Treat empty string values as 'n' for config check

### DIFF
--- a/scripts/check-logs.py
+++ b/scripts/check-logs.py
@@ -149,6 +149,11 @@ def check_built_config(build):
             state = None
             if '=' in line:
                 name, state = line.split('=', 1)
+                # Treat empty string values as 'n', as TuxSuite only supports y|m|n
+                # for overriding configuration options, so 'n' may be used to reset
+                # a value
+                if state == '""':
+                    state = 'n'
             elif line.startswith("# CONFIG_"):
                 name, state = line.split(" ", 2)[1:]
                 if state != "is not set":


### PR DESCRIPTION
Commit 3e2f19e3 ("generator: yml: Reset CONFIG_EFI_SBAT_FILE for Fedora configurations") used '=n' to reset a string value to its default due to a limitation in TuxSuite / TuxMake. This causes a mismatch between the value provided and the value in the config, resulting in an error from the config check:

```
ERROR: CONFIG_EFI_SBAT_FILE=n not found in .config!
```

If the value is empty, treat it as 'n' for the sake of this check.
