### PR TITLE
Handle CONFIG_CFI_CLANG → CONFIG_CFI

### DIFF
--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -204,19 +204,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _6caf4470519e51764e10589f05d70d73:
+  _e32cdef2e6555f24309fd9270aa27cf5:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: multi_v7_defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: multi_v7_defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -436,19 +436,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _8e78126e8c0351a6b502ee1434a6c568:
+  _2bad73de6a25b8b5e6c9109815549090:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -465,19 +465,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _5869edec3360f833ad54fe55f6972336:
+  _36e3a0b5dee14663fc448bb36ed84d22:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1045,19 +1045,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4905de907e729b69087ab43c1a24fc13:
+  _36478640ed6359ab2cc3c5b894129f02:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1074,19 +1074,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _0e35d288cd97cfcbfb5e7347f1627fb8:
+  _ad4dd51ba6e04b9a76a4f01a1b3c870a:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-17.yml
+++ b/.github/workflows/mainline-clang-17.yml
@@ -204,19 +204,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _dbcc7c8c97a20736fe248501b8b18733:
+  _0cdfecc8afc8f65180a7bc47e0d1792b:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: multi_v7_defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: multi_v7_defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -436,19 +436,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _d996d5a6d2204fc3a2dc389b0f59bf00:
+  _db9050b0b9110e1413abdaaba0e8d6a2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -465,19 +465,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e5abdb39c716251c3b966e9403ae82d3:
+  _9d0b4cdf168935b79298aae5a48050ce:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1045,19 +1045,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _18165dc0ef79fd9f2ffc47047282d908:
+  _fe8a3c0add496f950bb06dd3ef60cbe5:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1074,19 +1074,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _9155f71723f58e89f122fcce9e8f52b8:
+  _f4653f0447ef4dc527dff6e9d9888f5d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-18.yml
+++ b/.github/workflows/mainline-clang-18.yml
@@ -204,19 +204,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _67e1fcae7d2eeb4ad0f5528446acd86d:
+  _edabdf15513f7b529968cb361fa4f68d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: multi_v7_defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: multi_v7_defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -436,19 +436,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _429ddb761fbb8910639fac7c441bba57:
+  _f16cc1a2e7b18b4ac0f126c291284068:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -465,19 +465,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4c6c61e448e8cf65c92cc332553eee8a:
+  _f207cb88058053c7c13c81bd7c62b690:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1132,19 +1132,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4ea342c6a0382b8ec3fc818df516e5dd:
+  _10a85d223aec8befcaeda436004bdcfa:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1161,19 +1161,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _cba9967800187a10281e13bb85d86d69:
+  _99fce9d45f52f9e30b9b4562899fce55:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-19.yml
+++ b/.github/workflows/mainline-clang-19.yml
@@ -204,19 +204,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _bca6d618b51d85b3925a9169685f6e71:
+  _41ec72c28445dcf077429be9d64bfbdd:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: multi_v7_defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: multi_v7_defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -436,19 +436,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _0acf3aeb4791118198691053f213f459:
+  _ae6f52596b0912ca74804ab60a9ce1da:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -465,19 +465,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _a87adbbc7b7a44a3e9fcb78a92420b0d:
+  _7035e7a520454cb6c3c97c6f639bb7a7:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1132,19 +1132,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _903c4a446419ebd2084f00f87c150c2d:
+  _d0fe557d9450cfe5f7edda534c9eb9ad:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1161,19 +1161,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7ba2728d5b589699e33eca41f3691194:
+  _4115d3ffcd2342cf518769f1ec160941:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-20.yml
+++ b/.github/workflows/mainline-clang-20.yml
@@ -204,19 +204,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7aa9ff2047e46eafc27a9073f34a26a9:
+  _59812a4c534e0a77ab662744b1b3d205:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm
       LLVM_VERSION: 20
       BOOT: 1
-      CONFIG: multi_v7_defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: multi_v7_defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -436,19 +436,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _f4c59c45feeb23c010ecf33acd8569ce:
+  _3497c174070879ae45760d5356b15b42:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 20
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -465,19 +465,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _0370a514a9ab1ede1bacc45ebb2e51a0:
+  _82044c46d707b9d755282414c2ca25de:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 20
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1161,19 +1161,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _f3c6df057b3ddcaf3845f3aa996995af:
+  _c87bee2e915da2aeed723cc94dd2a055:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 20
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1190,19 +1190,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _5b1b525f80939291cd399038e7a55e71:
+  _e370aabfb7bde59f769ef41878be4d9d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 20
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-21.yml
+++ b/.github/workflows/mainline-clang-21.yml
@@ -204,19 +204,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _109898f21e47400dfcc35d1596611d82:
+  _7061e37e5fc2bf7d6d42f103bc703060:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 multi_v7_defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 multi_v7_defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm
       LLVM_VERSION: 21
       BOOT: 1
-      CONFIG: multi_v7_defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: multi_v7_defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -436,19 +436,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _10e853a8048075940b9397160fb9be5b:
+  _b8c739688b6f11557ae9c9213e1f673b:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 21
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -465,19 +465,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _a7e58f92bb6dd536d6c9516533dc978d:
+  _435fa32c5e81c18a136d377f9d8a887c:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 21
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1161,19 +1161,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _602b495cd1c2be6eb5f0e61eb2732632:
+  _7da01cc1aa8c709b23e5cb548a7cf045:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 21
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1190,19 +1190,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _38a26a06e6ce8ed32f497b66e289a2c0:
+  _b8774f250c21462bea2c1d2cf269781e:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 21
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/mainline-clang-22.yml
+++ b/.github/workflows/mainline-clang-22.yml
@@ -204,19 +204,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _37484e3311e14505a7faf4b6055cbb22:
+  _8531dfbbc5bf8398bb50799cf2e4ab0c:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 multi_v7_defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 multi_v7_defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm
       LLVM_VERSION: 22
       BOOT: 1
-      CONFIG: multi_v7_defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: multi_v7_defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -436,19 +436,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _77cf5b46d54ce6165d8e88ed640ff60c:
+  _e67424f67d9724b583954e6c6685febb:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 22
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -465,19 +465,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _c9cc4a949f7089982756501ce9845707:
+  _38b6b0cb9659a9b726ca09184de12932:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 22
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1161,19 +1161,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _45e6c623313ef4b083039e8b5e704ac9:
+  _88836787338998d38d85ee4fb319f74f:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 22
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1190,19 +1190,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _fc2e0f0e3f337b7cc878ab272bf40c50:
+  _6e3e89c5eb19dcdf7fa3be1e6405f41f:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 22
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -204,19 +204,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _6caf4470519e51764e10589f05d70d73:
+  _e32cdef2e6555f24309fd9270aa27cf5:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 multi_v7_defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: multi_v7_defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: multi_v7_defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -436,19 +436,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _8e78126e8c0351a6b502ee1434a6c568:
+  _2bad73de6a25b8b5e6c9109815549090:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -465,19 +465,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _5869edec3360f833ad54fe55f6972336:
+  _36e3a0b5dee14663fc448bb36ed84d22:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1045,19 +1045,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4905de907e729b69087ab43c1a24fc13:
+  _36478640ed6359ab2cc3c5b894129f02:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1074,19 +1074,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _0e35d288cd97cfcbfb5e7347f1627fb8:
+  _ad4dd51ba6e04b9a76a4f01a1b3c870a:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 16
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-17.yml
+++ b/.github/workflows/next-clang-17.yml
@@ -204,19 +204,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _dbcc7c8c97a20736fe248501b8b18733:
+  _0cdfecc8afc8f65180a7bc47e0d1792b:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 multi_v7_defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: multi_v7_defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: multi_v7_defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -436,19 +436,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _d996d5a6d2204fc3a2dc389b0f59bf00:
+  _db9050b0b9110e1413abdaaba0e8d6a2:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -465,19 +465,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e5abdb39c716251c3b966e9403ae82d3:
+  _9d0b4cdf168935b79298aae5a48050ce:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1045,19 +1045,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _18165dc0ef79fd9f2ffc47047282d908:
+  _fe8a3c0add496f950bb06dd3ef60cbe5:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1074,19 +1074,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _9155f71723f58e89f122fcce9e8f52b8:
+  _f4653f0447ef4dc527dff6e9d9888f5d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 17
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-18.yml
+++ b/.github/workflows/next-clang-18.yml
@@ -204,19 +204,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _67e1fcae7d2eeb4ad0f5528446acd86d:
+  _edabdf15513f7b529968cb361fa4f68d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 multi_v7_defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: multi_v7_defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: multi_v7_defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -436,19 +436,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _429ddb761fbb8910639fac7c441bba57:
+  _f16cc1a2e7b18b4ac0f126c291284068:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -465,19 +465,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4c6c61e448e8cf65c92cc332553eee8a:
+  _f207cb88058053c7c13c81bd7c62b690:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1132,19 +1132,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4ea342c6a0382b8ec3fc818df516e5dd:
+  _10a85d223aec8befcaeda436004bdcfa:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1161,19 +1161,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _cba9967800187a10281e13bb85d86d69:
+  _99fce9d45f52f9e30b9b4562899fce55:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 18
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-19.yml
+++ b/.github/workflows/next-clang-19.yml
@@ -204,19 +204,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _bca6d618b51d85b3925a9169685f6e71:
+  _41ec72c28445dcf077429be9d64bfbdd:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 multi_v7_defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: multi_v7_defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: multi_v7_defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -436,19 +436,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _0acf3aeb4791118198691053f213f459:
+  _ae6f52596b0912ca74804ab60a9ce1da:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -465,19 +465,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _a87adbbc7b7a44a3e9fcb78a92420b0d:
+  _7035e7a520454cb6c3c97c6f639bb7a7:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1132,19 +1132,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _903c4a446419ebd2084f00f87c150c2d:
+  _d0fe557d9450cfe5f7edda534c9eb9ad:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1161,19 +1161,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7ba2728d5b589699e33eca41f3691194:
+  _4115d3ffcd2342cf518769f1ec160941:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 19
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-20.yml
+++ b/.github/workflows/next-clang-20.yml
@@ -204,19 +204,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7aa9ff2047e46eafc27a9073f34a26a9:
+  _59812a4c534e0a77ab662744b1b3d205:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 multi_v7_defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm
       LLVM_VERSION: 20
       BOOT: 1
-      CONFIG: multi_v7_defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: multi_v7_defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -436,19 +436,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _f4c59c45feeb23c010ecf33acd8569ce:
+  _3497c174070879ae45760d5356b15b42:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 20
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -465,19 +465,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _0370a514a9ab1ede1bacc45ebb2e51a0:
+  _82044c46d707b9d755282414c2ca25de:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 20
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1161,19 +1161,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _f3c6df057b3ddcaf3845f3aa996995af:
+  _c87bee2e915da2aeed723cc94dd2a055:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 20
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1190,19 +1190,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _5b1b525f80939291cd399038e7a55e71:
+  _e370aabfb7bde59f769ef41878be4d9d:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 20
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-21.yml
+++ b/.github/workflows/next-clang-21.yml
@@ -204,19 +204,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _109898f21e47400dfcc35d1596611d82:
+  _7061e37e5fc2bf7d6d42f103bc703060:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 multi_v7_defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 multi_v7_defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm
       LLVM_VERSION: 21
       BOOT: 1
-      CONFIG: multi_v7_defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: multi_v7_defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -436,19 +436,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _10e853a8048075940b9397160fb9be5b:
+  _b8c739688b6f11557ae9c9213e1f673b:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 21
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -465,19 +465,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _a7e58f92bb6dd536d6c9516533dc978d:
+  _435fa32c5e81c18a136d377f9d8a887c:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 21
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1161,19 +1161,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _602b495cd1c2be6eb5f0e61eb2732632:
+  _7da01cc1aa8c709b23e5cb548a7cf045:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 21
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1190,19 +1190,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _38a26a06e6ce8ed32f497b66e289a2c0:
+  _b8774f250c21462bea2c1d2cf269781e:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 21
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/next-clang-22.yml
+++ b/.github/workflows/next-clang-22.yml
@@ -204,19 +204,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _37484e3311e14505a7faf4b6055cbb22:
+  _8531dfbbc5bf8398bb50799cf2e4ab0c:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 multi_v7_defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 multi_v7_defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm
       LLVM_VERSION: 22
       BOOT: 1
-      CONFIG: multi_v7_defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: multi_v7_defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -436,19 +436,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _77cf5b46d54ce6165d8e88ed640ff60c:
+  _e67424f67d9724b583954e6c6685febb:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 22
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -465,19 +465,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _c9cc4a949f7089982756501ce9845707:
+  _38b6b0cb9659a9b726ca09184de12932:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: arm64
       LLVM_VERSION: 22
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1161,19 +1161,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _45e6c623313ef4b083039e8b5e704ac9:
+  _88836787338998d38d85ee4fb319f74f:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 defconfig+CONFIG_CFI_CLANG=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 defconfig+CONFIG_CFI=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 22
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y
+      CONFIG: defconfig+CONFIG_CFI=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu
@@ -1190,19 +1190,19 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _fc2e0f0e3f337b7cc878ab272bf40c50:
+  _6e3e89c5eb19dcdf7fa3be1e6405f41f:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+    name: ARCH=x86_64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: x86_64
       LLVM_VERSION: 22
       BOOT: 1
-      CONFIG: defconfig+CONFIG_CFI_CLANG=y+CONFIG_LTO_CLANG_THIN=y
+      CONFIG: defconfig+CONFIG_CFI=y+CONFIG_LTO_CLANG_THIN=y
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/generator/yml/0007-configs.yml
+++ b/generator/yml/0007-configs.yml
@@ -14,7 +14,8 @@ configs:
   - &arm32_v6          {config: aspeed_g5_defconfig,                                                                                        ARCH: *arm-arch,        << : *kernel_dtbs}
   - &arm32_v7          {config: multi_v7_defconfig,                                                                                         ARCH: *arm-arch,        << : *kernel}
   - &arm32_v7_t        {config: [multi_v7_defconfig, CONFIG_THUMB2_KERNEL=y],                                                               ARCH: *arm-arch,        << : *kernel}
-  - &arm32_cfi         {config: [multi_v7_defconfig, CONFIG_CFI_CLANG=y],                                                                   ARCH: *arm-arch,        << : *kernel}
+  - &arm32_cfi         {config: [multi_v7_defconfig, CONFIG_CFI=y],                                                                         ARCH: *arm-arch,        << : *kernel}
+  - &arm32_cfi_cl      {config: [multi_v7_defconfig, CONFIG_CFI_CLANG=y],                                                                   ARCH: *arm-arch,        << : *kernel}
   - &arm32_imx         {config: imx_v4_v5_defconfig,                                                                                        ARCH: *arm-arch,        << : *default}
   - &arm32_omap        {config: omap2plus_defconfig,                                                                                        ARCH: *arm-arch,        << : *default}
   - &arm32_lpae_fp     {config: [multi_v7_defconfig, CONFIG_ARM_LPAE=y, CONFIG_UNWINDER_FRAME_POINTER=y],                                   ARCH: *arm-arch,        << : *kernel}
@@ -29,8 +30,10 @@ configs:
   - &arm64be           {config: [defconfig, CONFIG_CPU_BIG_ENDIAN=y],                                                                       ARCH: *arm64-arch,      << : *kernel}
   - &arm64_lto_full    {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                       ARCH: *arm64-arch,      << : *kernel}
   - &arm64_lto_thin    {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                       ARCH: *arm64-arch,      << : *kernel}
-  - &arm64_cfi         {config: [defconfig, CONFIG_CFI_CLANG=y],                                                                            ARCH: *arm64-arch,      << : *kernel}
-  - &arm64_cfi_lto     {config: [defconfig, CONFIG_CFI_CLANG=y, CONFIG_LTO_CLANG_THIN=y],                                                   ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_cfi         {config: [defconfig, CONFIG_CFI=y],                                                                                  ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_cfi_cl      {config: [defconfig, CONFIG_CFI_CLANG=y],                                                                            ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_cfi_lto     {config: [defconfig, CONFIG_CFI=y, CONFIG_LTO_CLANG_THIN=y],                                                         ARCH: *arm64-arch,      << : *kernel}
+  - &arm64_cfi_cl_lto  {config: [defconfig, CONFIG_CFI_CLANG=y, CONFIG_LTO_CLANG_THIN=y],                                                   ARCH: *arm64-arch,      << : *kernel}
   - &arm64_kasan       {<< : *arm64-kasan-configs,                                                                                          ARCH: *arm64-arch,      << : *kernel}
   - &arm64_kasan_sw    {<< : *arm64-kasan-sw-configs,                                                                                       ARCH: *arm64-arch,      << : *kernel}
   - &arm64_ubsan       {config: [defconfig, CONFIG_UBSAN=y],                                                                                ARCH: *arm64-arch,      << : *kernel}
@@ -94,8 +97,10 @@ configs:
   - &x86_64            {config: defconfig,                                                                                                                          << : *kernel}
   - &x86_64_lto_full   {config: [defconfig, CONFIG_LTO_CLANG_FULL=y],                                                                                               << : *kernel}
   - &x86_64_lto_thin   {config: [defconfig, CONFIG_LTO_CLANG_THIN=y],                                                                                               << : *kernel}
-  - &x86_64_cfi        {config: [defconfig, CONFIG_CFI_CLANG=y],                                                                                                    << : *kernel}
-  - &x86_64_cfi_lto    {config: [defconfig, CONFIG_CFI_CLANG=y, CONFIG_LTO_CLANG_THIN=y],                                                                           << : *kernel}
+  - &x86_64_cfi        {config: [defconfig, CONFIG_CFI=y],                                                                                                          << : *kernel}
+  - &x86_64_cfi_cl     {config: [defconfig, CONFIG_CFI_CLANG=y],                                                                                                    << : *kernel}
+  - &x86_64_cfi_lto    {config: [defconfig, CONFIG_CFI=y, CONFIG_LTO_CLANG_THIN=y],                                                                                 << : *kernel}
+  - &x86_64_cfi_cl_lto {config: [defconfig, CONFIG_CFI_CLANG=y, CONFIG_LTO_CLANG_THIN=y],                                                                           << : *kernel}
   - &x86_64_gki        {config: gki_defconfig,                                                                                                                      << : *kernel}
   - &x86_64_cut        {config: x86_64_cuttlefish_defconfig,                                                                                                        << : *kernel}
   - &x86_64_allmod     {config: allmodconfig,                                                                                                                       << : *default}

--- a/generator/yml/0009-llvm-12.yml
+++ b/generator/yml/0009-llvm-12.yml
@@ -140,7 +140,7 @@
   - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
-  - {<< : *arm64_cfi_lto,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}
   - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: false, << : *llvm_12}
   - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_12}

--- a/generator/yml/0009-llvm-13.yml
+++ b/generator/yml/0009-llvm-13.yml
@@ -296,7 +296,7 @@
   - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *arm64_cfi_lto,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_13}

--- a/generator/yml/0009-llvm-14.yml
+++ b/generator/yml/0009-llvm-14.yml
@@ -292,7 +292,7 @@
   - {<< : *arm64,             << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *arm64_cfi_lto,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_14}

--- a/generator/yml/0009-llvm-15.yml
+++ b/generator/yml/0009-llvm-15.yml
@@ -425,7 +425,7 @@
   - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_15}
-  - {<< : *arm64_cfi_lto,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_15}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_15}

--- a/generator/yml/0009-llvm-16.yml
+++ b/generator/yml/0009-llvm-16.yml
@@ -160,7 +160,7 @@
   - {<< : *arm32_v6,          << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm32_v7,          << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm32_v7_t,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *arm32_cfi,         << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *arm32_cfi_cl,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm32_imx,         << : *stable,           << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *arm32_omap,        << : *stable,           << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *arm32_lpae_fp,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
@@ -173,8 +173,8 @@
   - {<< : *arm64be,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_lto_full,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_lto_thin,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *arm64_cfi,         << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *arm64_cfi_lto,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *arm64_cfi_cl,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_kasan,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_kasan_sw,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_ubsan,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
@@ -214,8 +214,8 @@
   - {<< : *x86_64,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_lto_full,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_lto_thin,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *x86_64_cfi,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *x86_64_cfi_lto,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *x86_64_cfi_cl,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_kasan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_kcsan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_ubsan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_16}
@@ -235,7 +235,7 @@
   - {<< : *arm32_v6,          << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm32_v7,          << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm32_v7_t,        << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *arm32_cfi,         << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *arm32_cfi_cl,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm32_imx,         << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *arm32_omap,        << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *arm32_lpae_fp,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
@@ -248,8 +248,8 @@
   - {<< : *arm64be,           << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_lto_full,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_lto_thin,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *arm64_cfi,         << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_kasan,       << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_kasan_sw,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_ubsan,       << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
@@ -288,8 +288,8 @@
   - {<< : *x86_64,            << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_lto_full,   << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_lto_thin,   << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *x86_64_cfi,        << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_kasan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_kcsan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_ubsan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
@@ -320,8 +320,8 @@
   - {<< : *arm64be,           << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_lto_full,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_lto_thin,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *arm64_cfi,         << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_kasan,       << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_kasan_sw,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_ubsan,       << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
@@ -358,8 +358,8 @@
   - {<< : *x86_64,            << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_lto_full,   << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_lto_thin,   << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *x86_64_cfi,        << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_kasan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_kcsan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_ubsan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_16}
@@ -390,8 +390,8 @@
   - {<< : *arm64be,           << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_lto_full,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_lto_thin,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *arm64_cfi,         << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_kasan,       << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_kasan_sw,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_ubsan,       << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
@@ -426,8 +426,8 @@
   - {<< : *x86_64,            << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_lto_full,   << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_lto_thin,   << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *x86_64_cfi,        << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_kasan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_kcsan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *x86_64_ubsan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_16}
@@ -458,7 +458,7 @@
   - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *arm64_cfi_lto,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_16}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_16}

--- a/generator/yml/0009-llvm-17.yml
+++ b/generator/yml/0009-llvm-17.yml
@@ -166,7 +166,7 @@
   - {<< : *arm32_v6,          << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm32_v7,          << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm32_v7_t,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *arm32_cfi,         << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *arm32_cfi_cl,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm32_imx,         << : *stable,           << : *llvm_full,       boot: false, << : *llvm_17}
   - {<< : *arm32_omap,        << : *stable,           << : *llvm_full,       boot: false, << : *llvm_17}
   - {<< : *arm32_lpae_fp,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
@@ -179,8 +179,8 @@
   - {<< : *arm64be,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_lto_full,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_lto_thin,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *arm64_cfi,         << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *arm64_cfi_lto,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *arm64_cfi_cl,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_kasan,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_kasan_sw,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_ubsan,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
@@ -222,8 +222,8 @@
   - {<< : *x86_64,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_lto_full,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_lto_thin,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *x86_64_cfi,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *x86_64_cfi_lto,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *x86_64_cfi_cl,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_kasan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_kcsan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_ubsan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_17}
@@ -244,7 +244,7 @@
   - {<< : *arm32_v6,          << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm32_v7,          << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm32_v7_t,        << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *arm32_cfi,         << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *arm32_cfi_cl,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm32_imx,         << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_17}
   - {<< : *arm32_omap,        << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_17}
   - {<< : *arm32_lpae_fp,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
@@ -257,8 +257,8 @@
   - {<< : *arm64be,           << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_lto_full,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_lto_thin,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *arm64_cfi,         << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_kasan,       << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_kasan_sw,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_ubsan,       << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
@@ -299,8 +299,8 @@
   - {<< : *x86_64,            << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_lto_full,   << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_lto_thin,   << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *x86_64_cfi,        << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_kasan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_kcsan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_ubsan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_17}
@@ -332,8 +332,8 @@
   - {<< : *arm64be,           << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_lto_full,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_lto_thin,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *arm64_cfi,         << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_kasan,       << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_kasan_sw,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_ubsan,       << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
@@ -370,8 +370,8 @@
   - {<< : *x86_64,            << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_lto_full,   << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_lto_thin,   << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *x86_64_cfi,        << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_kasan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_kcsan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_ubsan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_17}
@@ -402,8 +402,8 @@
   - {<< : *arm64be,           << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_lto_full,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_lto_thin,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *arm64_cfi,         << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_kasan,       << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_kasan_sw,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_ubsan,       << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
@@ -438,8 +438,8 @@
   - {<< : *x86_64,            << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_lto_full,   << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_lto_thin,   << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *x86_64_cfi,        << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_kasan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_kcsan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *x86_64_ubsan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_17}
@@ -470,7 +470,7 @@
   - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *arm64_cfi_lto,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_17}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_17}

--- a/generator/yml/0009-llvm-18.yml
+++ b/generator/yml/0009-llvm-18.yml
@@ -178,7 +178,7 @@
   - {<< : *arm32_v6,          << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm32_v7,          << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm32_v7_t,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *arm32_cfi,         << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *arm32_cfi_cl,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm32_imx,         << : *stable,           << : *llvm_full,       boot: false, << : *llvm_18}
   - {<< : *arm32_omap,        << : *stable,           << : *llvm_full,       boot: false, << : *llvm_18}
   - {<< : *arm32_lpae_fp,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
@@ -191,8 +191,8 @@
   - {<< : *arm64be,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_lto_full,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_lto_thin,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *arm64_cfi,         << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *arm64_cfi_lto,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *arm64_cfi_cl,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_kasan,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_kasan_sw,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_ubsan,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
@@ -239,8 +239,8 @@
   - {<< : *x86_64,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_lto_full,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_lto_thin,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *x86_64_cfi,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *x86_64_cfi_lto,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *x86_64_cfi_cl,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_kasan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_kcsan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_ubsan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_18}
@@ -262,7 +262,7 @@
   - {<< : *arm32_v6,          << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm32_v7,          << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm32_v7_t,        << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *arm32_cfi,         << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *arm32_cfi_cl,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm32_imx,         << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_18}
   - {<< : *arm32_omap,        << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_18}
   - {<< : *arm32_lpae_fp,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
@@ -275,8 +275,8 @@
   - {<< : *arm64be,           << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_lto_full,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_lto_thin,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *arm64_cfi,         << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_kasan,       << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_kasan_sw,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_ubsan,       << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
@@ -322,8 +322,8 @@
   - {<< : *x86_64,            << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_lto_full,   << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_lto_thin,   << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *x86_64_cfi,        << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_kasan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_kcsan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_ubsan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_18}
@@ -356,8 +356,8 @@
   - {<< : *arm64be,           << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_lto_full,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_lto_thin,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *arm64_cfi,         << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_kasan,       << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_kasan_sw,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_ubsan,       << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
@@ -398,8 +398,8 @@
   - {<< : *x86_64,            << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_lto_full,   << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_lto_thin,   << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *x86_64_cfi,        << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_kasan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_kcsan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_ubsan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_18}
@@ -430,8 +430,8 @@
   - {<< : *arm64be,           << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_lto_full,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_lto_thin,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *arm64_cfi,         << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_kasan,       << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_kasan_sw,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_ubsan,       << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
@@ -466,8 +466,8 @@
   - {<< : *x86_64,            << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_lto_full,   << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_lto_thin,   << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *x86_64_cfi,        << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_kasan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_kcsan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *x86_64_ubsan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_18}
@@ -498,7 +498,7 @@
   - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *arm64_cfi_lto,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_18}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_18}

--- a/generator/yml/0009-llvm-19.yml
+++ b/generator/yml/0009-llvm-19.yml
@@ -178,7 +178,7 @@
   - {<< : *arm32_v6,          << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm32_v7,          << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm32_v7_t,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *arm32_cfi,         << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *arm32_cfi_cl,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm32_imx,         << : *stable,           << : *llvm_full,       boot: false, << : *llvm_19}
   - {<< : *arm32_omap,        << : *stable,           << : *llvm_full,       boot: false, << : *llvm_19}
   - {<< : *arm32_lpae_fp,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
@@ -191,8 +191,8 @@
   - {<< : *arm64be,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_lto_full,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_lto_thin,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *arm64_cfi,         << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *arm64_cfi_lto,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *arm64_cfi_cl,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_kasan,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_kasan_sw,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_ubsan,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
@@ -239,8 +239,8 @@
   - {<< : *x86_64,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_lto_full,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_lto_thin,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *x86_64_cfi,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *x86_64_cfi_lto,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *x86_64_cfi_cl,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_kasan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_kcsan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_ubsan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_19}
@@ -262,7 +262,7 @@
   - {<< : *arm32_v6,          << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm32_v7,          << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm32_v7_t,        << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *arm32_cfi,         << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *arm32_cfi_cl,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm32_imx,         << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_19}
   - {<< : *arm32_omap,        << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_19}
   - {<< : *arm32_lpae_fp,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
@@ -275,8 +275,8 @@
   - {<< : *arm64be,           << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_lto_full,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_lto_thin,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *arm64_cfi,         << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_kasan,       << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_kasan_sw,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_ubsan,       << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
@@ -322,8 +322,8 @@
   - {<< : *x86_64,            << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_lto_full,   << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_lto_thin,   << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *x86_64_cfi,        << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_kasan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_kcsan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_ubsan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_19}
@@ -356,8 +356,8 @@
   - {<< : *arm64be,           << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_lto_full,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_lto_thin,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *arm64_cfi,         << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_kasan,       << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_kasan_sw,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_ubsan,       << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
@@ -398,8 +398,8 @@
   - {<< : *x86_64,            << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_lto_full,   << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_lto_thin,   << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *x86_64_cfi,        << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_kasan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_kcsan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_ubsan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_19}
@@ -430,8 +430,8 @@
   - {<< : *arm64be,           << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_lto_full,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_lto_thin,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *arm64_cfi,         << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_kasan,       << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_kasan_sw,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_ubsan,       << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
@@ -466,8 +466,8 @@
   - {<< : *x86_64,            << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_lto_full,   << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_lto_thin,   << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *x86_64_cfi,        << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_kasan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_kcsan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *x86_64_ubsan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_19}
@@ -498,7 +498,7 @@
   - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *arm64_cfi_lto,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_19}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_19}

--- a/generator/yml/0009-llvm-20.yml
+++ b/generator/yml/0009-llvm-20.yml
@@ -180,7 +180,7 @@
   - {<< : *arm32_v6,          << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm32_v7,          << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm32_v7_t,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *arm32_cfi,         << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *arm32_cfi_cl,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm32_imx,         << : *stable,           << : *llvm_full,       boot: false, << : *llvm_20}
   - {<< : *arm32_omap,        << : *stable,           << : *llvm_full,       boot: false, << : *llvm_20}
   - {<< : *arm32_lpae_fp,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
@@ -193,8 +193,8 @@
   - {<< : *arm64be,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_lto_full,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_lto_thin,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *arm64_cfi,         << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *arm64_cfi_lto,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *arm64_cfi_cl,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_kasan,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_kasan_sw,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_ubsan,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
@@ -242,8 +242,8 @@
   - {<< : *x86_64,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_lto_full,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_lto_thin,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *x86_64_cfi,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *x86_64_cfi_lto,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *x86_64_cfi_cl,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_kasan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_kcsan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_ubsan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_20}
@@ -265,7 +265,7 @@
   - {<< : *arm32_v6,          << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm32_v7,          << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm32_v7_t,        << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *arm32_cfi,         << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *arm32_cfi_cl,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm32_imx,         << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_20}
   - {<< : *arm32_omap,        << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_20}
   - {<< : *arm32_lpae_fp,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
@@ -278,8 +278,8 @@
   - {<< : *arm64be,           << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_lto_full,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_lto_thin,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *arm64_cfi,         << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_kasan,       << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_kasan_sw,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_ubsan,       << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
@@ -325,8 +325,8 @@
   - {<< : *x86_64,            << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_lto_full,   << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_lto_thin,   << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *x86_64_cfi,        << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_kasan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_kcsan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_ubsan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_20}
@@ -359,8 +359,8 @@
   - {<< : *arm64be,           << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_lto_full,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_lto_thin,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *arm64_cfi,         << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_kasan,       << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_kasan_sw,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_ubsan,       << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
@@ -401,8 +401,8 @@
   - {<< : *x86_64,            << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_lto_full,   << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_lto_thin,   << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *x86_64_cfi,        << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_kasan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_kcsan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_ubsan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_20}
@@ -433,8 +433,8 @@
   - {<< : *arm64be,           << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_lto_full,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_lto_thin,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *arm64_cfi,         << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_kasan,       << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_kasan_sw,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_ubsan,       << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
@@ -469,8 +469,8 @@
   - {<< : *x86_64,            << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_lto_full,   << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_lto_thin,   << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *x86_64_cfi,        << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_kasan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_kcsan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *x86_64_ubsan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_20}
@@ -501,7 +501,7 @@
   - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *arm64_cfi_lto,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_20}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_20}

--- a/generator/yml/0009-llvm-latest.yml
+++ b/generator/yml/0009-llvm-latest.yml
@@ -178,7 +178,7 @@
   - {<< : *arm32_v6,          << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm32_v7,          << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm32_v7_t,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *arm32_cfi,         << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_cfi_cl,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm32_imx,         << : *stable,           << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm32_omap,        << : *stable,           << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm32_lpae_fp,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -191,8 +191,8 @@
   - {<< : *arm64be,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_lto_full,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_lto_thin,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *arm64_cfi,         << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *arm64_cfi_lto,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_cfi_cl,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_kasan,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_kasan_sw,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_ubsan,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -239,8 +239,8 @@
   - {<< : *x86_64,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_lto_full,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_lto_thin,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *x86_64_cfi,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *x86_64_cfi_lto,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_cfi_cl,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_kasan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_kcsan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_ubsan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -262,7 +262,7 @@
   - {<< : *arm32_v6,          << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm32_v7,          << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm32_v7_t,        << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *arm32_cfi,         << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm32_cfi_cl,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm32_imx,         << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm32_omap,        << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_latest}
   - {<< : *arm32_lpae_fp,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -275,8 +275,8 @@
   - {<< : *arm64be,           << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_lto_full,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_lto_thin,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *arm64_cfi,         << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_kasan,       << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_kasan_sw,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_ubsan,       << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -322,8 +322,8 @@
   - {<< : *x86_64,            << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_lto_full,   << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_lto_thin,   << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *x86_64_cfi,        << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_kasan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_kcsan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_ubsan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -356,8 +356,8 @@
   - {<< : *arm64be,           << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_lto_full,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_lto_thin,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *arm64_cfi,         << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_kasan,       << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_kasan_sw,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_ubsan,       << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -398,8 +398,8 @@
   - {<< : *x86_64,            << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_lto_full,   << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_lto_thin,   << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *x86_64_cfi,        << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_kasan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_kcsan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_ubsan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -430,8 +430,8 @@
   - {<< : *arm64be,           << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_lto_full,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_lto_thin,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *arm64_cfi,         << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_kasan,       << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_kasan_sw,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_ubsan,       << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -466,8 +466,8 @@
   - {<< : *x86_64,            << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_lto_full,   << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_lto_thin,   << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *x86_64_cfi,        << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_kasan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_kcsan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *x86_64_ubsan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -498,7 +498,7 @@
   - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *arm64_cfi_lto,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_latest}

--- a/generator/yml/0009-llvm-tot.yml
+++ b/generator/yml/0009-llvm-tot.yml
@@ -178,7 +178,7 @@
   - {<< : *arm32_v6,          << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm32_v7,          << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm32_v7_t,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *arm32_cfi,         << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_cfi_cl,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm32_imx,         << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm32_omap,        << : *stable,           << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm32_lpae_fp,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -191,8 +191,8 @@
   - {<< : *arm64be,           << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_lto_full,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_lto_thin,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *arm64_cfi,         << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *arm64_cfi_lto,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_cfi_cl,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_kasan,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_kasan_sw,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_ubsan,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -239,8 +239,8 @@
   - {<< : *x86_64,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_full,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_thin,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *x86_64_cfi,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *x86_64_cfi_lto,    << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_cfi_cl,     << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_kasan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_kcsan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_ubsan,      << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -262,7 +262,7 @@
   - {<< : *arm32_v6,          << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm32_v7,          << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm32_v7_t,        << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *arm32_cfi,         << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm32_cfi_cl,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm32_imx,         << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm32_omap,        << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_tot}
   - {<< : *arm32_lpae_fp,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -275,8 +275,8 @@
   - {<< : *arm64be,           << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_lto_full,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_lto_thin,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *arm64_cfi,         << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_kasan,       << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_kasan_sw,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_ubsan,       << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -322,8 +322,8 @@
   - {<< : *x86_64,            << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_full,   << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_thin,   << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *x86_64_cfi,        << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_kasan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_kcsan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_ubsan,      << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -356,8 +356,8 @@
   - {<< : *arm64be,           << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_lto_full,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_lto_thin,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *arm64_cfi,         << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_kasan,       << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_kasan_sw,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_ubsan,       << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -398,8 +398,8 @@
   - {<< : *x86_64,            << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_full,   << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_thin,   << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *x86_64_cfi,        << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_kasan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_kcsan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_ubsan,      << : *stable-6_6,       << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -430,8 +430,8 @@
   - {<< : *arm64be,           << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_lto_full,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_lto_thin,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *arm64_cfi,         << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *arm64_cfi_lto,     << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_cfi_cl,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_kasan,       << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_kasan_sw,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_ubsan,       << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -466,8 +466,8 @@
   - {<< : *x86_64,            << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_full,   << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_thin,   << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *x86_64_cfi,        << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *x86_64_cfi_lto,    << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_cfi_cl,     << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *x86_64_cfi_cl_lto, << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_kasan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_kcsan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_ubsan,      << : *stable-6_1,       << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -498,7 +498,7 @@
   - {<< : *arm64be,           << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_lto_full,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_lto_thin,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *arm64_cfi_lto,     << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
+  - {<< : *arm64_cfi_cl_lto,  << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_kasan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_kasan_sw,    << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_ubsan,       << : *stable-5_15,      << : *llvm_full,       boot: true,  << : *llvm_tot}

--- a/tuxsuite/mainline-clang-16.tux.yml
+++ b/tuxsuite/mainline-clang-16.tux.yml
@@ -53,7 +53,7 @@ jobs:
     toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -128,7 +128,7 @@ jobs:
     toolchain: korg-clang-16
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -138,7 +138,7 @@ jobs:
     toolchain: korg-clang-16
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
@@ -339,7 +339,7 @@ jobs:
     toolchain: korg-clang-16
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -349,7 +349,7 @@ jobs:
     toolchain: korg-clang-16
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-17.tux.yml
+++ b/tuxsuite/mainline-clang-17.tux.yml
@@ -53,7 +53,7 @@ jobs:
     toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -128,7 +128,7 @@ jobs:
     toolchain: korg-clang-17
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -138,7 +138,7 @@ jobs:
     toolchain: korg-clang-17
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
@@ -339,7 +339,7 @@ jobs:
     toolchain: korg-clang-17
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -349,7 +349,7 @@ jobs:
     toolchain: korg-clang-17
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-18.tux.yml
+++ b/tuxsuite/mainline-clang-18.tux.yml
@@ -53,7 +53,7 @@ jobs:
     toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -128,7 +128,7 @@ jobs:
     toolchain: korg-clang-18
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -138,7 +138,7 @@ jobs:
     toolchain: korg-clang-18
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
@@ -369,7 +369,7 @@ jobs:
     toolchain: korg-clang-18
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -379,7 +379,7 @@ jobs:
     toolchain: korg-clang-18
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-19.tux.yml
+++ b/tuxsuite/mainline-clang-19.tux.yml
@@ -53,7 +53,7 @@ jobs:
     toolchain: korg-clang-19
     kconfig:
     - multi_v7_defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -128,7 +128,7 @@ jobs:
     toolchain: korg-clang-19
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -138,7 +138,7 @@ jobs:
     toolchain: korg-clang-19
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
@@ -369,7 +369,7 @@ jobs:
     toolchain: korg-clang-19
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -379,7 +379,7 @@ jobs:
     toolchain: korg-clang-19
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-20.tux.yml
+++ b/tuxsuite/mainline-clang-20.tux.yml
@@ -53,7 +53,7 @@ jobs:
     toolchain: korg-clang-20
     kconfig:
     - multi_v7_defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -128,7 +128,7 @@ jobs:
     toolchain: korg-clang-20
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -138,7 +138,7 @@ jobs:
     toolchain: korg-clang-20
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
@@ -377,7 +377,7 @@ jobs:
     toolchain: korg-clang-20
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -387,7 +387,7 @@ jobs:
     toolchain: korg-clang-20
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-21.tux.yml
+++ b/tuxsuite/mainline-clang-21.tux.yml
@@ -53,7 +53,7 @@ jobs:
     toolchain: korg-clang-21
     kconfig:
     - multi_v7_defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -128,7 +128,7 @@ jobs:
     toolchain: korg-clang-21
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -138,7 +138,7 @@ jobs:
     toolchain: korg-clang-21
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
@@ -377,7 +377,7 @@ jobs:
     toolchain: korg-clang-21
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -387,7 +387,7 @@ jobs:
     toolchain: korg-clang-21
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-22.tux.yml
+++ b/tuxsuite/mainline-clang-22.tux.yml
@@ -53,7 +53,7 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - multi_v7_defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -128,7 +128,7 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -138,7 +138,7 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
@@ -377,7 +377,7 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -387,7 +387,7 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel

--- a/tuxsuite/next-clang-16.tux.yml
+++ b/tuxsuite/next-clang-16.tux.yml
@@ -52,7 +52,7 @@ jobs:
     toolchain: korg-clang-16
     kconfig:
     - multi_v7_defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -127,7 +127,7 @@ jobs:
     toolchain: korg-clang-16
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -137,7 +137,7 @@ jobs:
     toolchain: korg-clang-16
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
@@ -338,7 +338,7 @@ jobs:
     toolchain: korg-clang-16
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -348,7 +348,7 @@ jobs:
     toolchain: korg-clang-16
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel

--- a/tuxsuite/next-clang-17.tux.yml
+++ b/tuxsuite/next-clang-17.tux.yml
@@ -52,7 +52,7 @@ jobs:
     toolchain: korg-clang-17
     kconfig:
     - multi_v7_defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -127,7 +127,7 @@ jobs:
     toolchain: korg-clang-17
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -137,7 +137,7 @@ jobs:
     toolchain: korg-clang-17
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
@@ -338,7 +338,7 @@ jobs:
     toolchain: korg-clang-17
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -348,7 +348,7 @@ jobs:
     toolchain: korg-clang-17
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel

--- a/tuxsuite/next-clang-18.tux.yml
+++ b/tuxsuite/next-clang-18.tux.yml
@@ -52,7 +52,7 @@ jobs:
     toolchain: korg-clang-18
     kconfig:
     - multi_v7_defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -127,7 +127,7 @@ jobs:
     toolchain: korg-clang-18
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -137,7 +137,7 @@ jobs:
     toolchain: korg-clang-18
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
@@ -368,7 +368,7 @@ jobs:
     toolchain: korg-clang-18
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -378,7 +378,7 @@ jobs:
     toolchain: korg-clang-18
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel

--- a/tuxsuite/next-clang-19.tux.yml
+++ b/tuxsuite/next-clang-19.tux.yml
@@ -52,7 +52,7 @@ jobs:
     toolchain: korg-clang-19
     kconfig:
     - multi_v7_defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -127,7 +127,7 @@ jobs:
     toolchain: korg-clang-19
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -137,7 +137,7 @@ jobs:
     toolchain: korg-clang-19
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
@@ -368,7 +368,7 @@ jobs:
     toolchain: korg-clang-19
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -378,7 +378,7 @@ jobs:
     toolchain: korg-clang-19
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel

--- a/tuxsuite/next-clang-20.tux.yml
+++ b/tuxsuite/next-clang-20.tux.yml
@@ -52,7 +52,7 @@ jobs:
     toolchain: korg-clang-20
     kconfig:
     - multi_v7_defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -127,7 +127,7 @@ jobs:
     toolchain: korg-clang-20
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -137,7 +137,7 @@ jobs:
     toolchain: korg-clang-20
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
@@ -376,7 +376,7 @@ jobs:
     toolchain: korg-clang-20
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -386,7 +386,7 @@ jobs:
     toolchain: korg-clang-20
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel

--- a/tuxsuite/next-clang-21.tux.yml
+++ b/tuxsuite/next-clang-21.tux.yml
@@ -52,7 +52,7 @@ jobs:
     toolchain: korg-clang-21
     kconfig:
     - multi_v7_defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -127,7 +127,7 @@ jobs:
     toolchain: korg-clang-21
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -137,7 +137,7 @@ jobs:
     toolchain: korg-clang-21
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
@@ -376,7 +376,7 @@ jobs:
     toolchain: korg-clang-21
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -386,7 +386,7 @@ jobs:
     toolchain: korg-clang-21
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel

--- a/tuxsuite/next-clang-22.tux.yml
+++ b/tuxsuite/next-clang-22.tux.yml
@@ -52,7 +52,7 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - multi_v7_defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -127,7 +127,7 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -137,7 +137,7 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel
@@ -376,7 +376,7 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     targets:
     - kernel
     make_variables:
@@ -386,7 +386,7 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - defconfig
-    - CONFIG_CFI_CLANG=y
+    - CONFIG_CFI=y
     - CONFIG_LTO_CLANG_THIN=y
     targets:
     - kernel


### PR DESCRIPTION
Commit 23ef9d439769 ("kcfi: Rename CONFIG_CFI_CLANG to CONFIG_CFI") is in -next and mainline so these builds need to be adjusted to keep kCFI enabled.

Change the old builds so that new builds inherit the new configuration through copying.
