### PR TITLE
Disable ARM allyesconfig on 5.15 with clang-11 and clang-12

### DIFF
--- a/.github/workflows/5.15-clang-11.yml
+++ b/.github/workflows/5.15-clang-11.yml
@@ -1305,35 +1305,6 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _2ab873ab23a433b720a6c5c4e2faebeb:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_allconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=11 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm
-      LLVM_VERSION: 11
-      BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_allconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _51e2eff457ec186a91964ee9c06f04f3:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/5.15-clang-12.yml
+++ b/.github/workflows/5.15-clang-12.yml
@@ -1392,35 +1392,6 @@ jobs:
         name: boot_utils_json_allconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7f5b2b0f6af27b166c4bfdef9b3b0ea4:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_allconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm BOOT=0 LLVM=1 LLVM_IAS=0 LLVM_VERSION=12 allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm
-      LLVM_VERSION: 12
-      BOOT: 0
-      CONFIG: allyesconfig+CONFIG_WERROR=n+CONFIG_DRM_WERROR=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_allconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_allconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _40d38df5fba1ddfc0ada216733994225:
     runs-on: ubuntu-latest
     needs:

--- a/generator/yml/0009-llvm-11.yml
+++ b/generator/yml/0009-llvm-11.yml
@@ -133,7 +133,8 @@
   - {<< : *arm32_lpae_fp,     << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *arm32_allmod,      << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_11}
   - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_11}
-  - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_11}
+  # ARM allyesconfig build disabled: https://github.com/ClangBuiltLinux/linux/issues/1615
+  # - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_11}
   - {<< : *arm32_alpine,      << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_11}
   - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_11}

--- a/generator/yml/0009-llvm-12.yml
+++ b/generator/yml/0009-llvm-12.yml
@@ -133,7 +133,8 @@
   - {<< : *arm32_lpae_fp,     << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *arm32_allmod,      << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_12}
   - {<< : *arm32_allno,       << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_12}
-  - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_12}
+  # ARM allyesconfig build disabled: https://github.com/ClangBuiltLinux/linux/issues/1615
+  # - {<< : *arm32_allyes,      << : *stable-5_15,      << : *llvm,            boot: false, << : *llvm_12}
   - {<< : *arm32_alpine,      << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *arm32_suse,        << : *stable-5_15,      << : *llvm,            boot: true,  << : *llvm_12}
   - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}

--- a/tuxsuite/5.15-clang-11.tux.yml
+++ b/tuxsuite/5.15-clang-11.tux.yml
@@ -388,17 +388,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
-  - target_arch: arm
-    toolchain: korg-clang-11
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
-    - CONFIG_DRM_WERROR=n
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
   - target_arch: arm64
     toolchain: korg-clang-11
     kconfig: allmodconfig

--- a/tuxsuite/5.15-clang-12.tux.yml
+++ b/tuxsuite/5.15-clang-12.tux.yml
@@ -417,17 +417,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 0
-  - target_arch: arm
-    toolchain: korg-clang-12
-    kconfig:
-    - allyesconfig
-    - CONFIG_WERROR=n
-    - CONFIG_DRM_WERROR=n
-    targets:
-    - default
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 0
   - target_arch: arm64
     toolchain: korg-clang-12
     kconfig: allmodconfig


### PR DESCRIPTION
Recently, ARCH=arm allyesconfig has started failing in the same way that necessitated disabling it on 6.1 and 6.6 with clang-11 and clang-12. Disable these builds, as this is not a high value target.
