### PR TITLE
Revert accidental LLVM_IAS=1 enablement for sparc64 with clang-22

### DIFF
--- a/.github/workflows/6.18-clang-22.yml
+++ b/.github/workflows/6.18-clang-22.yml
@@ -1049,13 +1049,13 @@ jobs:
     - uses: astral-sh/setup-uv@v9.0.0
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7ba11fd4a5a73b163f99600915950e68:
+  _d41cae568aded747a87bd35190566a9a:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=sparc CC=clang LLVM_IAS=1 LLVM_VERSION=22 sparc64_defconfig
+    name: ARCH=sparc CC=clang LLVM_IAS=0 LLVM_VERSION=22 sparc64_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: sparc

--- a/.github/workflows/mainline-clang-22.yml
+++ b/.github/workflows/mainline-clang-22.yml
@@ -1049,13 +1049,13 @@ jobs:
     - uses: astral-sh/setup-uv@v9.0.0
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7ba11fd4a5a73b163f99600915950e68:
+  _d41cae568aded747a87bd35190566a9a:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=sparc CC=clang LLVM_IAS=1 LLVM_VERSION=22 sparc64_defconfig
+    name: ARCH=sparc CC=clang LLVM_IAS=0 LLVM_VERSION=22 sparc64_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: sparc

--- a/.github/workflows/next-clang-22.yml
+++ b/.github/workflows/next-clang-22.yml
@@ -1049,13 +1049,13 @@ jobs:
     - uses: astral-sh/setup-uv@v9.0.0
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7ba11fd4a5a73b163f99600915950e68:
+  _d41cae568aded747a87bd35190566a9a:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=sparc CC=clang LLVM_IAS=1 LLVM_VERSION=22 sparc64_defconfig
+    name: ARCH=sparc CC=clang LLVM_IAS=0 LLVM_VERSION=22 sparc64_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: sparc

--- a/.github/workflows/stable-clang-22.yml
+++ b/.github/workflows/stable-clang-22.yml
@@ -1049,13 +1049,13 @@ jobs:
     - uses: astral-sh/setup-uv@v9.0.0
     - name: Check Build and Boot Logs
       run: scripts/check-logs.py
-  _7ba11fd4a5a73b163f99600915950e68:
+  _d41cae568aded747a87bd35190566a9a:
     runs-on: ubuntu-latest
     needs:
     - kick_tuxsuite_defconfigs
     - check_cache
     - check_patches
-    name: ARCH=sparc CC=clang LLVM_IAS=1 LLVM_VERSION=22 sparc64_defconfig
+    name: ARCH=sparc CC=clang LLVM_IAS=0 LLVM_VERSION=22 sparc64_defconfig
     if: ${{ needs.check_cache.outputs.status != 'pass' }}
     env:
       ARCH: sparc

--- a/generator/yml/0009-llvm-22.yml
+++ b/generator/yml/0009-llvm-22.yml
@@ -65,7 +65,7 @@
   - {<< : *s390_kasan,        << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_22}
   - {<< : *s390_fedora,       << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_22}
   - {<< : *s390_suse,         << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_22}
-  - {<< : *sparc64,           << : *mainline,         << : *clang_ias,       boot: true,  << : *llvm_22}
+  - {<< : *sparc64,           << : *mainline,         << : *clang,           boot: true,  << : *llvm_22}
   - {<< : *um,                << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_22}
   - {<< : *x86_64,            << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_22}
   - {<< : *x86_64_lto_full,   << : *mainline,         << : *llvm_full,       boot: true,  << : *llvm_22}
@@ -150,7 +150,7 @@
   - {<< : *s390_kasan,        << : *next,             << : *llvm_full,       boot: true,  << : *llvm_22}
   - {<< : *s390_fedora,       << : *next,             << : *llvm_full,       boot: true,  << : *llvm_22}
   - {<< : *s390_suse,         << : *next,             << : *llvm_full,       boot: true,  << : *llvm_22}
-  - {<< : *sparc64,           << : *next,             << : *clang_ias,       boot: true,  << : *llvm_22}
+  - {<< : *sparc64,           << : *next,             << : *clang,           boot: true,  << : *llvm_22}
   - {<< : *um,                << : *next,             << : *llvm_full,       boot: true,  << : *llvm_22}
   - {<< : *x86_64,            << : *next,             << : *llvm_full,       boot: true,  << : *llvm_22}
   - {<< : *x86_64_lto_full,   << : *next,             << : *llvm_full,       boot: true,  << : *llvm_22}
@@ -236,7 +236,7 @@
   - {<< : *s390_kasan,        << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_22}
   - {<< : *s390_fedora,       << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_22}
   - {<< : *s390_suse,         << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_22}
-  - {<< : *sparc64,           << : *stable,           << : *clang_ias,       boot: true,  << : *llvm_22}
+  - {<< : *sparc64,           << : *stable,           << : *clang,           boot: true,  << : *llvm_22}
   - {<< : *um,                << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_22}
   - {<< : *x86_64,            << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_22}
   - {<< : *x86_64_lto_full,   << : *stable,           << : *llvm_full,       boot: true,  << : *llvm_22}
@@ -321,7 +321,7 @@
   - {<< : *s390_kasan,        << : *stable-6_18,      << : *llvm_full,       boot: true,  << : *llvm_22}
   - {<< : *s390_fedora,       << : *stable-6_18,      << : *llvm_full,       boot: true,  << : *llvm_22}
   - {<< : *s390_suse,         << : *stable-6_18,      << : *llvm_full,       boot: true,  << : *llvm_22}
-  - {<< : *sparc64,           << : *stable-6_18,      << : *clang_ias,       boot: true,  << : *llvm_22}
+  - {<< : *sparc64,           << : *stable-6_18,      << : *clang,           boot: true,  << : *llvm_22}
   - {<< : *um,                << : *stable-6_18,      << : *llvm_full,       boot: true,  << : *llvm_22}
   - {<< : *x86_64,            << : *stable-6_18,      << : *llvm_full,       boot: true,  << : *llvm_22}
   - {<< : *x86_64_lto_full,   << : *stable-6_18,      << : *llvm_full,       boot: true,  << : *llvm_22}

--- a/tuxsuite/6.18-clang-22.tux.yml
+++ b/tuxsuite/6.18-clang-22.tux.yml
@@ -336,7 +336,7 @@ jobs:
     - kernel
     kernel_image: image
     make_variables:
-      LLVM_IAS: 1
+      LLVM_IAS: 0
   - target_arch: um
     toolchain: korg-clang-22
     kconfig: defconfig

--- a/tuxsuite/mainline-clang-22.tux.yml
+++ b/tuxsuite/mainline-clang-22.tux.yml
@@ -336,7 +336,7 @@ jobs:
     - kernel
     kernel_image: image
     make_variables:
-      LLVM_IAS: 1
+      LLVM_IAS: 0
   - target_arch: um
     toolchain: korg-clang-22
     kconfig: defconfig

--- a/tuxsuite/next-clang-22.tux.yml
+++ b/tuxsuite/next-clang-22.tux.yml
@@ -336,7 +336,7 @@ jobs:
     - kernel
     kernel_image: image
     make_variables:
-      LLVM_IAS: 1
+      LLVM_IAS: 0
   - target_arch: um
     toolchain: korg-clang-22
     kconfig: defconfig

--- a/tuxsuite/stable-clang-22.tux.yml
+++ b/tuxsuite/stable-clang-22.tux.yml
@@ -336,7 +336,7 @@ jobs:
     - kernel
     kernel_image: image
     make_variables:
-      LLVM_IAS: 1
+      LLVM_IAS: 0
   - target_arch: um
     toolchain: korg-clang-22
     kconfig: defconfig


### PR DESCRIPTION
Commit ebb693ee ("generator: yml: Copy llvm_latest builds to llvm_22") accidentally enabled the integrated assembler for sparc64 builds with `clang-22` from copying the latest file after commit 98ecefc9 ("generator: yml: Update llvm_latest to LLVM 23"). This breaks the build because the integrated assembler was not ready for sparc64 until `clang-23`. Revert back to `LLVM_IAS=0` for this version.
