### PR TITLE
Disable i386 builds with clang < 17 on 6.12

### DIFF
--- a/.github/workflows/6.12-clang-13.yml
+++ b/.github/workflows/6.12-clang-13.yml
@@ -509,36 +509,6 @@ jobs:
     - uses: astral-sh/setup-uv@v7
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7dde147b804e95998e110f5dfe487e8f:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 defconfig
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: i386
-      LLVM_VERSION: 13
-      BOOT: 1
-      CONFIG: defconfig
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v7
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v7
-      with:
-        name: boot_utils_json_defconfigs
-    - uses: astral-sh/setup-uv@v7
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _41bfb2f60b3f93f83d0159ac988829d1:
     runs-on: ubuntu-latest
     needs:
@@ -1077,36 +1047,6 @@ jobs:
       LLVM_VERSION: 13
       BOOT: 1
       CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v7
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v7
-      with:
-        name: boot_utils_json_distribution_configs
-    - uses: astral-sh/setup-uv@v7
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
-  _a806c79f399d017938fc07b0c8ab38ac:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_distribution_configs
-    - check_cache
-    - check_patches
-    name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=13 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: i386
-      LLVM_VERSION: 13
-      BOOT: 0
-      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.12-clang-14.yml
+++ b/.github/workflows/6.12-clang-14.yml
@@ -509,36 +509,6 @@ jobs:
     - uses: astral-sh/setup-uv@v7
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _6b9b48c5ca690a81c94f317d6baf1765:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 defconfig
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: i386
-      LLVM_VERSION: 14
-      BOOT: 1
-      CONFIG: defconfig
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v7
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v7
-      with:
-        name: boot_utils_json_defconfigs
-    - uses: astral-sh/setup-uv@v7
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _9192a16443a58cecb588e3133703784b:
     runs-on: ubuntu-latest
     needs:
@@ -1137,36 +1107,6 @@ jobs:
       LLVM_VERSION: 14
       BOOT: 1
       CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v7
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v7
-      with:
-        name: boot_utils_json_distribution_configs
-    - uses: astral-sh/setup-uv@v7
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
-  _acd418378c0559207a0517e13bee439a:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_distribution_configs
-    - check_cache
-    - check_patches
-    name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=14 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: i386
-      LLVM_VERSION: 14
-      BOOT: 0
-      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.12-clang-15.yml
+++ b/.github/workflows/6.12-clang-15.yml
@@ -539,36 +539,6 @@ jobs:
     - uses: astral-sh/setup-uv@v7
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _ccd2469adcccd86013c35ea01669960c:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 defconfig
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: i386
-      LLVM_VERSION: 15
-      BOOT: 1
-      CONFIG: defconfig
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v7
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v7
-      with:
-        name: boot_utils_json_defconfigs
-    - uses: astral-sh/setup-uv@v7
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _0a729ec9537be6bf294c840bad55f2ce:
     runs-on: ubuntu-latest
     needs:
@@ -1227,36 +1197,6 @@ jobs:
       LLVM_VERSION: 15
       BOOT: 1
       CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v7
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v7
-      with:
-        name: boot_utils_json_distribution_configs
-    - uses: astral-sh/setup-uv@v7
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
-  _b83decaf220474115c8990486e9f87d9:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_distribution_configs
-    - check_cache
-    - check_patches
-    name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=15 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: i386
-      LLVM_VERSION: 15
-      BOOT: 0
-      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/.github/workflows/6.12-clang-16.yml
+++ b/.github/workflows/6.12-clang-16.yml
@@ -629,36 +629,6 @@ jobs:
     - uses: astral-sh/setup-uv@v7
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7ccbab5313124c68e0f0070caff1fd90:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_defconfigs
-    - check_cache
-    - check_patches
-    name: ARCH=i386 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 defconfig
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: i386
-      LLVM_VERSION: 16
-      BOOT: 1
-      CONFIG: defconfig
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v7
-      with:
-        name: output_artifact_defconfigs
-    - uses: actions/download-artifact@v7
-      with:
-        name: boot_utils_json_defconfigs
-    - uses: astral-sh/setup-uv@v7
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
   _fedc5f4e7e04694ff10adc74ddb292bf:
     runs-on: ubuntu-latest
     needs:
@@ -1407,36 +1377,6 @@ jobs:
       LLVM_VERSION: 16
       BOOT: 1
       CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/arm64/default+CONFIG_DEBUG_INFO_BTF=n
-      REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
-    container:
-      image: ghcr.io/clangbuiltlinux/qemu
-      options: --ipc=host
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        submodules: true
-    - uses: actions/download-artifact@v7
-      with:
-        name: output_artifact_distribution_configs
-    - uses: actions/download-artifact@v7
-      with:
-        name: boot_utils_json_distribution_configs
-    - uses: astral-sh/setup-uv@v7
-    - name: Check Build and Boot Logs
-      run: scripts/check-logs.py
-  _67ee1b643a349f3b1cae61f56a470977:
-    runs-on: ubuntu-latest
-    needs:
-    - kick_tuxsuite_distribution_configs
-    - check_cache
-    - check_patches
-    name: ARCH=i386 BOOT=0 LLVM=1 LLVM_IAS=1 LLVM_VERSION=16 https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
-    if: ${{ needs.check_cache.outputs.status != 'pass' }}
-    env:
-      ARCH: i386
-      LLVM_VERSION: 16
-      BOOT: 0
-      CONFIG: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
       REPO_SCOPED_PAT: ${{ secrets.REPO_SCOPED_PAT }}
     container:
       image: ghcr.io/clangbuiltlinux/qemu

--- a/generator/yml/0009-llvm-13.yml
+++ b/generator/yml/0009-llvm-13.yml
@@ -31,8 +31,10 @@
   - {<< : *arm64_suse,        << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *hexagon,           << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *hexagon_allmod,    << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_13}
-  - {<< : *i386,              << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_13}
-  - {<< : *i386_suse,         << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_13}
+  # i386 fails to build after e2ffa15b9baa ("kbuild: Disable CC_HAS_ASM_GOTO_OUTPUT on clang < 17")
+  # https://github.com/ClangBuiltLinux/linux/issues/2121
+  # - {<< : *i386,              << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_13}
+  # - {<< : *i386_suse,         << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_13}
   - {<< : *mips,              << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_13}
   - {<< : *mipsel,            << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_13}
   # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)

--- a/generator/yml/0009-llvm-14.yml
+++ b/generator/yml/0009-llvm-14.yml
@@ -32,8 +32,10 @@
   - {<< : *arm64_suse,        << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *hexagon,           << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *hexagon_allmod,    << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_14}
-  - {<< : *i386,              << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_14}
-  - {<< : *i386_suse,         << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_14}
+  # i386 fails to build after e2ffa15b9baa ("kbuild: Disable CC_HAS_ASM_GOTO_OUTPUT on clang < 17")
+  # https://github.com/ClangBuiltLinux/linux/issues/2121
+  # - {<< : *i386,              << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_14}
+  # - {<< : *i386_suse,         << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_14}
   - {<< : *mips,              << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_14}
   - {<< : *mipsel,            << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_14}
   # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)

--- a/generator/yml/0009-llvm-15.yml
+++ b/generator/yml/0009-llvm-15.yml
@@ -246,8 +246,10 @@
   - {<< : *arm64_suse,        << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *hexagon,           << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *hexagon_allmod,    << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_15}
-  - {<< : *i386,              << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_15}
-  - {<< : *i386_suse,         << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_15}
+  # i386 fails to build after e2ffa15b9baa ("kbuild: Disable CC_HAS_ASM_GOTO_OUTPUT on clang < 17")
+  # https://github.com/ClangBuiltLinux/linux/issues/2121
+  # - {<< : *i386,              << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_15}
+  # - {<< : *i386_suse,         << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_15}
   - {<< : *mips,              << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_15}
   - {<< : *mipsel,            << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_15}
   # ppc32: Build disabled (https://github.com/ClangBuiltLinux/linux/issues/1679)

--- a/generator/yml/0009-llvm-16.yml
+++ b/generator/yml/0009-llvm-16.yml
@@ -268,8 +268,10 @@
   - {<< : *arm64_virt,        << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *hexagon,           << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *hexagon_allmod,    << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_16}
-  - {<< : *i386,              << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
-  - {<< : *i386_suse,         << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_16}
+  # i386 fails to build after e2ffa15b9baa ("kbuild: Disable CC_HAS_ASM_GOTO_OUTPUT on clang < 17")
+  # https://github.com/ClangBuiltLinux/linux/issues/2121
+  # - {<< : *i386,              << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
+  # - {<< : *i386_suse,         << : *stable-6_12,      << : *llvm_full,       boot: false, << : *llvm_16}
   - {<< : *mips,              << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
   - {<< : *mipsel,            << : *stable-6_12,      << : *llvm_full,       boot: true,  << : *llvm_16}
   # ppc32: Boot disabled (https://github.com/ClangBuiltLinux/linux/issues/1814)

--- a/tuxsuite/6.12-clang-13.tux.yml
+++ b/tuxsuite/6.12-clang-13.tux.yml
@@ -149,14 +149,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: i386
-    toolchain: korg-clang-13
-    kconfig: defconfig
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: mips
     toolchain: korg-clang-13
     kconfig:
@@ -323,14 +315,6 @@ jobs:
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: i386
-    toolchain: korg-clang-13
-    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
-    targets:
-    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1

--- a/tuxsuite/6.12-clang-14.tux.yml
+++ b/tuxsuite/6.12-clang-14.tux.yml
@@ -149,14 +149,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: i386
-    toolchain: korg-clang-14
-    kconfig: defconfig
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: mips
     toolchain: korg-clang-14
     kconfig:
@@ -343,14 +335,6 @@ jobs:
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: i386
-    toolchain: korg-clang-14
-    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
-    targets:
-    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1

--- a/tuxsuite/6.12-clang-15.tux.yml
+++ b/tuxsuite/6.12-clang-15.tux.yml
@@ -159,14 +159,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: i386
-    toolchain: korg-clang-15
-    kconfig: defconfig
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: mips
     toolchain: korg-clang-15
     kconfig:
@@ -372,14 +364,6 @@ jobs:
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: i386
-    toolchain: korg-clang-15
-    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
-    targets:
-    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1

--- a/tuxsuite/6.12-clang-16.tux.yml
+++ b/tuxsuite/6.12-clang-16.tux.yml
@@ -190,14 +190,6 @@ jobs:
     make_variables:
       LLVM: 1
       LLVM_IAS: 1
-  - target_arch: i386
-    toolchain: korg-clang-16
-    kconfig: defconfig
-    targets:
-    - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
   - target_arch: mips
     toolchain: korg-clang-16
     kconfig:
@@ -433,14 +425,6 @@ jobs:
     - CONFIG_DEBUG_INFO_BTF=n
     targets:
     - kernel
-    make_variables:
-      LLVM: 1
-      LLVM_IAS: 1
-  - target_arch: i386
-    toolchain: korg-clang-16
-    kconfig: https://github.com/openSUSE/kernel-source/raw/master/config/i386/default
-    targets:
-    - default
     make_variables:
       LLVM: 1
       LLVM_IAS: 1


### PR DESCRIPTION
For the same reason as commit f7c16150 ("generator: yml: Disable i386 builds with clang < 17 on 6.18 and newer").
