### PR TITLE
Revert "generator: yml: Disable CONFIG_DEBUG_INFO_COMPRESSED_ZSTD in Android configs"

### DIFF
--- a/.github/workflows/android-mainline-clang-19.yml
+++ b/.github/workflows/android-mainline-clang-19.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _427ad04336d3b729e9f06ac390339c83:
+  _0913b033bbb90e4af0d1c3e20ba5a03d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _69be54e07c0c29096e6473be61b248d6:
+  _3eb68f215995c2c50b536d2dc8d27755:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-mainline-clang-20.yml
+++ b/.github/workflows/android-mainline-clang-20.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _d0dd1703161afcada7c2ed606466e184:
+  _d45e53c7a1bf4bd7cb36d81fbb79b8e3:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 20
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _91c6691c663b91ab0a878f440c07e577:
+  _5d91479856541072a55eab8e3cf55729:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 20
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-mainline-clang-21.yml
+++ b/.github/workflows/android-mainline-clang-21.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _78dba792a49a77ec4549053d434f5ad3:
+  _28c8fe42b28be9d263d9c7bfa10e8864:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 21
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _732c7eced3e2dc8feb494ad5aa0e27b6:
+  _044bce49826813f5ef57a2e03aff3104:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 21
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android-mainline-clang-22.yml
+++ b/.github/workflows/android-mainline-clang-22.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _29df985ee757664dbc11a17e6248585b:
+  _bcf26d51fcd9a73fe5db7be7c26a4ef2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 22
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _f1ea8d09076c9fca5010a03f9d296c44:
+  _2724d9ad7d117edfefc8a1d6be7b97fa:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 22
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-5.15-clang-17.yml
+++ b/.github/workflows/android14-5.15-clang-17.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _c9a7bb527b7340eacb42c20cbc2ecf43:
+  _57225b66c2cca415de91dd060472c53e:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _c857a5b77f9ff7258c0b914b8ca906cd:
+  _934c8b5199cfd7d563f331608b4aef1d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-5.15-clang-18.yml
+++ b/.github/workflows/android14-5.15-clang-18.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e05cc2bd0d980c406da77866025ae9a6:
+  _ebd88385a017d6a8b6a4d3b1d4bff8f4:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _c89fe0a8c5057794c34bb22f1b69d33d:
+  _1e7e455003c708db13544699bc315515:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-5.15-clang-19.yml
+++ b/.github/workflows/android14-5.15-clang-19.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _427ad04336d3b729e9f06ac390339c83:
+  _0913b033bbb90e4af0d1c3e20ba5a03d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _69be54e07c0c29096e6473be61b248d6:
+  _3eb68f215995c2c50b536d2dc8d27755:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-5.15-clang-20.yml
+++ b/.github/workflows/android14-5.15-clang-20.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _d0dd1703161afcada7c2ed606466e184:
+  _d45e53c7a1bf4bd7cb36d81fbb79b8e3:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 20
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _91c6691c663b91ab0a878f440c07e577:
+  _5d91479856541072a55eab8e3cf55729:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 20
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-5.15-clang-21.yml
+++ b/.github/workflows/android14-5.15-clang-21.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _78dba792a49a77ec4549053d434f5ad3:
+  _28c8fe42b28be9d263d9c7bfa10e8864:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 21
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _732c7eced3e2dc8feb494ad5aa0e27b6:
+  _044bce49826813f5ef57a2e03aff3104:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 21
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-5.15-clang-22.yml
+++ b/.github/workflows/android14-5.15-clang-22.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _29df985ee757664dbc11a17e6248585b:
+  _bcf26d51fcd9a73fe5db7be7c26a4ef2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 22
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _f1ea8d09076c9fca5010a03f9d296c44:
+  _2724d9ad7d117edfefc8a1d6be7b97fa:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 22
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-6.1-clang-17.yml
+++ b/.github/workflows/android14-6.1-clang-17.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _c9a7bb527b7340eacb42c20cbc2ecf43:
+  _57225b66c2cca415de91dd060472c53e:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _c857a5b77f9ff7258c0b914b8ca906cd:
+  _934c8b5199cfd7d563f331608b4aef1d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-6.1-clang-18.yml
+++ b/.github/workflows/android14-6.1-clang-18.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e05cc2bd0d980c406da77866025ae9a6:
+  _ebd88385a017d6a8b6a4d3b1d4bff8f4:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _c89fe0a8c5057794c34bb22f1b69d33d:
+  _1e7e455003c708db13544699bc315515:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-6.1-clang-19.yml
+++ b/.github/workflows/android14-6.1-clang-19.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _427ad04336d3b729e9f06ac390339c83:
+  _0913b033bbb90e4af0d1c3e20ba5a03d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _69be54e07c0c29096e6473be61b248d6:
+  _3eb68f215995c2c50b536d2dc8d27755:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-6.1-clang-20.yml
+++ b/.github/workflows/android14-6.1-clang-20.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _d0dd1703161afcada7c2ed606466e184:
+  _d45e53c7a1bf4bd7cb36d81fbb79b8e3:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 20
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _91c6691c663b91ab0a878f440c07e577:
+  _5d91479856541072a55eab8e3cf55729:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 20
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-6.1-clang-21.yml
+++ b/.github/workflows/android14-6.1-clang-21.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _78dba792a49a77ec4549053d434f5ad3:
+  _28c8fe42b28be9d263d9c7bfa10e8864:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 21
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _732c7eced3e2dc8feb494ad5aa0e27b6:
+  _044bce49826813f5ef57a2e03aff3104:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 21
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android14-6.1-clang-22.yml
+++ b/.github/workflows/android14-6.1-clang-22.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _29df985ee757664dbc11a17e6248585b:
+  _bcf26d51fcd9a73fe5db7be7c26a4ef2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 22
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _f1ea8d09076c9fca5010a03f9d296c44:
+  _2724d9ad7d117edfefc8a1d6be7b97fa:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 22
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.6-clang-18.yml
+++ b/.github/workflows/android15-6.6-clang-18.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e05cc2bd0d980c406da77866025ae9a6:
+  _ebd88385a017d6a8b6a4d3b1d4bff8f4:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _c89fe0a8c5057794c34bb22f1b69d33d:
+  _1e7e455003c708db13544699bc315515:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.6-clang-19.yml
+++ b/.github/workflows/android15-6.6-clang-19.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _427ad04336d3b729e9f06ac390339c83:
+  _0913b033bbb90e4af0d1c3e20ba5a03d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _69be54e07c0c29096e6473be61b248d6:
+  _3eb68f215995c2c50b536d2dc8d27755:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.6-clang-20.yml
+++ b/.github/workflows/android15-6.6-clang-20.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _d0dd1703161afcada7c2ed606466e184:
+  _d45e53c7a1bf4bd7cb36d81fbb79b8e3:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 20
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _91c6691c663b91ab0a878f440c07e577:
+  _5d91479856541072a55eab8e3cf55729:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 20
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.6-clang-21.yml
+++ b/.github/workflows/android15-6.6-clang-21.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _78dba792a49a77ec4549053d434f5ad3:
+  _28c8fe42b28be9d263d9c7bfa10e8864:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 21
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _732c7eced3e2dc8feb494ad5aa0e27b6:
+  _044bce49826813f5ef57a2e03aff3104:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 21
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/android15-6.6-clang-22.yml
+++ b/.github/workflows/android15-6.6-clang-22.yml
@@ -117,19 +117,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _29df985ee757664dbc11a17e6248585b:
+  _bcf26d51fcd9a73fe5db7be7c26a4ef2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 22
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -146,19 +146,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _f1ea8d09076c9fca5010a03f9d296c44:
+  _2724d9ad7d117edfefc8a1d6be7b97fa:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 gki_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 22
       BOOT: 1
-      CONFIG: gki_defconfig+CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+      CONFIG: gki_defconfig
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/generator/yml/0007-configs.yml
+++ b/generator/yml/0007-configs.yml
@@ -34,8 +34,7 @@ configs:
   - &arm64_kasan       {<< : *arm64-kasan-configs,                                                                                          ARCH: *arm64-arch,      << : *kernel}
   - &arm64_kasan_sw    {<< : *arm64-kasan-sw-configs,                                                                                       ARCH: *arm64-arch,      << : *kernel}
   - &arm64_ubsan       {config: [defconfig, CONFIG_UBSAN=y],                                                                                ARCH: *arm64-arch,      << : *kernel}
-  #                                             https://github.com/ClangBuiltLinux/continuous-integration2/issues/716
-  - &arm64_gki         {config: [gki_defconfig, CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n],                                                       ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_gki         {config: gki_defconfig,                                                                                              ARCH: *arm64-arch,      << : *kernel}
   - &arm64_cut         {config: cuttlefish_defconfig,                                                                                       ARCH: *arm64-arch,      << : *kernel}
   - &arm64_allmod      {config: allmodconfig,                                                                                               ARCH: *arm64-arch,      << : *default}
   - &arm64_allmod_lto  {<< : *arm64-allmod-lto-configs,                                                                                     ARCH: *arm64-arch,      << : *default}
@@ -97,8 +96,7 @@ configs:
   - &x86_64_lto_thin   {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                                               << : *kernel}
   - &x86_64_cfi        {config: [defconfig, CONFIG_CFI_CLANG=y],                                                                                                    << : *kernel}
   - &x86_64_cfi_lto    {config: [defconfig, CONFIG_CFI_CLANG=y, CONFIG_LTO_CLANG_THIN=y],                                                                           << : *kernel}
-  #                                             https://github.com/ClangBuiltLinux/continuous-integration2/issues/716
-  - &x86_64_gki        {config: [gki_defconfig, CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n],                                                                               << : *kernel}
+  - &x86_64_gki        {config: gki_defconfig,                                                                                                                      << : *kernel}
   - &x86_64_cut        {config: x86_64_cuttlefish_defconfig,                                                                                                        << : *kernel}
   - &x86_64_allmod     {config: allmodconfig,                                                                                                                       << : *default}
   - &x86_64_allmod_lto {<< : *x86_64-allmod-lto-configs,                                                                                                            << : *default}

--- a/tuxsuite/android-mainline-clang-19.tux.yml
+++ b/tuxsuite/android-mainline-clang-19.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-19
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-19
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-mainline-clang-20.tux.yml
+++ b/tuxsuite/android-mainline-clang-20.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-20
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-20
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-mainline-clang-21.tux.yml
+++ b/tuxsuite/android-mainline-clang-21.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-21
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-21
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android-mainline-clang-22.tux.yml
+++ b/tuxsuite/android-mainline-clang-22.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-5.15-clang-17.tux.yml
+++ b/tuxsuite/android14-5.15-clang-17.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-17
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-17
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-5.15-clang-18.tux.yml
+++ b/tuxsuite/android14-5.15-clang-18.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-18
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-18
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-5.15-clang-19.tux.yml
+++ b/tuxsuite/android14-5.15-clang-19.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-19
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-19
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-5.15-clang-20.tux.yml
+++ b/tuxsuite/android14-5.15-clang-20.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-20
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-20
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-5.15-clang-21.tux.yml
+++ b/tuxsuite/android14-5.15-clang-21.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-21
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-21
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-5.15-clang-22.tux.yml
+++ b/tuxsuite/android14-5.15-clang-22.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-6.1-clang-17.tux.yml
+++ b/tuxsuite/android14-6.1-clang-17.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-17
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-17
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-6.1-clang-18.tux.yml
+++ b/tuxsuite/android14-6.1-clang-18.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-18
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-18
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-6.1-clang-19.tux.yml
+++ b/tuxsuite/android14-6.1-clang-19.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-19
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-19
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-6.1-clang-20.tux.yml
+++ b/tuxsuite/android14-6.1-clang-20.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-20
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-20
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-6.1-clang-21.tux.yml
+++ b/tuxsuite/android14-6.1-clang-21.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-21
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-21
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android14-6.1-clang-22.tux.yml
+++ b/tuxsuite/android14-6.1-clang-22.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.6-clang-18.tux.yml
+++ b/tuxsuite/android15-6.6-clang-18.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-18
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-18
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.6-clang-19.tux.yml
+++ b/tuxsuite/android15-6.6-clang-19.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-19
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-19
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.6-clang-20.tux.yml
+++ b/tuxsuite/android15-6.6-clang-20.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-20
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-20
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.6-clang-21.tux.yml
+++ b/tuxsuite/android15-6.6-clang-21.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: korg-clang-21
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: korg-clang-21
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:

--- a/tuxsuite/android15-6.6-clang-22.tux.yml
+++ b/tuxsuite/android15-6.6-clang-22.tux.yml
@@ -25,9 +25,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: arm64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:
@@ -35,9 +33,7 @@ jobs:
       LLVM_IAS: 1
   - target_arch: x86_64
     toolchain: clang-nightly
-    kconfig:
-    - gki_defconfig
-    - CONFIG_DEBUG_INFO_COMPRESSED_ZSTD=n
+    kconfig: gki_defconfig
     targets:
     - kernel
     make_variables:


### PR DESCRIPTION
This reverts commit 019d8c2f41f2759c6b78738dc736b7b2902680bf.

Now that the containers that we use have been updated to Debian Trixie [1], we now have access to elfutils 0.192, which should contain support for reading zstd compressed debug info.

Closes: https://github.com/ClangBuiltLinux/continuous-integration2/issues/716
Link: https://gitlab.com/Linaro/tuxmake/-/commit/46280e20b8ed2df749e9115640271c0a6a2c812c [1]
