### PR TITLE
Enable the integrated assembler for sparc64 with clang-23+

### DIFF
--- a/.github/workflows/6.18-clang-23.yml
+++ b/.github/workflows/6.18-clang-23.yml
@@ -1049,13 +1049,13 @@ jobs:
     - uses: astral-sh/setup-uv@v7
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _f55f621d06182ca5a43e1565d0337966:
+  _d068250330a300115e739d1082eb2bd9:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=sparc CC=clang LLVM_IAS=0 LLVM_VERSION=23 sparc64_defconfig
+    name: ARCH=sparc CC=clang LLVM_IAS=1 LLVM_VERSION=23 sparc64_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: sparc

--- a/.github/workflows/mainline-clang-23.yml
+++ b/.github/workflows/mainline-clang-23.yml
@@ -1049,13 +1049,13 @@ jobs:
     - uses: astral-sh/setup-uv@v7
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _f55f621d06182ca5a43e1565d0337966:
+  _d068250330a300115e739d1082eb2bd9:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=sparc CC=clang LLVM_IAS=0 LLVM_VERSION=23 sparc64_defconfig
+    name: ARCH=sparc CC=clang LLVM_IAS=1 LLVM_VERSION=23 sparc64_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: sparc

--- a/.github/workflows/next-clang-23.yml
+++ b/.github/workflows/next-clang-23.yml
@@ -1049,13 +1049,13 @@ jobs:
     - uses: astral-sh/setup-uv@v7
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _f55f621d06182ca5a43e1565d0337966:
+  _d068250330a300115e739d1082eb2bd9:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=sparc CC=clang LLVM_IAS=0 LLVM_VERSION=23 sparc64_defconfig
+    name: ARCH=sparc CC=clang LLVM_IAS=1 LLVM_VERSION=23 sparc64_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: sparc

--- a/.github/workflows/stable-clang-23.yml
+++ b/.github/workflows/stable-clang-23.yml
@@ -1049,13 +1049,13 @@ jobs:
     - uses: astral-sh/setup-uv@v7
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _f55f621d06182ca5a43e1565d0337966:
+  _d068250330a300115e739d1082eb2bd9:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=sparc CC=clang LLVM_IAS=0 LLVM_VERSION=23 sparc64_defconfig
+    name: ARCH=sparc CC=clang LLVM_IAS=1 LLVM_VERSION=23 sparc64_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: sparc

--- a/generator/yml/0009-llvm-tot.yml
+++ b/generator/yml/0009-llvm-tot.yml
@@ -65,7 +65,7 @@
   - {<< : *s390_kasan,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *s390_fedora,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *s390_suse,         << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *sparc64,           << : *mainline,         << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *sparc64,           << : *mainline,         << : *clang_ias,       boot: true,  << : *llvm_tot}
   - {<< : *um,                << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -150,7 +150,7 @@
   - {<< : *s390_kasan,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *s390_fedora,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *s390_suse,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *sparc64,           << : *next,             << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *sparc64,           << : *next,             << : *clang_ias,       boot: true,  << : *llvm_tot}
   - {<< : *um,                << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -236,7 +236,7 @@
   - {<< : *s390_kasan,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *s390_fedora,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *s390_suse,         << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *sparc64,           << : *stable,           << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *sparc64,           << : *stable,           << : *clang_ias,       boot: true,  << : *llvm_tot}
   - {<< : *um,                << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_full,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_tot}
@@ -321,7 +321,7 @@
   - {<< : *s390_kasan,        << : *stable-6_18,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *s390_fedora,       << : *stable-6_18,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *s390_suse,         << : *stable-6_18,      << : *llvm_full,       boot: true,  << : *llvm_tot}
-  - {<< : *sparc64,           << : *stable-6_18,      << : *clang,           boot: true,  << : *llvm_tot}
+  - {<< : *sparc64,           << : *stable-6_18,      << : *clang_ias,       boot: true,  << : *llvm_tot}
   - {<< : *um,                << : *stable-6_18,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64,            << : *stable-6_18,      << : *llvm_full,       boot: true,  << : *llvm_tot}
   - {<< : *x86_64_lto_full,   << : *stable-6_18,      << : *llvm_full,       boot: true,  << : *llvm_tot}

--- a/tuxsuite/6.18-clang-23.tux.yml
+++ b/tuxsuite/6.18-clang-23.tux.yml
@@ -336,7 +336,7 @@ jobs:
     - kernel
     kernel_image: image
     make_variables:
-      LLVM_IAS: 0
+      LLVM_IAS: 1
   - target_arch: um
     toolchain: clang-nightly
     kconfig: defconfig

--- a/tuxsuite/mainline-clang-23.tux.yml
+++ b/tuxsuite/mainline-clang-23.tux.yml
@@ -336,7 +336,7 @@ jobs:
     - kernel
     kernel_image: image
     make_variables:
-      LLVM_IAS: 0
+      LLVM_IAS: 1
   - target_arch: um
     toolchain: clang-nightly
     kconfig: defconfig

--- a/tuxsuite/next-clang-23.tux.yml
+++ b/tuxsuite/next-clang-23.tux.yml
@@ -336,7 +336,7 @@ jobs:
     - kernel
     kernel_image: image
     make_variables:
-      LLVM_IAS: 0
+      LLVM_IAS: 1
   - target_arch: um
     toolchain: clang-nightly
     kconfig: defconfig

--- a/tuxsuite/stable-clang-23.tux.yml
+++ b/tuxsuite/stable-clang-23.tux.yml
@@ -336,7 +336,7 @@ jobs:
     - kernel
     kernel_image: image
     make_variables:
-      LLVM_IAS: 0
+      LLVM_IAS: 1
   - target_arch: um
     toolchain: clang-nightly
     kconfig: defconfig


### PR DESCRIPTION
A recently merged LLVM change allows the integrated assembler to assemble all code in sparc64_defconfig. Enable it for clang-23 and newer so that we can keep it working.

Link: https://lore.kernel.org/ov9qx_G3-lAxKXO_ur8gXhE8J5toGs8NkZ2mtMBdwEVND6y0f9CakihiR1kVbaS_lgMVbYs3NegNpFgCRjzzb79wzfbm4_1WeVt1q5pe_f0=@protonmail.com/
