### PR TITLE
Disable arm64 big endian builds on -next and mainline

### DIFF
--- a/.github/workflows/mainline-clang-15.yml
+++ b/.github/workflows/mainline-clang-15.yml
@@ -320,35 +320,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e1084951b99347c2cf3f483a2bc53b61:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 15
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _e32b19d33529170300f8490cbf5e8869:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/mainline-clang-16.yml
+++ b/.github/workflows/mainline-clang-16.yml
@@ -349,35 +349,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _83636c808c5c0dbe8287ecdd6425210c:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 16
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _6ba0787bd3d0f66517f6d6ace8dc3060:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/mainline-clang-17.yml
+++ b/.github/workflows/mainline-clang-17.yml
@@ -349,35 +349,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _cf579091969096119c5e3b06eee6268e:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 17
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _e21aa1d59320e4a2396710994e8a9f61:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/mainline-clang-18.yml
+++ b/.github/workflows/mainline-clang-18.yml
@@ -349,35 +349,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7831b51d6765e6fe9bdb5ecdbd40bcd5:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 18
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _905c6aff3f9ee4e116f5610a92043f9d:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/mainline-clang-19.yml
+++ b/.github/workflows/mainline-clang-19.yml
@@ -349,35 +349,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3f96fb9e6b90485b2ff699f2fe6efdda:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 19
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _4ea034b343d08fab262172c09251d7f7:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/mainline-clang-20.yml
+++ b/.github/workflows/mainline-clang-20.yml
@@ -349,35 +349,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4290984f97d94d1a4349c91c232e625a:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 20
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _ce2fa065568a4ba1b9efaf9ff132f293:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/mainline-clang-21.yml
+++ b/.github/workflows/mainline-clang-21.yml
@@ -349,35 +349,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _ac3de33f7636e775964b3653c86a84c4:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 21
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _414a44590f0483c51eff8f1e2559a051:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/mainline-clang-22.yml
+++ b/.github/workflows/mainline-clang-22.yml
@@ -349,35 +349,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _82a07d5128bea43b084417cd50a995e0:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 22
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _9ca721cc31f757af731d719d1d79b27f:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/next-clang-15.yml
+++ b/.github/workflows/next-clang-15.yml
@@ -320,35 +320,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _e1084951b99347c2cf3f483a2bc53b61:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 15
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _e32b19d33529170300f8490cbf5e8869:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/next-clang-16.yml
+++ b/.github/workflows/next-clang-16.yml
@@ -349,35 +349,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _83636c808c5c0dbe8287ecdd6425210c:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 16
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _6ba0787bd3d0f66517f6d6ace8dc3060:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/next-clang-17.yml
+++ b/.github/workflows/next-clang-17.yml
@@ -349,35 +349,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _cf579091969096119c5e3b06eee6268e:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=17 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 17
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _e21aa1d59320e4a2396710994e8a9f61:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/next-clang-18.yml
+++ b/.github/workflows/next-clang-18.yml
@@ -349,35 +349,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7831b51d6765e6fe9bdb5ecdbd40bcd5:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=18 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 18
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _905c6aff3f9ee4e116f5610a92043f9d:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/next-clang-19.yml
+++ b/.github/workflows/next-clang-19.yml
@@ -349,35 +349,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _3f96fb9e6b90485b2ff699f2fe6efdda:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=19 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 19
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _4ea034b343d08fab262172c09251d7f7:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/next-clang-20.yml
+++ b/.github/workflows/next-clang-20.yml
@@ -349,35 +349,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _4290984f97d94d1a4349c91c232e625a:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=20 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 20
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _ce2fa065568a4ba1b9efaf9ff132f293:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/next-clang-21.yml
+++ b/.github/workflows/next-clang-21.yml
@@ -349,35 +349,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _ac3de33f7636e775964b3653c86a84c4:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=21 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 21
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _414a44590f0483c51eff8f1e2559a051:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/next-clang-22.yml
+++ b/.github/workflows/next-clang-22.yml
@@ -349,35 +349,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _82a07d5128bea43b084417cd50a995e0:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=22 defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm64
-      LLVM_VERSION: 22
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _9ca721cc31f757af731d719d1d79b27f:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/next-clang-android.yml
+++ b/.github/workflows/next-clang-android.yml
@@ -233,35 +233,6 @@ jobs:
         name: boot_utils_json_defconfigs
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _66d5f7613f33d6225179b4f74b52c782:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=arm64 LLVM=1 LLVM_IAS=1 LLVM_VERSION=android defconfig+CONFIG_CPU_BIG_ENDIAN=y
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: arm64
-      LLVM_VERSION: android
-      BOOT: 1
-      CONFIG: defconfig+CONFIG_CPU_BIG_ENDIAN=y
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v4
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v4
-      with:
-        name: boot_utils_json_defconfigs
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _012f9698c8641a28bfe42b1f88c3eeed:
     runs-on: ubuntu-latest
     needs:

--- a/generator/yml/0009-llvm-15.yml
+++ b/generator/yml/0009-llvm-15.yml
@@ -18,7 +18,6 @@
   - {<< : *arm32_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
-  - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64_kasan,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_15}
@@ -87,7 +86,6 @@
   - {<< : *arm32_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
-  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *arm64_kasan,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_15}

--- a/generator/yml/0009-llvm-16.yml
+++ b/generator/yml/0009-llvm-16.yml
@@ -19,7 +19,6 @@
   - {<< : *arm32_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_16}
@@ -94,7 +93,6 @@
   - {<< : *arm32_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_16}

--- a/generator/yml/0009-llvm-17.yml
+++ b/generator/yml/0009-llvm-17.yml
@@ -19,7 +19,6 @@
   - {<< : *arm32_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_17}
@@ -97,7 +96,6 @@
   - {<< : *arm32_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
-  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}
   - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_17}

--- a/generator/yml/0009-llvm-18.yml
+++ b/generator/yml/0009-llvm-18.yml
@@ -19,7 +19,6 @@
   - {<< : *arm32_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_18}
@@ -103,7 +102,6 @@
   - {<< : *arm32_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_18}
-  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_18}
   - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_18}

--- a/generator/yml/0009-llvm-19.yml
+++ b/generator/yml/0009-llvm-19.yml
@@ -19,7 +19,6 @@
   - {<< : *arm32_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_19}
@@ -103,7 +102,6 @@
   - {<< : *arm32_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_19}
-  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_19}
   - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_19}

--- a/generator/yml/0009-llvm-20.yml
+++ b/generator/yml/0009-llvm-20.yml
@@ -19,7 +19,6 @@
   - {<< : *arm32_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_20}
@@ -104,7 +103,6 @@
   - {<< : *arm32_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_20}
-  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_20}
   - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_20}

--- a/generator/yml/0009-llvm-android.yml
+++ b/generator/yml/0009-llvm-android.yml
@@ -12,7 +12,6 @@
   - {<< : *arm32_allno,       << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
   - {<< : *arm32_allyes,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
-  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
   - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_android}
   - {<< : *arm64_allmod,      << : *next,             << : *llvm_full,       boot: false, << : *llvm_android}

--- a/generator/yml/0009-llvm-latest.yml
+++ b/generator/yml/0009-llvm-latest.yml
@@ -19,7 +19,6 @@
   - {<< : *arm32_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_latest}
@@ -103,7 +102,6 @@
   - {<< : *arm32_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
-  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}
   - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_latest}

--- a/generator/yml/0009-llvm-tot.yml
+++ b/generator/yml/0009-llvm-tot.yml
@@ -19,7 +19,6 @@
   - {<< : *arm32_alpine,      << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm32_suse,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64,             << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *arm64be,           << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_lto_full,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_lto_thin,    << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_cfi,         << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -103,7 +102,6 @@
   - {<< : *arm32_alpine,      << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm32_suse,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64,             << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *arm64be,           << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_lto_full,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_lto_thin,    << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *arm64_cfi,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}

--- a/tuxsuite/mainline-clang-15.tux.yml
+++ b/tuxsuite/mainline-clang-15.tux.yml
@@ -88,16 +88,6 @@ jobs:
     toolchain: korg-clang-15
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: korg-clang-15
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-16.tux.yml
+++ b/tuxsuite/mainline-clang-16.tux.yml
@@ -98,16 +98,6 @@ jobs:
     toolchain: korg-clang-16
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: korg-clang-16
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-17.tux.yml
+++ b/tuxsuite/mainline-clang-17.tux.yml
@@ -98,16 +98,6 @@ jobs:
     toolchain: korg-clang-17
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: korg-clang-17
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-18.tux.yml
+++ b/tuxsuite/mainline-clang-18.tux.yml
@@ -98,16 +98,6 @@ jobs:
     toolchain: korg-clang-18
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: korg-clang-18
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-19.tux.yml
+++ b/tuxsuite/mainline-clang-19.tux.yml
@@ -98,16 +98,6 @@ jobs:
     toolchain: korg-clang-19
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: korg-clang-19
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-20.tux.yml
+++ b/tuxsuite/mainline-clang-20.tux.yml
@@ -98,16 +98,6 @@ jobs:
     toolchain: korg-clang-20
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: korg-clang-20
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-21.tux.yml
+++ b/tuxsuite/mainline-clang-21.tux.yml
@@ -98,16 +98,6 @@ jobs:
     toolchain: korg-clang-21
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: korg-clang-21
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/mainline-clang-22.tux.yml
+++ b/tuxsuite/mainline-clang-22.tux.yml
@@ -98,16 +98,6 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-nightly
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/next-clang-15.tux.yml
+++ b/tuxsuite/next-clang-15.tux.yml
@@ -87,16 +87,6 @@ jobs:
     toolchain: korg-clang-15
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: korg-clang-15
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/next-clang-16.tux.yml
+++ b/tuxsuite/next-clang-16.tux.yml
@@ -97,16 +97,6 @@ jobs:
     toolchain: korg-clang-16
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: korg-clang-16
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/next-clang-17.tux.yml
+++ b/tuxsuite/next-clang-17.tux.yml
@@ -97,16 +97,6 @@ jobs:
     toolchain: korg-clang-17
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: korg-clang-17
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/next-clang-18.tux.yml
+++ b/tuxsuite/next-clang-18.tux.yml
@@ -97,16 +97,6 @@ jobs:
     toolchain: korg-clang-18
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: korg-clang-18
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/next-clang-19.tux.yml
+++ b/tuxsuite/next-clang-19.tux.yml
@@ -97,16 +97,6 @@ jobs:
     toolchain: korg-clang-19
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: korg-clang-19
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/next-clang-20.tux.yml
+++ b/tuxsuite/next-clang-20.tux.yml
@@ -97,16 +97,6 @@ jobs:
     toolchain: korg-clang-20
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: korg-clang-20
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/next-clang-21.tux.yml
+++ b/tuxsuite/next-clang-21.tux.yml
@@ -97,16 +97,6 @@ jobs:
     toolchain: korg-clang-21
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: korg-clang-21
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/next-clang-22.tux.yml
+++ b/tuxsuite/next-clang-22.tux.yml
@@ -97,16 +97,6 @@ jobs:
     toolchain: clang-nightly
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-nightly
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel

--- a/tuxsuite/next-clang-android.tux.yml
+++ b/tuxsuite/next-clang-android.tux.yml
@@ -60,16 +60,6 @@ jobs:
     toolchain: clang-android
     kconfig:
     - defconfig
-    - CONFIG_CPU_BIG_ENDIAN=y
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: arm64
-    toolchain: clang-android
-    kconfig:
-    - defconfig
     - CONFIG_LTO_CLANG_FULL=y
     targets:
     - kernel


### PR DESCRIPTION
CONFIG_CPU_BIG_ENDIAN has gained a dependency on CONFIG_BROKEN in commit 1cf89b6bf660 ("arm64: Kconfig: Make CPU_BIG_ENDIAN depend on BROKEN") to begin its deprecation so it is no longer selectable.
